### PR TITLE
adds list of imported projects to comment update

### DIFF
--- a/AGENTS.MD
+++ b/AGENTS.MD
@@ -2,7 +2,7 @@
 This document gives agents instructions and tips for working in this repository. It applies to the entire repo.
 
 ## Purpose & Overview
-- `maintainerd` is a Go service with a SQLite-backed data layer that processes GitHub webhooks and onboards projects to services (e.g., FOSSA).
+- `maintainer-d` is a Go service with a SQLite-backed data layer that processes GitHub webhooks and onboards projects to services (e.g., FOSSA).
 - Deployment uses plain Kubernetes manifests under `deploy/manifests` (production only).
 
 ## Deploy Rules
@@ -33,5 +33,5 @@ This document gives agents instructions and tips for working in this repository.
 ## Coding Guidelines
 - Keep changes minimal and focused. Match existing Go style and module layout.
 - Avoid unrelated refactors in the same change. Update docs/Makefile if deployment surface changes.
-- Use the "The Friends method" of writing commit messages to describe patches where each commit message is notionally pre-fixed with the sentence, "This is the change that " and then the commit message continues this sentence, for example, "adds repo being monitored to log output at loglevel INFO"
+- Use the "The Friends method" of writing commit messages to describe patches where each commit message is notionally pre-fixed with the sentence, "This is the change that " and then the commit message continues this sentence, for example, (this is the change that) "adds the repo being monitored to log output at loglevel INFO"
 f

--- a/onboarding/README.MD
+++ b/onboarding/README.MD
@@ -1,0 +1,58 @@
+# Project Onboarding 
+
+Project Sandbox Onboarding, often abbreviated to, "project onboarding" or just
+"onboarding", comprises the set of tasks that must be carried out by both the
+Project maintainer team and CNCF Staff
+
+Onboarding activities are tracked in a formatted GitHub Issue in the
+cncf/sandbox repo.
+
+The CNCF keeps an internal record of Projects and the Maintainers who work on
+them.
+
+The internal record associates Project Maintainers with their project. The
+record is stored internally out of public view, because we ask maintainers
+to give us an email address and a lot of maintainerd do not want to share the 
+email address that they use to register their participation in a CNCF Project,
+
+1. A Maintainer's participation is registered with maintainerd when their
+details are recorded on the internal record in association with their project.
+This requires manual effort on the part of the CNCF Projects Team at the moment,
+in future we would like to store the association of our maintainers with their
+projects in a combination of The Project Control Center and OpenProfile.dev both
+operated by LFX team in the Linux Foundation.
+
+2. Once the internal records are present, maintainer-d can read those records and
+store them in the maintainer-d database.
+
+# FOSSA User Onboarding Workflow
+
+1. When a project chooses to use FOSSA for license scanning CNCF Staff member can
+add the fossa label to indicate that choice.
+
+2. Labelling the issue triggers an event that is sent to the maintainer-d webhook.
+
+3. Then maintainer-d proceeds to setup the project in the CNCF FOSSA service instance.
+
+4.1 A FOSSA Team is created using the name project name in the issue
+
+4.2 For each registered maintainer, an invitation to join CNCF FOSSA is sent to
+the maintainer
+
+4.3 The onboarding issue is updated with a comment that tags the maintainers
+using their GitHub Handle and explains to them that they need to accept their invite.
+
+4.4 Inviting a user to join CNCF FOSSA does not tie their invitation to the team
+that we created in step 5.1, and this means that a separate step of, "adding the
+invited user to their FOSSA Team" needs to be carried out.
+
+Maintainers or CNCF Stff can add a "/fossa-invite accepted" comment to 
+the issue when a maintainer has accepted their invitation to join CNCF FOSSA 
+
+For every registered maintainer, maintainer-d will check to see if they 
+are now a user on CNCF FOSSA and will add them to their team. 
+
+The onboarding issue is updated with a comment that describes actions taken 
+and the next steps that need to be taken by the maintainers (namely, they now need to 
+import their project repositories int to FOSSA which checks the project's compliance with 
+the CNCF's 3rd-Party license policy

--- a/plugins/fossa/client_e2e_test.go
+++ b/plugins/fossa/client_e2e_test.go
@@ -1,0 +1,122 @@
+package fossa_test
+
+import (
+	"os"
+	"testing"
+
+	"maintainerd/plugins/fossa"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const defaultE2ETeam = "SOPS"
+const defaultImportedProjectCount = 5
+
+func newE2EClient(t *testing.T) (*fossa.Client, string) {
+	t.Helper()
+
+	token := os.Getenv("FOSSA_API_TOKEN")
+	if token == "" {
+		t.Skip("FOSSA_API_TOKEN not set; skipping live FOSSA end-to-end tests")
+	}
+
+	client := fossa.NewClient(token)
+	if apiBase := os.Getenv("FOSSA_API_BASE"); apiBase != "" {
+		client.APIBase = apiBase
+	}
+
+	team := os.Getenv("FOSSA_TEST_TEAM")
+	if team == "" {
+		team = defaultE2ETeam
+	}
+
+	return client, team
+}
+
+func lookupTeamID(t *testing.T, client *fossa.Client, teamName string) int {
+	t.Helper()
+
+	teams, err := client.FetchTeams()
+	if err != nil {
+		t.Fatalf("FetchTeams returned error: %v", err)
+	}
+
+	for _, team := range teams {
+		if team.Name == teamName {
+			return team.ID
+		}
+	}
+
+	t.Fatalf("could not locate team ID for %q", teamName)
+	return 0
+}
+
+func TestFetchUsersE2E(t *testing.T) {
+	client, _ := newE2EClient(t)
+
+	users, err := client.FetchUsers()
+	if err != nil {
+		t.Fatalf("FetchUsers returned error: %v", err)
+	}
+	if len(users) == 0 {
+		t.Fatalf("FetchUsers returned zero users")
+	}
+}
+
+func TestFetchTeamsE2E(t *testing.T) {
+	client, teamName := newE2EClient(t)
+
+	teams, err := client.FetchTeams()
+	if err != nil {
+		t.Fatalf("FetchTeams returned error: %v", err)
+	}
+	if len(teams) == 0 {
+		t.Fatalf("FetchTeams returned zero teams")
+	}
+
+	var found bool
+	for _, team := range teams {
+		if team.Name == teamName {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("FetchTeams did not include expected test team %q", teamName)
+	}
+}
+
+func TestFetchTeamUserEmailsE2E(t *testing.T) {
+	client, teamName := newE2EClient(t)
+
+	targetTeamID := lookupTeamID(t, client, teamName)
+
+	emails, err := client.FetchTeamUserEmails(targetTeamID)
+	if err != nil {
+		t.Fatalf("FetchTeamUserEmails returned error: %v", err)
+	}
+	if len(emails) == 0 {
+		t.Fatalf("FetchTeamUserEmails returned zero emails for team %q", teamName)
+	}
+}
+
+func TestFetchImportedReposE2E(t *testing.T) {
+	client, teamName := newE2EClient(t)
+	targetTeamID := lookupTeamID(t, client, teamName)
+
+	count, repos, err := client.FetchImportedRepos(targetTeamID)
+	if err != nil {
+		t.Fatalf("FetchImportedRepos returned error: %v", err)
+	}
+
+	if count == 0 {
+		t.Fatalf("FetchImportedRepos reported zero imported repositories for team %q", teamName)
+	}
+	if len(repos.Results) == 0 {
+		t.Fatalf("FetchImportedRepos returned zero project entries for team %q", teamName)
+	}
+	if len(repos.Results) > count {
+		t.Fatalf("FetchImportedRepos returned %d repo names, which exceeds count %d", len(repos.Results), count)
+	}
+	assert.Equal(t, defaultImportedProjectCount, len(repos.Results))
+}


### PR DESCRIPTION
Theses changes update the onboarding issue comment that is added when FOSSA onboarding runs to include a count of projects that have been imported for scanning into FOSSA and lists out those repos that are being scanned. 