### PR TITLE
improves ProjectList Filter UX by slowing down the filter

### DIFF
--- a/web/src/components/ProjectsList.module.css
+++ b/web/src/components/ProjectsList.module.css
@@ -74,6 +74,11 @@
   table-layout: fixed;
 }
 
+.tableBodyLoading {
+  opacity: 0.6;
+  transition: opacity 180ms ease-in-out;
+}
+
 .table th {
   text-align: left;
   padding: 8px 0;


### PR DESCRIPTION
fixes #79 

 - debounce filter by reducing the number of updates made to the table by reacting less often to status changes, instead of triggering an update on every keystroke, wait 350ms.
 - uses startTransition to tell React that the Project List table update is not urgent so that its re-render can be yielded to if necessary