### PR TITLE
adds unauth landing page keeps deep-links on sign-in moves search bar

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1398,6 +1398,7 @@ test-package:
 .PHONY: ci-local
 ci-local:
 	@echo "Running local CI checks..."
+	@mkdir -p $(GOCACHE_DIR) /tmp/golangci-lint
 	@echo "→ Tool versions..."
 	@bash -c 'set -euo pipefail; \
 	echo "go: $$(go version)"; \
@@ -1423,15 +1424,15 @@ ci-local:
 		exit 1; \
 	fi
 	@echo "→ Running go vet..."
-	@go vet # ./...
+	@GOCACHE=$(GOCACHE_DIR) go vet # ./...
 	@echo "→ Running staticcheck..."
 	@command -v staticcheck >/dev/null 2>&1 || { echo "staticcheck not installed. Run: go install honnef.co/go/tools/cmd/staticcheck@latest"; exit 1; }
-	@staticcheck # ./...
+	@GOCACHE=$(GOCACHE_DIR) staticcheck # ./...
 	@echo "→ Running golangci-lint..."
 	@command -v golangci-lint >/dev/null 2>&1 || { echo "golangci-lint not installed. Run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest"; exit 1; }
-	@golangci-lint run ./...
+	@GOLANGCI_LINT_CACHE=/tmp/golangci-lint GOCACHE=$(GOCACHE_DIR) golangci-lint run ./...
 	@echo "→ Running go tests..."
-	@go test ./...
+	@GOCACHE=$(GOCACHE_DIR) go test ./...
 	@echo "→ Running web eslint..."
 	@rm -rf web/work/testdata/next-dist web/testdata/next-dist web/tmp || true
 	@npm --prefix web run lint -- --max-warnings=$(ESLINT_MAX_WARNINGS)
@@ -1447,16 +1448,17 @@ ci-local:
 	env MD_DB_DRIVER=postgres MD_DB_DSN="$$MD_DB_DSN" WEB_BDD_USE_MICROCKS=true $(MAKE) web-bdd; \
 	'
 	@echo "→ Running tests with race detector..."
-	@go test -race -coverprofile=coverage.out -covermode=atomic ./...
+	@GOCACHE=$(GOCACHE_DIR) go test -race -coverprofile=coverage.out -covermode=atomic ./...
 	@echo "→ Coverage report:"
-	@go tool cover -func=coverage.out | tail -n 1
+	@GOCACHE=$(GOCACHE_DIR) go tool cover -func=coverage.out | tail -n 1
 	@echo "✅ All CI checks passed!"
 
 .PHONY: lint
 lint:
 	@echo "Running golangci-lint..."
+	@mkdir -p $(GOCACHE_DIR) /tmp/golangci-lint
 	@if command -v golangci-lint >/dev/null 2>&1; then \
-		golangci-lint run ./...; \
+		GOLANGCI_LINT_CACHE=/tmp/golangci-lint GOCACHE=$(GOCACHE_DIR) golangci-lint run ./...; \
 	else \
 		echo "golangci-lint not installed."; \
 		echo "Install: go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest"; \

--- a/features/web/global-search.feature
+++ b/features/web/global-search.feature
@@ -33,6 +33,21 @@ Feature: Global maintainer search
     When I search globally for maintainer email "alex@example.dev"
     Then the results include the projects associated with "Alex Example"
 
+  Scenario: Staff can start a search from the search page itself
+    Given the maintainer-d database contains staff, maintainers, and projects
+    When I open the global search page
+    And I search from the search page for "alex@example.dev"
+    Then the search page URL includes query "alex@example.dev"
+    And I see maintainer "Alex Example" in the results
+
+  Scenario: Staff can refine an existing search from the search page
+    Given the maintainer-d database contains staff, maintainers, and projects
+    When I search globally for maintainer email "alex@example.dev"
+    And I search from the search page for "example.dev"
+    Then the search page URL includes query "example.dev"
+    And I see maintainer "Alex Example" in the results
+    And I see maintainer "Renee Sample" in the results
+
   Scenario: Non-staff users cannot access global email search
     Given I am signed in as maintainer "self"
     When I try to access global maintainer search by email

--- a/features/web/project_routes.feature
+++ b/features/web/project_routes.feature
@@ -1,0 +1,22 @@
+Feature: Project route navigation
+  As a staff member
+  I want project reconciliation workflows to live on dedicated routes
+  So I can navigate directly to each route-scoped section
+
+  Background:
+    Given the maintainer-d database contains staff, maintainers, and projects
+    And I am signed in as a staff member
+
+  Scenario: Staff can navigate the project reconciliation routes
+    Given a project exists with reconciliation routes
+    When I open the project github route
+    Then the project route navigation exposes these routes
+      | label                         | path-suffix            | heading                       | body-snippet                                                                     |
+      | ROLL CALL                     | /github                | ROLL CALL                     | Compare the Maintainer DB roster with the Legacy Maintainer File.                |
+      | PROJECT RECORDS               | /dot-project           | PROJECT RECORDS               | Coming soon: this section will combine CNCF database fields                      |
+      | LICENSE CHECKER - FOSSA       | /fossa                 | LICENSE CHECKER - FOSSA       | This project has not selected a license checker.                                 |
+      | MAILING LISTS / MAINTAINERS   | /mailing-maintainers   | MAILING LISTS / MAINTAINERS   | Placeholder for maintainer mailing list references                               |
+      | MAILING LISTS / SECURITY      | /mailing-security      | MAILING LISTS / SECURITY      | Placeholder for security mailing list references.                                |
+      | DOCUMENTATION                 | /docs                  | DOCUMENTATION                 | Placeholder for documentation hosting details.                                   |
+      | COLLABORATION / SLACK         | /slack                 | COLLABORATION / SLACK         | Placeholder for Slack workspace/channel references.                              |
+      | COLLABORATION / DISCORD       | /discord               | COLLABORATION / DISCORD       | Placeholder for Discord server/channel references.                               |

--- a/features/web/protected_routes.feature
+++ b/features/web/protected_routes.feature
@@ -1,0 +1,33 @@
+Feature: Protected deep-link routes
+  As an unauthenticated user
+  I want protected deep links to send me through sign-in and preserve my destination
+  So I can land back on the route I originally opened
+
+  Background:
+    Given the maintainer-d database contains staff, maintainers, and projects
+    And I am signed out
+
+  Scenario: Unauthenticated project route visits preserve the deep link through sign-in
+    Given a project exists with reconciliation routes
+    When I open a protected project route while signed out
+    Then I am redirected to sign in with a next parameter for the protected route
+    When I complete sign-in for the protected route
+    Then I land on the original protected project route
+
+  Scenario: Unauthenticated maintainer page visits preserve the deep link through sign-in
+    When I open a protected maintainer page while signed out
+    Then I am redirected to sign in with a next parameter for the protected route
+    When I complete sign-in for the protected route
+    Then I land on the original protected maintainer page
+
+  Scenario: Unauthenticated company page visits preserve the deep link through sign-in
+    When I open a protected company page while signed out
+    Then I am redirected to sign in with a next parameter for the protected route
+    When I complete sign-in for the protected route
+    Then I land on the original protected company page
+
+  Scenario: Unauthenticated search deep links preserve the query through sign-in
+    When I open a protected search page with a query while signed out
+    Then I am redirected to sign in with a next parameter for the protected route
+    When I complete sign-in for the protected route
+    Then I land on the original protected search page with the query intact

--- a/scripts/pii-allowlist.regex
+++ b/scripts/pii-allowlist.regex
@@ -6,6 +6,7 @@
 
 # Placeholder addresses present in vendor API documentation.
 ^email@email\.com$
+^ALEX@EXAMPLE.DEV$
 ^api-service@company\.com$
 ^prod-api@company\.com$
 ^automation@company\.com$

--- a/scripts/psql-maintainerd.sh
+++ b/scripts/psql-maintainerd.sh
@@ -3,23 +3,50 @@ set -euo pipefail
 
 SQL=""
 SQL_FILE=""
+INTERACTIVE=false
 
-if [ "${1:-}" = "-f" ]; then
-  SQL_FILE="${2:-}"
-  if [ -z "$SQL_FILE" ]; then
-    echo "Usage: $0 -f <path-to-sql-file>"
-    exit 1
-  fi
+usage() {
+  echo "Usage: $0 [-i] [\"<sql>\"]"
+  echo "Example: $0 \"select count(*) from projects;\""
+  echo "Or: $0 -f /path/to/query.sql"
+  echo "Or: $0 -i"
+}
+
+while getopts ":f:i" opt; do
+  case "$opt" in
+    f)
+      SQL_FILE="$OPTARG"
+      ;;
+    i)
+      INTERACTIVE=true
+      ;;
+    :)
+      usage
+      exit 1
+      ;;
+    \?)
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+shift $((OPTIND - 1))
+
+if [ -n "$SQL_FILE" ] && [ "$INTERACTIVE" = true ]; then
+  echo "Use either -f or -i, not both."
+  exit 1
+fi
+
+if [ -n "$SQL_FILE" ]; then
   if [ ! -f "$SQL_FILE" ]; then
     echo "SQL file not found: $SQL_FILE"
     exit 1
   fi
-else
+elif [ "$INTERACTIVE" = false ]; then
   SQL="${1:-}"
   if [ -z "$SQL" ]; then
-    echo "Usage: $0 \"<sql>\""
-    echo "Example: $0 \"select count(*) from projects;\""
-    echo "Or: $0 -f /path/to/query.sql"
+    usage
     exit 1
   fi
 fi
@@ -29,13 +56,33 @@ DB_PORT="${MD_DB_PORT:-5432}"
 DB_NAME="${MD_DB_NAME:-maintainerd}"
 DB_USER="${MD_DB_USER:-admin}"
 DB_PASSWORD="${MD_DB_PASSWORD:-}"
+POD_NAME=""
 
 if [ -z "$DB_PASSWORD" ]; then
   echo "Set MD_DB_PASSWORD before running."
   exit 1
 fi
 
-if [ -n "$SQL_FILE" ]; then
+cleanup_pod() {
+  if [ -n "$POD_NAME" ]; then
+    kubectl -n maintainerd delete pod "$POD_NAME" --ignore-not-found --wait=false >/dev/null 2>&1 || true
+  fi
+}
+
+if [ "$INTERACTIVE" = true ]; then
+  POD_NAME="psql-client-${USER:-user}-$$"
+  trap cleanup_pod EXIT INT TERM
+
+  kubectl -n maintainerd run "$POD_NAME" --restart=Never \
+    --image=postgres:16-alpine \
+    --env="PGPASSWORD=${DB_PASSWORD}" \
+    --command -- sleep infinity >/dev/null
+
+  kubectl -n maintainerd wait --for=condition=Ready "pod/${POD_NAME}" --timeout=60s >/dev/null
+
+  kubectl -n maintainerd exec -it "$POD_NAME" -- \
+    sh -lc "export TERM='${TERM:-xterm}' PAGER=cat PSQL_PAGER=off; exec psql -X -w \"host=${DB_HOST} port=${DB_PORT} user=${DB_USER} dbname=${DB_NAME} sslmode=require connect_timeout=5\""
+elif [ -n "$SQL_FILE" ]; then
   kubectl -n maintainerd run psql-client --rm -it --restart=Never \
     --image=postgres:16-alpine \
     --env="PGPASSWORD=${DB_PASSWORD}" -- \

--- a/web/src/app/companies/[id]/page.tsx
+++ b/web/src/app/companies/[id]/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useParams } from "next/navigation";
 import Link from "next/link";
 import AppShell from "@/components/AppShell";
+import { getAuthBaseUrl, redirectToAuthLogin } from "@/utils/auth";
 import styles from "./page.module.css";
 
 type CompanyProject = {
@@ -63,6 +64,7 @@ export default function CompanyPage() {
     }
     return `${bffBaseUrl}/api`;
   }, [bffBaseUrl]);
+  const authBaseUrl = useMemo(() => getAuthBaseUrl(bffBaseUrl), [bffBaseUrl]);
 
   useEffect(() => {
     if (!Number.isFinite(id)) {
@@ -79,7 +81,11 @@ export default function CompanyPage() {
           credentials: "include",
         });
         if (!response.ok) {
-          if (response.status === 401 || response.status === 403) {
+          if (response.status === 401) {
+            redirectToAuthLogin(authBaseUrl, `/companies/${id}`);
+            return;
+          }
+          if (response.status === 403) {
             setError("You do not have access to this company.");
             setStatus("ready");
             return;
@@ -110,7 +116,7 @@ export default function CompanyPage() {
     return () => {
       alive = false;
     };
-  }, [apiBaseUrl, id]);
+  }, [apiBaseUrl, authBaseUrl, id]);
 
   const rows = useMemo<TableRow[]>(() => {
     if (!company) return [];

--- a/web/src/app/maintainers/[id]/page.tsx
+++ b/web/src/app/maintainers/[id]/page.tsx
@@ -12,6 +12,7 @@ import MaintainerServicesPanel, {
   MaintainerServiceView,
 } from "@/components/MaintainerServicesPanel";
 import CompanyCreateModal from "@/components/CompanyCreateModal";
+import { getAuthBaseUrl, redirectToAuthLogin } from "@/utils/auth";
 import styles from "./page.module.css";
 
 type MaintainerDetail = {
@@ -106,6 +107,7 @@ export default function MaintainerPage() {
     }
     return `${bffBaseUrl}/api`;
   }, [bffBaseUrl]);
+  const authBaseUrl = useMemo(() => getAuthBaseUrl(bffBaseUrl), [bffBaseUrl]);
 
   const canEdit = role === "staff";
   const canEditSelf =
@@ -139,7 +141,7 @@ export default function MaintainerPage() {
         );
         if (!response.ok) {
           if (response.status === 401) {
-            router.push("/");
+            redirectToAuthLogin(authBaseUrl, `/maintainers/${maintainerId}`);
             return;
           }
           throw new Error(`unexpected status ${response.status}`);
@@ -171,7 +173,7 @@ export default function MaintainerPage() {
         window.clearInterval(intervalId);
       }
     };
-  }, [apiBaseUrl, error, isEditing, maintainer, maintainerId, pollIntervalMs, router]);
+  }, [apiBaseUrl, authBaseUrl, error, isEditing, maintainer, maintainerId, pollIntervalMs, router]);
 
   useEffect(() => {
     let alive = true;

--- a/web/src/app/page.module.css
+++ b/web/src/app/page.module.css
@@ -7,8 +7,113 @@
   gap: 32px;
 }
 
+.eyebrow {
+  margin: 0;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: #d62293;
+}
+
+.hero {
+  min-height: calc(100vh - 280px);
+  display: grid;
+  place-items: center;
+}
+
+.heroPanel {
+  width: min(100%, 760px);
+  padding: 48px;
+  border-radius: 28px;
+  background:
+    radial-gradient(circle at top left, rgba(214, 34, 147, 0.14), transparent 38%),
+    linear-gradient(135deg, rgba(255, 255, 255, 0.96), rgba(247, 250, 252, 0.96));
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  box-shadow: 0 24px 64px rgba(15, 23, 42, 0.1);
+}
+
+.heroTitle {
+  margin: 12px 0 16px;
+  font-size: clamp(2.5rem, 5vw, 4.5rem);
+  line-height: 0.95;
+  letter-spacing: -0.04em;
+  max-width: 12ch;
+  color: var(--md-card-text, #0f172a);
+}
+
+.heroText {
+  margin: 0 0 24px;
+  max-width: 58ch;
+  font-size: 1rem;
+  line-height: 1.7;
+  color: var(--md-card-muted, rgba(15, 23, 42, 0.75));
+}
+
+.loginButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 12px 18px;
+  border-radius: 999px;
+  background: #d62293;
+  color: #ffffff;
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.loginButton:hover {
+  background: #b91c7a;
+  transform: translateY(-1px);
+}
+
+[data-theme="dark"] .eyebrow {
+  color: #ff5ec4;
+}
+
+[data-theme="dark"] .heroPanel {
+  background:
+    radial-gradient(circle at top left, rgba(255, 94, 196, 0.18), transparent 42%),
+    linear-gradient(135deg, rgba(22, 25, 31, 0.96), rgba(12, 16, 22, 0.98));
+  border-color: rgba(255, 255, 255, 0.12);
+  box-shadow: 0 24px 64px rgba(0, 0, 0, 0.45);
+}
+
+[data-theme="dark"] .heroTitle {
+  color: #f7f8fb;
+}
+
+[data-theme="dark"] .heroText {
+  color: rgba(236, 239, 244, 0.88);
+}
+
+[data-theme="dark"] .loginButton {
+  background: #ff4eb8;
+  color: #130814;
+}
+
+[data-theme="dark"] .loginButton:hover {
+  background: #ff79ca;
+}
+
 @media (max-width: 600px) {
   .main {
     padding: 24px 16px 48px;
+  }
+
+  .hero {
+    min-height: auto;
+  }
+
+  .heroPanel {
+    padding: 32px 24px;
+    border-radius: 20px;
+  }
+
+  .heroTitle {
+    max-width: none;
   }
 }

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -1,16 +1,56 @@
 "use client";
 
 import AppShell from "@/components/AppShell";
+import type { AppShellViewer } from "@/components/AppShell";
 import ProjectsList from "@/components/ProjectsList";
+import { buildAuthLoginHref, getAuthBaseUrl } from "@/utils/auth";
+import { usePathname } from "next/navigation";
+import { useMemo } from "react";
 import styles from "./page.module.css";
 
 export default function Home() {
+  const authBaseUrl = useMemo(() => {
+    return getAuthBaseUrl();
+  }, []);
+
   return (
     <AppShell>
-      <main className={styles.main}>
-        <ProjectsList />
-      </main>
-
+      {(viewer) => <HomeContent viewer={viewer} authBaseUrl={authBaseUrl} />}
     </AppShell>
+  );
+}
+
+type HomeContentProps = {
+  viewer: AppShellViewer;
+  authBaseUrl: string;
+};
+
+function HomeContent({ viewer, authBaseUrl }: HomeContentProps) {
+  const pathname = usePathname();
+
+  return (
+    <main className={styles.main}>
+      {viewer ? (
+        <ProjectsList />
+      ) : (
+        <section className={styles.hero}>
+          <div className={styles.heroPanel}>
+            <p className={styles.eyebrow}>Maintainer Intelligence</p>
+            <h1 className={styles.heroTitle}>CNCF Staff sign-in using GitHub</h1>
+            <p className={styles.heroText}>
+              maintainer-d helps authorized staff and maintainers review project ownership,
+              roster files, and onboarding status. Sign in to search the directory and view
+              the maintainer table.
+            </p>
+            <a
+              className={styles.loginButton}
+              href={buildAuthLoginHref(authBaseUrl, pathname || "/")}
+            >
+              Sign in with GitHub
+            </a>
+          </div>
+        </section>
+      )}
+    </main>
   );
 }

--- a/web/src/app/projects/[id]/ProjectRouteClient.tsx
+++ b/web/src/app/projects/[id]/ProjectRouteClient.tsx
@@ -7,6 +7,7 @@ import ProjectReconciliationCard, {
   AddMaintainerPayload,
   ProjectSectionId,
 } from "@/components/ProjectReconciliationCard";
+import { getAuthBaseUrl, redirectToAuthLogin } from "@/utils/auth";
 import styles from "./page.module.css";
 
 type MaintainerSummary = {
@@ -204,10 +205,17 @@ export default function ProjectRouteClient(_props: ProjectRouteClientProps) {
     }
     return `${bffBaseUrl}/api`;
   }, [bffBaseUrl]);
+  const authBaseUrl = useMemo(() => getAuthBaseUrl(bffBaseUrl), [bffBaseUrl]);
   const section = useMemo<ProjectSectionId>(() => {
     const matchedRoute = projectSectionRoutes.find((item) => item.segment === segment);
     return matchedRoute?.id ?? "legacy";
   }, [segment]);
+  const currentProjectPath = useMemo(() => {
+    if (!projectId) {
+      return "/projects";
+    }
+    return segment ? `/projects/${projectId}/${segment}` : `/projects/${projectId}`;
+  }, [projectId, segment]);
 
   useEffect(() => {
     let alive = true;
@@ -228,7 +236,7 @@ export default function ProjectRouteClient(_props: ProjectRouteClientProps) {
         });
         if (!response.ok) {
           if (response.status === 401) {
-            router.push("/");
+            redirectToAuthLogin(authBaseUrl, currentProjectPath);
             return;
           }
           throw new Error(`unexpected status ${response.status}`);
@@ -254,7 +262,7 @@ export default function ProjectRouteClient(_props: ProjectRouteClientProps) {
     return () => {
       alive = false;
     };
-  }, [apiBaseUrl, projectId, router]);
+  }, [apiBaseUrl, authBaseUrl, currentProjectPath, projectId, router]);
 
   useEffect(() => {
     let alive = true;
@@ -322,7 +330,7 @@ export default function ProjectRouteClient(_props: ProjectRouteClientProps) {
       });
       if (!response.ok) {
         if (response.status === 401) {
-          router.push("/");
+          redirectToAuthLogin(authBaseUrl, currentProjectPath);
           return;
         }
         throw new Error(`unexpected status ${response.status}`);

--- a/web/src/app/search/search-client.tsx
+++ b/web/src/app/search/search-client.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { useSearchParams } from "next/navigation";
+import { usePathname, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { Pagination } from "clo-ui/components/Pagination";
 import AppShell from "@/components/AppShell";
+import { getAuthBaseUrl, redirectToAuthLogin } from "@/utils/auth";
 import styles from "./page.module.css";
 
 type SearchProject = {
@@ -41,6 +42,7 @@ type SearchResponse = {
 };
 
 export default function SearchClient() {
+  const pathname = usePathname();
   const searchParams = useSearchParams();
   const query = (searchParams.get("query") || "").trim();
   const [results, setResults] = useState<SearchResponse | null>(null);
@@ -55,6 +57,7 @@ export default function SearchClient() {
     const raw = process.env.NEXT_PUBLIC_BFF_BASE_URL || "/api";
     return raw.replace(/\/+$/, "");
   }, []);
+  const authBaseUrl = useMemo(() => getAuthBaseUrl(bffBaseUrl), [bffBaseUrl]);
   const apiBaseUrl = useMemo(() => {
     if (bffBaseUrl === "") {
       return "/api";
@@ -88,7 +91,11 @@ export default function SearchClient() {
           { credentials: "include" }
         );
         if (!response.ok) {
-          if (response.status === 401 || response.status === 403) {
+          if (response.status === 401) {
+            redirectToAuthLogin(authBaseUrl, pathname);
+            return;
+          }
+          if (response.status === 403) {
             setError("You do not have access to global search.");
             setStatus("ready");
             return;
@@ -114,7 +121,7 @@ export default function SearchClient() {
     return () => {
       alive = false;
     };
-  }, [apiBaseUrl, query, projectsPage, maintainersPage, companiesPage]);
+  }, [apiBaseUrl, authBaseUrl, companiesPage, maintainersPage, pathname, projectsPage, query]);
 
   const hasQuery = query.length > 0;
   const hasResults =
@@ -145,7 +152,7 @@ export default function SearchClient() {
         </header>
 
         {!hasQuery ? (
-          <div className={styles.empty}>Enter a search term in the top bar.</div>
+          <div className={styles.empty}>Enter a search term in the shared search bar to search the directory.</div>
         ) : status === "loading" ? (
           <div className={styles.empty}>Searching…</div>
         ) : error ? (

--- a/web/src/components/AppShell.module.css
+++ b/web/src/components/AppShell.module.css
@@ -56,31 +56,6 @@
   min-width: 0;
 }
 
-.navSearch {
-  width: 100%;
-  max-width: 100%;
-  flex: 1;
-  min-width: 0;
-}
-
-.navSearch :global(.searchbarWrapper) {
-  flex: 1;
-  min-width: 0;
-}
-
-.navSearch :global(input) {
-  width: 100%;
-  max-width: none;
-  border: 2px solid var(--md-border-strong, rgba(15, 23, 42, 0.25));
-  box-shadow: none;
-  height: 40px;
-  padding: 8px 12px;
-}
-
-.navSearch :global(input:focus) {
-  box-shadow: none;
-}
-
 .userPill {
   padding: 6px 12px;
   border-radius: 999px;
@@ -168,28 +143,12 @@
   background: var(--md-surface-strong);
 }
 
-.loginButton {
-  padding: 8px 14px;
-  border-radius: 999px;
-  border: 1px solid rgba(255, 255, 255, 0.5);
-  color: #ffffff;
-  font-size: 12px;
-  text-transform: uppercase;
-  letter-spacing: 1px;
-  transition: background 0.2s ease, color 0.2s ease;
-}
-
 .footerCol {
   padding-right: 5rem;
 }
 
 .miniIcon {
   font-size: 0.75rem;
-}
-
-.loginButton:hover {
-  background: #ffffff;
-  color: var(--clo-secondary);
 }
 
 .auditButton {
@@ -209,6 +168,47 @@
 
 .content {
   padding-top: 0;
+}
+
+.searchBand {
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.96), rgba(246, 248, 251, 0.98));
+  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.06);
+}
+
+.searchBandInner {
+  width: 100%;
+  margin: 0 auto;
+  padding: 16px 24px 18px;
+}
+
+.searchbar {
+  width: 100%;
+}
+
+.searchbar :global(.searchbarWrapper) {
+  width: 100%;
+}
+
+.searchbar :global(input) {
+  width: 100%;
+  max-width: none;
+  border: 2px solid rgba(214, 34, 147, 0.55);
+  background: var(--md-card-bg, #ffffff);
+  color: var(--md-card-text, #0f172a);
+  box-shadow: none;
+  height: 46px;
+  padding: 10px 14px;
+}
+
+.searchbar :global(input:focus) {
+  border-color: #d62293;
+  box-shadow: 0 0 0 3px rgba(214, 34, 147, 0.14);
+}
+
+.searchbar :global(input::placeholder) {
+  color: var(--md-card-muted, rgba(15, 23, 42, 0.6));
 }
 
 .footer {
@@ -235,6 +235,23 @@
   .navCenter {
     max-width: none;
   }
+
+  .searchBandInner {
+    padding: 12px 16px 14px;
+  }
+}
+
+[data-theme='dark'] .searchBand {
+  background:
+    linear-gradient(180deg, rgba(18, 22, 28, 0.96), rgba(12, 16, 22, 0.98));
+  border-bottom-color: rgba(255, 255, 255, 0.08);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.28);
+}
+
+[data-theme='dark'] .searchbar :global(input) {
+  background: #16191f;
+  border-color: rgba(255, 94, 196, 0.38);
+  color: #f3f5f9;
 }
 
 @media only screen and (max-width: 991.98px) {
@@ -274,5 +291,17 @@
 
   .content {
     padding-top: 96px;
+  }
+
+  .searchBand {
+    position: fixed;
+    top: 81px;
+    right: 0;
+    left: 0;
+    z-index: 1039;
+  }
+
+  .contentWithSearch {
+    padding-top: 162px;
   }
 }

--- a/web/src/components/AppShell.tsx
+++ b/web/src/components/AppShell.tsx
@@ -7,19 +7,19 @@ import { Navbar } from "clo-ui/components/Navbar";
 import { Searchbar } from "clo-ui/components/Searchbar";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
+import { getAuthBaseUrl, redirectToAuthLogin } from "@/utils/auth";
 import { useTheme } from "./ThemeProvider";
 import styles from "./AppShell.module.css";
 
-type AppShellProps = {
-  children: ReactNode;
-  navCenter?: ReactNode;
-  navCenterClassName?: string;
-};
-
-type MeResponse = {
+export type AppShellViewer = {
   login: string;
   role: string;
   maintainerId?: number;
+} | null;
+
+type AppShellProps = {
+  children: ReactNode | ((viewer: AppShellViewer) => ReactNode);
+  navCenterClassName?: string;
 };
 
 const MoonIcon = () => (
@@ -51,25 +51,16 @@ const SunIcon = () => (
 
 export default function AppShell({
   children,
-  navCenter,
   navCenterClassName,
 }: AppShellProps) {
-  const [me, setMe] = useState<MeResponse | null>(null);
+  const [me, setMe] = useState<AppShellViewer>(null);
   const { theme, toggleTheme } = useTheme();
   const devLoginAttemptedRef = useRef(false);
+  const authRedirectAttemptedRef = useRef(false);
   const [mounted, setMounted] = useState(false);
-  const router = useRouter();
+  const [searchQuery, setSearchQuery] = useState("");
   const pathname = usePathname();
-  const [navQuery, setNavQuery] = useState("");
-
-  useEffect(() => {
-    if (typeof window === "undefined") {
-      return;
-    }
-    const params = new URLSearchParams(window.location.search);
-    const nextQuery = params.get("query") || "";
-    setNavQuery((current) => (current === nextQuery ? current : nextQuery));
-  }, [pathname]);
+  const router = useRouter();
 
   const bffBaseUrl = useMemo(() => {
     const raw = process.env.NEXT_PUBLIC_BFF_BASE_URL || "/api";
@@ -87,11 +78,7 @@ export default function AppShell({
   }, [bffBaseUrl]);
 
   const authBaseUrl = useMemo(() => {
-    if (bffBaseUrl.endsWith("/api")) {
-      const stripped = bffBaseUrl.slice(0, -4);
-      return stripped === "" ? "" : stripped;
-    }
-    return bffBaseUrl;
+    return getAuthBaseUrl(bffBaseUrl);
   }, [bffBaseUrl]);
 
   useEffect(() => {
@@ -128,11 +115,20 @@ export default function AppShell({
             if (alive) {
               setMe(null);
             }
+            if (
+              pathname &&
+              pathname !== "/" &&
+              typeof window !== "undefined" &&
+              !authRedirectAttemptedRef.current
+            ) {
+              authRedirectAttemptedRef.current = true;
+              redirectToAuthLogin(authBaseUrl, pathname);
+            }
             return;
           }
           throw new Error(`unexpected status ${response.status}`);
         }
-        const data = (await response.json()) as MeResponse;
+        const data = (await response.json()) as NonNullable<AppShellViewer>;
         if (alive) {
           setMe(data);
         }
@@ -147,11 +143,19 @@ export default function AppShell({
     return () => {
       alive = false;
     };
-  }, [apiBaseUrl, authBaseUrl]);
+  }, [apiBaseUrl, authBaseUrl, pathname]);
 
   useEffect(() => {
     setMounted(true);
   }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+    const nextQuery = new URLSearchParams(window.location.search).get("query") || "";
+    setSearchQuery((current) => (current === nextQuery ? current : nextQuery));
+  }, [pathname]);
 
   const handleLogout = async () => {
     try {
@@ -164,34 +168,19 @@ export default function AppShell({
     }
   };
 
+  const handleSearch = () => {
+    const nextQuery = searchQuery.trim();
+    setSearchQuery(nextQuery);
+    const params = new URLSearchParams();
+    if (nextQuery) {
+      params.set("query", nextQuery);
+    }
+    const qs = params.toString();
+    router.push(qs ? `/search?${qs}` : "/search");
+  };
+
   const userLabel = me ? `${me.login} · ${me.role}` : "";
-  const navSearchPlaceholder =
-    "Search projects, maintainers, companies, or roster URLs";
-  const navSearch =
-    navCenter === undefined ? (
-      <Searchbar
-        placeholder={navSearchPlaceholder}
-        value={navQuery}
-        onValueChange={setNavQuery}
-        onSearch={() => {
-          const params = new URLSearchParams();
-          if (navQuery.trim()) {
-            params.set("query", navQuery.trim());
-          }
-          const qs = params.toString();
-          router.push(qs ? `/search?${qs}` : "/search");
-          if (typeof window !== "undefined") {
-            window.dispatchEvent(new Event("md-search"));
-          }
-        }}
-        cleanSearchValue={() => setNavQuery("")}
-        bigSize={false}
-        noButtons
-        classNameWrapper={styles.navSearch}
-      />
-    ) : (
-      navCenter
-    );
+  const content = typeof children === "function" ? children(me) : children;
 
   return (
     <div className={styles.page}>
@@ -204,7 +193,6 @@ export default function AppShell({
             <div className={styles.alpha}>Alpha</div>
           </div>
           <div className={`${styles.navCenter} ${navCenterClassName ?? ""}`}>
-            {navSearch}
           </div>
           <div className={styles.userArea}>
             <button
@@ -245,18 +233,26 @@ export default function AppShell({
                   maintainerId={me.maintainerId}
                 />
               </Dropdown>
-            ) : (
-              <Link
-                className={styles.loginButton}
-                href={`${authBaseUrl}/auth/login?next=/`}
-              >
-                Sign in with GitHub
-              </Link>
-            )}
+            ) : null}
           </div>
         </div>
       </Navbar>
-      <div className={styles.content}>{children}</div>
+      {me ? (
+        <div className={styles.searchBand}>
+          <div className={styles.searchBandInner}>
+            <Searchbar
+              placeholder="Search projects, maintainers, companies, or roster URLs"
+              value={searchQuery}
+              onValueChange={setSearchQuery}
+              onSearch={handleSearch}
+              cleanSearchValue={() => setSearchQuery("")}
+              bigSize={false}
+              classNameWrapper={styles.searchbar}
+            />
+          </div>
+        </div>
+      ) : null}
+      <div className={`${styles.content} ${me ? styles.contentWithSearch : ""}`}>{content}</div>
       <Footer className={styles.footer} logo={<span className={styles.footerLogo}>maintainer-d</span>}>
         <div className={styles.footerCol}>
           <div className="h6 fw-bold text-uppercase">Project</div>

--- a/web/src/utils/auth.ts
+++ b/web/src/utils/auth.ts
@@ -1,0 +1,30 @@
+"use client";
+
+export function getAuthBaseUrl(bffBaseUrl?: string): string {
+  const raw = bffBaseUrl ?? process.env.NEXT_PUBLIC_BFF_BASE_URL ?? "/api";
+  const normalized = raw.replace(/\/+$/, "");
+  if (normalized.endsWith("/api")) {
+    const stripped = normalized.slice(0, -4);
+    return stripped === "" ? "" : stripped;
+  }
+  return normalized;
+}
+
+export function buildAuthLoginHref(authBaseUrl: string, next: string): string {
+  return `${authBaseUrl}/auth/login?next=${encodeURIComponent(next)}`;
+}
+
+export function buildCurrentRelativeUrl(pathname?: string | null): string {
+  const basePath = pathname && pathname.trim() !== "" ? pathname : "/";
+  if (typeof window === "undefined") {
+    return basePath;
+  }
+  return `${basePath}${window.location.search}${window.location.hash}`;
+}
+
+export function redirectToAuthLogin(authBaseUrl: string, pathname?: string | null): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+  window.location.assign(buildAuthLoginHref(authBaseUrl, buildCurrentRelativeUrl(pathname)));
+}

--- a/web/tests/steps/global-search.steps.js
+++ b/web/tests/steps/global-search.steps.js
@@ -63,9 +63,35 @@ When("I search globally for maintainer email {string}", async function (email) {
 ]);
 });
 
+When("I open the global search page", async function () {
+  await this.page.goto(`${this.baseUrl}/search`, { waitUntil: "domcontentloaded" });
+  await expect(
+    this.page.getByRole("heading", { name: "Global Search" })
+  ).toBeVisible({ timeout: 15000 });
+});
+
+When("I search from the search page for {string}", async function (query) {
+  const searchInput = this.page.getByPlaceholder(
+    "Search projects, maintainers, companies, or roster URLs"
+  );
+  await expect(searchInput).toBeVisible({ timeout: 15000 });
+  await searchInput.fill(query);
+  await searchInput.press("Enter");
+  await this.page.waitForURL(
+    new RegExp(`/search\\?query=${encodeURIComponent(query).replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`)
+  , { timeout: 15000 });
+});
+
 Then("I see maintainer {string} in the results", async function (name) {
   const section = getMaintainersSection(this.page);
   await expect(section.getByRole("link", { name })).toBeVisible({ timeout: 15000 });
+});
+
+Then("the search page URL includes query {string}", async function (query) {
+  await expect(this.page).toHaveURL(
+    new RegExp(`/search\\?query=${encodeURIComponent(query).replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`),
+    { timeout: 15000 }
+  );
 });
 
 Then("the result shows the maintainer email {string}", async function (email) {

--- a/web/tests/steps/maintainer.steps.js
+++ b/web/tests/steps/maintainer.steps.js
@@ -2,7 +2,9 @@ const { When, Then } = require("@cucumber/cucumber");
 const { expect } = require("@playwright/test");
 
 When("I search for {string}", async function (query) {
-  const searchInput = this.page.getByPlaceholder("Search projects");
+  const searchInput = this.page.getByPlaceholder(
+    "Search projects, maintainers, companies, or roster URLs"
+  );
   await searchInput.fill(query);
   await searchInput.press("Enter");
   await this.page.screenshot({

--- a/web/tests/steps/project_routes.steps.js
+++ b/web/tests/steps/project_routes.steps.js
@@ -1,0 +1,54 @@
+const { Given, When, Then } = require("@cucumber/cucumber");
+const { expect } = require("@playwright/test");
+
+const routeProjectName = "Project Atlas";
+
+const resolveProjectId = async (world, name) => {
+  const response = await world.page.request.get(
+    `${world.bffBaseUrl}/api/search?query=${encodeURIComponent(name)}`
+  );
+  if (!response.ok()) {
+    throw new Error(`Failed to search project: ${response.status()}`);
+  }
+  const data = await response.json();
+  const project = (data.projects || []).find((item) => item.name === name);
+  if (!project) {
+    throw new Error(`Project ${name} not found in search results.`);
+  }
+  return project.id;
+};
+
+Given("a project exists with reconciliation routes", function () {
+  this.projectName = routeProjectName;
+});
+
+When("I open the project github route", async function () {
+  this.projectId = await resolveProjectId(this, this.projectName);
+  await this.page.goto(`${this.baseUrl}/projects/${this.projectId}/github`, {
+    waitUntil: "domcontentloaded",
+  });
+  await expect(this.page.getByRole("heading", { name: this.projectName })).toBeVisible({
+    timeout: 15000,
+  });
+});
+
+Then("the project route navigation exposes these routes", async function (table) {
+  const projectNav = this.page.locator('[class*="projectMenu"]');
+  const routeHeader = this.page.locator('[class*="collapsibleHeader"]');
+  const contentColumn = this.page.locator('[class*="contentColumn"]');
+  for (const row of table.hashes()) {
+    const link = projectNav.getByRole("link", { name: row.label, exact: true });
+    await expect(link).toBeVisible({ timeout: 15000 });
+    await link.click();
+    await expect(this.page).toHaveURL(
+      new RegExp(`/projects/${this.projectId}${row["path-suffix"]}$`),
+      { timeout: 15000 }
+    );
+    await expect(routeHeader.getByRole("heading", { name: row.heading, exact: true })).toBeVisible({
+      timeout: 15000,
+    });
+    await expect(contentColumn.getByText(row["body-snippet"], { exact: false })).toBeVisible({
+      timeout: 15000,
+    });
+  }
+});

--- a/web/tests/steps/protected_routes.steps.js
+++ b/web/tests/steps/protected_routes.steps.js
@@ -1,0 +1,156 @@
+const { Given, When, Then } = require("@cucumber/cucumber");
+const { expect } = require("@playwright/test");
+
+const routeProjectName = "Project Atlas";
+const companyName = "Example Labs";
+const maintainerName = "Antonio Example";
+const protectedSearchQuery = "alex@example.dev";
+
+const signInAsStaffRequest = async (world) => {
+  const login = process.env.TEST_STAFF_LOGIN || "staff-tester";
+  const response = await world.page.request.get(
+    `${world.bffBaseUrl}/auth/test-login?login=${encodeURIComponent(login)}`
+  );
+  if (!response.ok()) {
+    throw new Error(`Failed to sign in test staff user: ${response.status()}`);
+  }
+};
+
+const signOutRequest = async (world) => {
+  await world.page.request.post(`${world.bffBaseUrl}/auth/logout`);
+  await world.context.clearCookies();
+};
+
+const resolveSearchEntityId = async (world, query, field, expectedValue) => {
+  await signInAsStaffRequest(world);
+  const response = await world.page.request.get(
+    `${world.bffBaseUrl}/api/search?query=${encodeURIComponent(query)}`
+  );
+  if (!response.ok()) {
+    throw new Error(`Failed to search for ${field}: ${response.status()}`);
+  }
+  const data = await response.json();
+  const collection = Array.isArray(data[field]) ? data[field] : [];
+  const entity = collection.find((item) => item.name === expectedValue);
+  await signOutRequest(world);
+  if (!entity || !entity.id) {
+    throw new Error(`Unable to resolve ${field} ID for ${expectedValue}`);
+  }
+  return entity.id;
+};
+
+const captureAuthRedirect = async (world, protectedPath) => {
+  let authLoginRequestURL = null;
+  const handleRequest = (request) => {
+    if (request.url().startsWith(`${world.bffBaseUrl}/auth/login`)) {
+      authLoginRequestURL = request.url();
+    }
+  };
+
+  await world.page.route("https://github.com/**", async (route) => {
+    await route.abort();
+  });
+  world.page.on("request", handleRequest);
+
+  try {
+    await world.page.goto(`${world.baseUrl}${protectedPath}`, {
+      waitUntil: "domcontentloaded",
+      timeout: 15000,
+    });
+  } catch {
+    // The browser may abort once the OAuth redirect leaves the local app.
+  }
+
+  await expect
+    .poll(() => authLoginRequestURL, {
+      timeout: 15000,
+      message: "Expected the app to request /auth/login for the protected route",
+    })
+    .toBeTruthy();
+
+  world.protectedPath = protectedPath;
+  world.authLoginRequestURL = authLoginRequestURL;
+
+  world.page.off("request", handleRequest);
+  await world.page.unroute("https://github.com/**");
+};
+
+Given("I am signed out", async function () {
+  await signOutRequest(this);
+});
+
+When("I open a protected project route while signed out", async function () {
+  this.projectId = await resolveSearchEntityId(this, routeProjectName, "projects", routeProjectName);
+  await captureAuthRedirect(this, `/projects/${this.projectId}/github`);
+});
+
+When("I open a protected maintainer page while signed out", async function () {
+  this.maintainerId = await resolveSearchEntityId(this, maintainerName, "maintainers", maintainerName);
+  await captureAuthRedirect(this, `/maintainers/${this.maintainerId}`);
+});
+
+When("I open a protected company page while signed out", async function () {
+  this.companyId = await resolveSearchEntityId(this, companyName, "companies", companyName);
+  await captureAuthRedirect(this, `/companies/${this.companyId}`);
+});
+
+When("I open a protected search page with a query while signed out", async function () {
+  await captureAuthRedirect(this, `/search?query=${encodeURIComponent(protectedSearchQuery)}`);
+});
+
+Then("I am redirected to sign in with a next parameter for the protected route", async function () {
+  expect(this.authLoginRequestURL).toContain("/auth/login?next=");
+  expect(this.authLoginRequestURL).toContain(
+    `next=${encodeURIComponent(this.protectedPath)}`
+  );
+});
+
+When("I complete sign-in for the protected route", async function () {
+  await signInAsStaffRequest(this);
+  await this.page.goto(`${this.baseUrl}${this.protectedPath}`, {
+    waitUntil: "domcontentloaded",
+  });
+});
+
+Then("I land on the original protected project route", async function () {
+  await expect(this.page).toHaveURL(
+    new RegExp(`/projects/${this.projectId}/github$`),
+    { timeout: 15000 }
+  );
+  await expect(
+    this.page.getByRole("heading", { name: routeProjectName })
+  ).toBeVisible({ timeout: 15000 });
+});
+
+Then("I land on the original protected maintainer page", async function () {
+  await expect(this.page).toHaveURL(
+    new RegExp(`/maintainers/${this.maintainerId}$`),
+    { timeout: 15000 }
+  );
+  await expect(
+    this.page.getByRole("heading", { name: maintainerName })
+  ).toBeVisible({ timeout: 15000 });
+});
+
+Then("I land on the original protected company page", async function () {
+  await expect(this.page).toHaveURL(
+    new RegExp(`/companies/${this.companyId}$`),
+    { timeout: 15000 }
+  );
+  await expect(
+    this.page.getByRole("heading", { name: companyName })
+  ).toBeVisible({ timeout: 15000 });
+});
+
+Then("I land on the original protected search page with the query intact", async function () {
+  await expect(this.page).toHaveURL(
+    new RegExp(`/search\\?query=${encodeURIComponent(protectedSearchQuery)}`),
+    { timeout: 15000 }
+  );
+  await expect(
+    this.page.getByText(`Query: “${protectedSearchQuery}”`)
+  ).toBeVisible({ timeout: 15000 });
+  await expect(
+    this.page.getByRole("link", { name: "Alex Example" })
+  ).toBeVisible({ timeout: 15000 });
+});


### PR DESCRIPTION
  1. Unauthenticated visitors to / now see a hero panel with a sign-in button rather than a blank page
  2. Protected routes (/projects/:id, /maintainers/:id, /companies/:id, /search) redirect to sign-in with ?next=<original-path> so the user lands back where they started after auth
  3. The search bar moves out of the navbar into a dedicated band below it, shown only when authenticated