### PR TITLE
runs FOSSA poller as a Deployment instead of a long-running CronJob.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -351,10 +351,25 @@ onboarding-backfill-job:
 	@echo "Running onboarding backfill job in namespace $(NAMESPACE) [ctx=$(CTX_STR)]"
 	@kubectl -n $(NAMESPACE) $(if $(KUBECONTEXT),--context $(KUBECONTEXT)) apply -f deploy/manifests/maintainerd-onboarding-backfill-job.yaml
 
+.PHONY: fossa-poller-deploy
+fossa-poller-deploy:
+	@bash -c 'set -euo pipefail; \
+	echo "Retiring legacy CronJob/maintainerd-fossa-poller in namespace $(NAMESPACE) [ctx=$(CTX_STR)]"; \
+	kubectl -n $(NAMESPACE) $(if $(KUBECONTEXT),--context $(KUBECONTEXT)) delete cronjob maintainerd-fossa-poller --ignore-not-found; \
+	jobs="$$(kubectl -n $(NAMESPACE) $(if $(KUBECONTEXT),--context $(KUBECONTEXT)) get jobs -o name | grep "^job.batch/maintainerd-fossa-poller-" || true)"; \
+	if [ -n "$${jobs}" ]; then \
+		echo "Deleting legacy fossa poller Jobs [ctx=$(CTX_STR)]"; \
+		echo "$${jobs}" | xargs -r kubectl -n $(NAMESPACE) $(if $(KUBECONTEXT),--context $(KUBECONTEXT)) delete --wait=true; \
+	fi; \
+	echo "Applying fossa poller deployment in namespace $(NAMESPACE) [ctx=$(CTX_STR)]"; \
+	kubectl -n $(NAMESPACE) $(if $(KUBECONTEXT),--context $(KUBECONTEXT)) apply -f deploy/manifests/maintainerd-fossa-poller-deployment.yaml; \
+	kubectl -n $(NAMESPACE) $(if $(KUBECONTEXT),--context $(KUBECONTEXT)) rollout status deployment/maintainerd-fossa-poller --timeout=180s; \
+	'
+
 .PHONY: fossa-poller-cronjob
 fossa-poller-cronjob:
-	@echo "Applying fossa poller cronjob in namespace $(NAMESPACE) [ctx=$(CTX_STR)]"
-	@kubectl -n $(NAMESPACE) $(if $(KUBECONTEXT),--context $(KUBECONTEXT)) apply -f deploy/manifests/cronjob-fossa-poller.yaml
+	@echo "fossa-poller-cronjob is deprecated; applying the deployment-backed poller instead [ctx=$(CTX_STR)]"
+	@$(MAKE) fossa-poller-deploy
 
 .PHONY: migrate-schema-safe
 migrate-schema-safe:
@@ -460,6 +475,7 @@ help:
 	@echo "make mntrd-image-deploy -> build, push, and restart Deployment in $(NAMESPACE)"
 	@echo "make sync-apply      -> apply CronJob + RBAC for the sync job"
 	@echo "make sync-run        -> trigger a manual sync job and tail logs"
+	@echo "make fossa-poller-deploy -> apply Deployment for the long-running FOSSA poller"
 	@echo "make bootstrap-run   -> prod: recreate bootstrap job after applying SOPS bootstrap secrets"
 	@echo "make bootstrap-run-dev -> dev: recreate bootstrap job after applying .envrc secrets"
 	@echo "make migrate-schema  -> run one-off schema migration job"
@@ -1063,9 +1079,11 @@ fossa-poller-image-set:
 	@if [ -z "$(TAG)" ]; then \
 		echo "Usage: make fossa-poller-image-set TAG=<tag>"; exit 1; \
 	fi
-	@echo "Setting maintainerd-fossa-poller image to $(FOSSA_POLLER_IMAGE) [ns=$(NAMESPACE)]"
+	@echo "Setting Deployment/maintainerd-fossa-poller image to $(FOSSA_POLLER_IMAGE) [ns=$(NAMESPACE)]"
 	@kubectl -n $(NAMESPACE) $(if $(KUBECONTEXT),--context $(KUBECONTEXT)) \
-		set image cronjob/maintainerd-fossa-poller fossa-poller=$(FOSSA_POLLER_IMAGE)
+		set image deployment/maintainerd-fossa-poller fossa-poller=$(FOSSA_POLLER_IMAGE)
+	@kubectl -n $(NAMESPACE) $(if $(KUBECONTEXT),--context $(KUBECONTEXT)) \
+		rollout status deployment/maintainerd-fossa-poller --timeout=180s
 
 .PHONY: sync-image-set
 sync-image-set:

--- a/deploy/manifests/maintainerd-fossa-poller-deployment.yaml
+++ b/deploy/manifests/maintainerd-fossa-poller-deployment.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: maintainerd-fossa-poller
+  namespace: maintainerd
+  labels:
+    app: maintainerd-fossa-poller
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: maintainerd-fossa-poller
+  template:
+    metadata:
+      labels:
+        app: maintainerd-fossa-poller
+    spec:
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app: maintainerd
+            namespaces:
+            - maintainerd
+            topologyKey: kubernetes.io/hostname
+      imagePullSecrets:
+      - name: ghcr-secret
+      serviceAccountName: maintainer-sync
+      terminationGracePeriodSeconds: 30
+      containers:
+      - name: fossa-poller
+        image: ghcr.io/robertkielty/maintainerd-fossa-poller:latest
+        imagePullPolicy: Always
+        args:
+        - -interval=5m
+        envFrom:
+        - secretRef:
+            name: maintainerd-db-env
+        - secretRef:
+            name: maintainerd-server-env
+        resources: {}

--- a/deploy/manifests/maintainerd-invite-team-assignment-job.yaml
+++ b/deploy/manifests/maintainerd-invite-team-assignment-job.yaml
@@ -1,0 +1,57 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: maintainerd-invite-team-assignment-migration
+  namespace: maintainerd
+data:
+  2026_03_06_invite_team_assignment.sql: |
+    BEGIN;
+
+    ALTER TABLE service_invitations
+      ADD COLUMN IF NOT EXISTS team_assignment_status TEXT;
+
+    ALTER TABLE service_invitations
+      ADD COLUMN IF NOT EXISTS team_add_attempts INTEGER NOT NULL DEFAULT 0;
+
+    ALTER TABLE service_invitations
+      ADD COLUMN IF NOT EXISTS next_team_add_at TIMESTAMPTZ;
+
+    CREATE INDEX IF NOT EXISTS idx_service_invitations_team_assignment_status
+      ON service_invitations (team_assignment_status);
+
+    CREATE INDEX IF NOT EXISTS idx_service_invitations_next_team_add_at
+      ON service_invitations (next_team_add_at);
+
+    COMMIT;
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: maintainerd-invite-team-assignment-migration
+  namespace: maintainerd
+spec:
+  backoffLimit: 0
+  ttlSecondsAfterFinished: 1800
+  template:
+    spec:
+      restartPolicy: Never
+      serviceAccountName: maintainer-sync
+      containers:
+      - name: migrate-invite-team-assignment
+        image: postgres:16
+        imagePullPolicy: IfNotPresent
+        command:
+        - sh
+        - -c
+        - psql "$MD_DB_DSN" -f /migrations/2026_03_06_invite_team_assignment.sql
+        envFrom:
+        - secretRef:
+            name: maintainerd-db-env
+        volumeMounts:
+        - name: migration-sql
+          mountPath: /migrations
+          readOnly: true
+      volumes:
+      - name: migration-sql
+        configMap:
+          name: maintainerd-invite-team-assignment-migration


### PR DESCRIPTION
Fixes #101 

  The FOSSA poller process is intentionally long-running: it performs an
  initial poll, then continues polling on a fixed interval. Running that
  binary under a CronJob causes the first Job to remain active indefinitely,
  and with concurrencyPolicy=Forbid that blocks all future schedules.

  This change

  replaces the CronJob-based deployment path with a singleton
  Deployment that matches the poller’s actual runtime behavior. It uses a
  Recreate strategy so image updates do not briefly run two pollers in parallel.

  updates the Makefile to:
  - add a deployment-backed fossa-poller deploy target
  - retire the legacy CronJob and any surviving poller Jobs during rollout
  - point fossa-poller-image-set at the Deployment and wait for rollout
  - keep the old fossa-poller-cronjob target as a deprecated alias

  Adds a dedicated Kubernetes Deployment manifest for maintainerd-fossa-poller
  with the existing secrets, service account, affinity, and explicit polling
  interval configuration.