### PR TITLE
updates maintainer records when end-user changes field values

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -371,6 +371,7 @@ help:
 	@echo "make sops-apply-bootstrap-secrets -> apply bootstrap secrets from SOPS"
 	@echo "make deploy-web -> apply web-bff/web services + deployments + ingress + cert"
 	@echo "make web-image-set TAG=... -> set maintainerd-web image to a specific tag"
+	@echo "make web-release TAG=... -> build+push web & web-bff with same tag, then set both images"
 	@echo "make clean-env       -> remove $(ENVOUT)"
 	@echo "make print           -> show which keys would be loaded (without values)"
 	@echo "make mntrd-image-build  -> build maintainerd image $(IMAGE) locally"
@@ -813,6 +814,16 @@ web-bff-image-set:
 	@echo "Setting maintainerd-web-bff image to $(WEB_BFF_IMAGE_REPO):$(TAG) [ns=$(NAMESPACE)]"
 	@kubectl -n $(NAMESPACE) $(if $(KUBECONTEXT),--context $(KUBECONTEXT)) \
 		set image deploy/maintainerd-web-bff web-bff=$(WEB_BFF_IMAGE_REPO):$(TAG)
+
+.PHONY: web-release
+web-release:
+	@if [ -z "$(TAG)" ]; then \
+		echo "Usage: make web-release TAG=<tag>"; exit 1; \
+	fi
+	@$(MAKE) web-image-push TAG=$(TAG)
+	@$(MAKE) web-bff-image-push TAG=$(TAG)
+	@$(MAKE) web-image-set TAG=$(TAG)
+	@$(MAKE) web-bff-image-set TAG=$(TAG)
 
 # Convenience combo target
 .PHONY: secrets

--- a/db/store.go
+++ b/db/store.go
@@ -23,7 +23,7 @@ type Store interface {
 	LogAuditEvent(logger *zap.SugaredLogger, event model.AuditLog) error
 	GetMaintainerMapByGitHubAccount() (map[string]model.Maintainer, error)
 	CreateServiceTeamForUser(interface{ any }) (*model.ServiceTeam, error)
-	CreateMaintainer(projectID uint, name, email, githubHandle, company string) (*model.Maintainer, error)
+	UpsertMaintainer(projectID uint, name, email, githubHandle, company string) (*model.Maintainer, error)
 	CreateCompany(name string) (*model.Company, error)
 	UpdateProjectMaturity(projectID uint, maturity model.Maturity) error
 	UpdateProjectLegacyMaintainerRef(projectID uint, ref string) error

--- a/features/web/create_project.feature
+++ b/features/web/create_project.feature
@@ -1,0 +1,21 @@
+Feature: Create new projects
+  As a CNCF staff member
+  I want to create a new project record when a Project has been admitted to the sandbox repo
+  So that maintainer-d can then allow the registration of maintainers with the Project
+
+  Background:
+    Given I am signed in as a staff member
+
+  @wip
+  Scenario: Create a new project from an onboarding issue
+    When I open the Create Project dialog
+    And I enter the onboarding issue URL for a sandbox project
+    Then the project name is resolved from the onboarding issue title
+    And I can provide either a legacy maintainer file or a dot project YAML URL
+    And the GitHub org is inferred from the provided file URL
+    When I submit the form
+    Then a new project record is created
+
+  Scenario: Restrict onboarding issues to cncf/sandbox
+    When I enter an onboarding issue URL outside cncf/sandbox
+    Then I am prompted to use a cncf/sandbox issue URL


### PR DESCRIPTION
  - existing maintainer records that had an email address but had a missing github account were not being updated with new data supplied by maintainer-d end-user