### PR TITLE
Cache dotproject maintainer yaml files in db

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,8 +2,12 @@
 This document gives agents instructions and tips for working in this repository. It applies to the entire repo.
 
 ## Purpose & Overview
-- `maintainer-d` is a Go service with a SQLite-backed data layer that processes GitHub webhooks and onboards projects to services (e.g., FOSSA).
+- `maintainer-d` is a Go service with a Postgres-backed data layer that processes GitHub webhooks and onboards projects to services (e.g., FOSSA).
 - Deployment uses plain Kubernetes manifests under `deploy/manifests` (production only).
+
+## Database Constraint
+- Treat this repository as Postgres-only for production changes and new operational code.
+- Do not add new SQLite-specific behavior, fallbacks, or documentation for new work unless the user explicitly asks for it.
 
 ## Deploy Rules
 - Apply manifests in `deploy/manifests` with `kubectl -n maintainerd apply -f deploy/manifests`.

--- a/cmd/dot-project-sync/main.go
+++ b/cmd/dot-project-sync/main.go
@@ -19,16 +19,28 @@ import (
 	"gorm.io/gorm"
 )
 
-const defaultDBPath = "/data/maintainers.db"
+type postSyncMetrics struct {
+	DBSizeBytes              int64
+	DotProjectSyncStateBytes int64
+	CachedFiles              int64
+	MaintainersBodyBytes     int64
+	AvgMaintainersBodyBytes  int64
+	MaxMaintainersBodyBytes  int64
+	ProjectsTotal            int64
+	ReposFound               int64
+	CachedBodies             int64
+}
 
 func main() {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer cancel()
 
-	dbDriver := envOr("MD_DB_DRIVER", "sqlite")
+	dbDriver := envOr("MD_DB_DRIVER", "postgres")
+	if dbDriver != "postgres" {
+		log.Fatalf("dot-project-sync requires MD_DB_DRIVER=postgres, got %q", dbDriver)
+	}
 	dbDSN := envOr("MD_DB_DSN", "")
-	dbPath := envOr("MD_DB_PATH", defaultDBPath)
-	if dbDriver == "postgres" && dbDSN == "" {
+	if dbDSN == "" {
 		log.Fatal("MD_DB_DSN is required when MD_DB_DRIVER=postgres")
 	}
 
@@ -37,12 +49,7 @@ func main() {
 		log.Fatal("GITHUB_API_TOKEN is required")
 	}
 
-	dsn := dbPath
-	if dbDriver == "postgres" {
-		dsn = dbDSN
-	}
-
-	dbConn, err := db.OpenGorm(dbDriver, dsn, &gorm.Config{})
+	dbConn, err := db.OpenGorm(dbDriver, dbDSN, &gorm.Config{})
 	if err != nil {
 		log.Fatalf("failed to open DB: %v", err)
 	}
@@ -64,8 +71,13 @@ func main() {
 		log.Fatalf("dot-project sync failed: %v", err)
 	}
 
+	metrics, metricsErr := collectPostSyncMetrics(ctx, store)
+	if metricsErr != nil {
+		log.Printf("dot-project sync post-sync metrics failed: %v", metricsErr)
+	}
+
 	logger := zap.NewNop().Sugar()
-	if err := store.LogAuditEvent(logger, buildAuditEvent(summary)); err != nil {
+	if err := store.LogAuditEvent(logger, buildAuditEvent(summary, metrics, metricsErr)); err != nil {
 		log.Printf("dot-project sync audit log failed: %v", err)
 	}
 
@@ -94,7 +106,73 @@ func envOr(key, fallback string) string {
 	return fallback
 }
 
-func buildAuditEvent(summary dotproject.SyncSummary) model.AuditLog {
+func collectPostSyncMetrics(ctx context.Context, store *db.SQLStore) (*postSyncMetrics, error) {
+	if store == nil || store.DB() == nil {
+		return nil, fmt.Errorf("sql store is not initialized")
+	}
+	if store.DB().Name() != "postgres" {
+		return nil, fmt.Errorf("dot-project-sync post-sync metrics require postgres, got %q", store.DB().Name())
+	}
+
+	metrics := &postSyncMetrics{}
+
+	sizeRow := struct {
+		DBSizeBytes              int64
+		DotProjectSyncStateBytes int64
+	}{}
+	if err := store.DB().WithContext(ctx).Raw(`
+		select
+			pg_database_size(current_database()) as db_size_bytes,
+			pg_total_relation_size('dot_project_sync_states') as dot_project_sync_state_bytes
+	`).Scan(&sizeRow).Error; err != nil {
+		return metrics, err
+	}
+	metrics.DBSizeBytes = sizeRow.DBSizeBytes
+	metrics.DotProjectSyncStateBytes = sizeRow.DotProjectSyncStateBytes
+
+	bodyRow := struct {
+		CachedFiles             int64
+		MaintainersBodyBytes    int64
+		AvgMaintainersBodyBytes int64
+		MaxMaintainersBodyBytes int64
+	}{}
+	if err := store.DB().WithContext(ctx).Raw(`
+		select
+			count(*) filter (where maintainers_file_body is not null) as cached_files,
+			coalesce(sum(pg_column_size(maintainers_file_body)), 0) as maintainers_body_bytes,
+			coalesce(avg(pg_column_size(maintainers_file_body))::bigint, 0) as avg_maintainers_body_bytes,
+			coalesce(max(pg_column_size(maintainers_file_body)), 0) as max_maintainers_body_bytes
+		from dot_project_sync_states
+	`).Scan(&bodyRow).Error; err != nil {
+		return metrics, err
+	}
+	metrics.CachedFiles = bodyRow.CachedFiles
+	metrics.MaintainersBodyBytes = bodyRow.MaintainersBodyBytes
+	metrics.AvgMaintainersBodyBytes = bodyRow.AvgMaintainersBodyBytes
+	metrics.MaxMaintainersBodyBytes = bodyRow.MaxMaintainersBodyBytes
+
+	coverageRow := struct {
+		ProjectsTotal int64
+		ReposFound    int64
+		CachedBodies  int64
+	}{}
+	if err := store.DB().WithContext(ctx).Raw(`
+		select
+			count(*) as projects_total,
+			count(*) filter (where repo_exists) as repos_found,
+			count(*) filter (where maintainers_file_body is not null) as cached_bodies
+		from dot_project_sync_states
+	`).Scan(&coverageRow).Error; err != nil {
+		return metrics, err
+	}
+	metrics.ProjectsTotal = coverageRow.ProjectsTotal
+	metrics.ReposFound = coverageRow.ReposFound
+	metrics.CachedBodies = coverageRow.CachedBodies
+
+	return metrics, nil
+}
+
+func buildAuditEvent(summary dotproject.SyncSummary, metrics *postSyncMetrics, metricsErr error) model.AuditLog {
 	metadata := map[string]any{
 		"loaded":                 summary.Loaded,
 		"scanned":                summary.Total,
@@ -112,6 +190,20 @@ func buildAuditEvent(summary dotproject.SyncSummary) model.AuditLog {
 	}
 	if len(summary.ErrorSummaries) > 0 {
 		metadata["errors"] = summary.ErrorSummaries
+	}
+	if metrics != nil {
+		metadata["db_size_bytes"] = metrics.DBSizeBytes
+		metadata["dot_project_sync_state_bytes"] = metrics.DotProjectSyncStateBytes
+		metadata["cached_files"] = metrics.CachedFiles
+		metadata["maintainers_body_bytes"] = metrics.MaintainersBodyBytes
+		metadata["avg_maintainers_body_bytes"] = metrics.AvgMaintainersBodyBytes
+		metadata["max_maintainers_body_bytes"] = metrics.MaxMaintainersBodyBytes
+		metadata["projects_total"] = metrics.ProjectsTotal
+		metadata["repos_found"] = metrics.ReposFound
+		metadata["cached_bodies"] = metrics.CachedBodies
+	}
+	if metricsErr != nil {
+		metadata["db_metrics_error"] = strings.TrimSpace(metricsErr.Error())
 	}
 	body, err := json.MarshalIndent(metadata, "", "  ")
 	if err != nil {

--- a/cmd/dot-project-sync/main_test.go
+++ b/cmd/dot-project-sync/main_test.go
@@ -28,7 +28,17 @@ func TestBuildAuditEvent(t *testing.T) {
 		Partial:             3,
 		Adopted:             1,
 		ErrorSummaries:      []string{"github rate limit exceeded", "boom"},
-	})
+	}, &postSyncMetrics{
+		DBSizeBytes:              14680064,
+		DotProjectSyncStateBytes: 172032,
+		CachedFiles:              35,
+		MaintainersBodyBytes:     17408,
+		AvgMaintainersBodyBytes:  497,
+		MaxMaintainersBodyBytes:  1024,
+		ProjectsTotal:            35,
+		ReposFound:               35,
+		CachedBodies:             35,
+	}, nil)
 
 	assert.Equal(t, "DOT_PROJECT_SYNC_RUN", event.Action)
 	assert.Contains(t, event.Message, "scanned=20")
@@ -41,6 +51,15 @@ func TestBuildAuditEvent(t *testing.T) {
 	assert.Equal(t, float64(5), metadata["skipped"])
 	assert.Equal(t, float64(2), metadata["github_error_count"])
 	assert.Equal(t, float64(1), metadata["rate_limit_error_count"])
+	assert.Equal(t, float64(14680064), metadata["db_size_bytes"])
+	assert.Equal(t, float64(172032), metadata["dot_project_sync_state_bytes"])
+	assert.Equal(t, float64(35), metadata["cached_files"])
+	assert.Equal(t, float64(17408), metadata["maintainers_body_bytes"])
+	assert.Equal(t, float64(497), metadata["avg_maintainers_body_bytes"])
+	assert.Equal(t, float64(1024), metadata["max_maintainers_body_bytes"])
+	assert.Equal(t, float64(35), metadata["projects_total"])
+	assert.Equal(t, float64(35), metadata["repos_found"])
+	assert.Equal(t, float64(35), metadata["cached_bodies"])
 	errorsValue, ok := metadata["errors"].([]any)
 	require.True(t, ok)
 	assert.Len(t, errorsValue, 2)

--- a/cmd/web-bff-seed/main.go
+++ b/cmd/web-bff-seed/main.go
@@ -223,25 +223,33 @@ func main() {
 		projectMap[projects[i].Name] = &projects[i]
 	}
 	atlasSyncState := model.DotProjectSyncState{
-		ProjectID:                projectMap["Project Atlas"].ID,
-		RepoExists:               true,
-		ProjectFileExists:        true,
-		MaintainersFileExists:    true,
-		SecurityFileExists:       true,
-		ContributingFileExists:   true,
-		GovernanceFileExists:     true,
-		DefaultBranch:            "main",
-		MaintainersFilename:      "MAINTAINERS.yaml",
-		SchemaVersion:            "1.0.0",
-		ImporterVersion:          "seed",
-		LastCheckedAt:            atlasSyncedAt,
-		ProjectFileETag:          "seed-project",
-		MaintainersFileETag:      "seed-maintainers",
-		SecurityFileETag:         "seed-security",
-		ContributingFileETag:     "seed-contributing",
-		GovernanceFileETag:       "seed-governance",
-		ProjectFileBodyHash:      "seed-project-hash",
-		MaintainersFileBodyHash:  "seed-maintainers-hash",
+		ProjectID:               projectMap["Project Atlas"].ID,
+		RepoExists:              true,
+		ProjectFileExists:       true,
+		MaintainersFileExists:   true,
+		SecurityFileExists:      true,
+		ContributingFileExists:  true,
+		GovernanceFileExists:    true,
+		DefaultBranch:           "main",
+		MaintainersFilename:     "MAINTAINERS.yaml",
+		SchemaVersion:           "1.0.0",
+		ImporterVersion:         "seed",
+		LastCheckedAt:           atlasSyncedAt,
+		ProjectFileETag:         "seed-project",
+		MaintainersFileETag:     "seed-maintainers",
+		SecurityFileETag:        "seed-security",
+		ContributingFileETag:    "seed-contributing",
+		GovernanceFileETag:      "seed-governance",
+		ProjectFileBodyHash:     "seed-project-hash",
+		MaintainersFileBodyHash: "seed-maintainers-hash",
+		MaintainersFileBody: strPtr(`maintainers:
+  - teams:
+      - name: project-maintainers
+        members:
+          - antonio-example
+          - renee-sample
+          - alex-example
+`),
 		SecurityFileBodyHash:     "seed-security-hash",
 		ContributingFileBodyHash: "seed-contributing-hash",
 		GovernanceFileBodyHash:   "seed-governance-hash",

--- a/cmd/web-bff/main.go
+++ b/cmd/web-bff/main.go
@@ -678,6 +678,7 @@ type projectDetailResponse struct {
 	DotProjectLastSyncedAt    *time.Time                     `json:"dotProjectLastSyncedAt,omitempty"`
 	DotProjectAdoptionStatus  string                         `json:"dotProjectAdoptionStatus,omitempty"`
 	DotProjectSyncState       *dotProjectSyncStateResponse   `json:"dotProjectSyncState,omitempty"`
+	DotProjectMaintainerCache *dotProjectMaintainerCacheBody `json:"dotProjectMaintainerCache,omitempty"`
 	RefStatus                 maintainerRefStatus            `json:"maintainerRefStatus"`
 	LegacyMaintainerRefBody   string                         `json:"legacyMaintainerRefBody,omitempty"`
 	RefOnlyGitHub             []string                       `json:"refOnlyGitHub"`
@@ -711,6 +712,14 @@ type dotProjectSyncStateResponse struct {
 	LastCheckedAt          *time.Time `json:"lastCheckedAt,omitempty"`
 	SyncError              string     `json:"syncError,omitempty"`
 	ParseError             string     `json:"parseError,omitempty"`
+}
+
+type dotProjectMaintainerCacheBody struct {
+	Filename      string     `json:"filename,omitempty"`
+	ETag          string     `json:"etag,omitempty"`
+	BodyHash      string     `json:"bodyHash,omitempty"`
+	Body          string     `json:"body,omitempty"`
+	LastCheckedAt *time.Time `json:"lastCheckedAt,omitempty"`
 }
 
 func (s *server) handleProjects(w http.ResponseWriter, r *http.Request) {
@@ -1412,6 +1421,18 @@ func (s *server) handleProject(w http.ResponseWriter, r *http.Request) {
 			syncState.ParseError = strings.TrimSpace(*dotProjectSyncState.ParseError)
 		}
 		response.DotProjectSyncState = syncState
+		if dotProjectSyncState.MaintainersFileBody != nil || dotProjectSyncState.MaintainersFilename != "" || dotProjectSyncState.MaintainersFileETag != "" || dotProjectSyncState.MaintainersFileBodyHash != "" {
+			maintainerCache := &dotProjectMaintainerCacheBody{
+				Filename:      strings.TrimSpace(dotProjectSyncState.MaintainersFilename),
+				ETag:          strings.TrimSpace(dotProjectSyncState.MaintainersFileETag),
+				BodyHash:      strings.TrimSpace(dotProjectSyncState.MaintainersFileBodyHash),
+				LastCheckedAt: dotProjectSyncState.LastCheckedAt,
+			}
+			if dotProjectSyncState.MaintainersFileBody != nil {
+				maintainerCache.Body = *dotProjectSyncState.MaintainersFileBody
+			}
+			response.DotProjectMaintainerCache = maintainerCache
+		}
 	}
 	if project.OnboardingIssue != nil {
 		onboardingIssue := strings.TrimSpace(*project.OnboardingIssue)

--- a/cmd/web-bff/main_test.go
+++ b/cmd/web-bff/main_test.go
@@ -282,6 +282,76 @@ func TestMaintainerCanAccessAllProjectsAndMaintainers(t *testing.T) {
 	})
 }
 
+func TestProjectDetailIncludesDotProjectMaintainerCache(t *testing.T) {
+	dbConn := setupPostgresTestDB(t)
+	store := db.NewSQLStore(dbConn)
+	now := time.Now().UTC().Truncate(time.Second)
+
+	staff := model.StaffMember{
+		Name:          "Staff Tester",
+		GitHubAccount: "staff-tester",
+		Email:         "staff@example.org",
+	}
+	require.NoError(t, dbConn.Create(&staff).Error)
+
+	project := model.Project{
+		Name:                    "Project Cache",
+		Maturity:                model.Graduated,
+		GitHubOrg:               "project-cache",
+		DotProjectRepoRef:       "https://github.com/project-cache/.project",
+		DotProjectMaintainerRef: "https://github.com/project-cache/.project/blob/main/Maintainers.YAML",
+	}
+	require.NoError(t, dbConn.Create(&project).Error)
+
+	body := "maintainers:\n  - teams:\n      - name: project-maintainers\n        members:\n          - alice-example\n"
+	syncState := model.DotProjectSyncState{
+		ProjectID:               project.ID,
+		RepoExists:              true,
+		MaintainersFileExists:   true,
+		MaintainersFilename:     "Maintainers.YAML",
+		MaintainersFileETag:     "\"maintainers-etag\"",
+		MaintainersFileBodyHash: "abc123def456",
+		MaintainersFileBody:     &body,
+		LastCheckedAt:           &now,
+	}
+	require.NoError(t, dbConn.Create(&syncState).Error)
+
+	s := &server{
+		store:      store,
+		sessions:   newSessionStore(log.New(io.Discard, "", 0)),
+		cookieName: defaultSessionCookieName,
+		logger:     log.New(io.Discard, "", 0),
+	}
+
+	staffSessionID := "staff-session"
+	s.sessions.Set(session{
+		ID:        staffSessionID,
+		Login:     staff.GitHubAccount,
+		Role:      roleStaff,
+		CreatedAt: now,
+		ExpiresAt: now.Add(time.Hour),
+	})
+
+	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/projects/%d", project.ID), nil)
+	req.AddCookie(&http.Cookie{Name: s.cookieName, Value: staffSessionID})
+	rec := httptest.NewRecorder()
+	handler := s.requireSession(http.HandlerFunc(s.handleProject))
+	handler.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	var response projectDetailResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&response))
+	require.NotNil(t, response.DotProjectSyncState)
+	assert.Equal(t, "Maintainers.YAML", response.DotProjectSyncState.MaintainersFilename)
+	require.NotNil(t, response.DotProjectMaintainerCache)
+	assert.Equal(t, "Maintainers.YAML", response.DotProjectMaintainerCache.Filename)
+	assert.Equal(t, "\"maintainers-etag\"", response.DotProjectMaintainerCache.ETag)
+	assert.Equal(t, "abc123def456", response.DotProjectMaintainerCache.BodyHash)
+	assert.Equal(t, body, response.DotProjectMaintainerCache.Body)
+	require.NotNil(t, response.DotProjectMaintainerCache.LastCheckedAt)
+	assert.True(t, response.DotProjectMaintainerCache.LastCheckedAt.Equal(now))
+}
+
 func TestMaintainerServiceAssociationsForStaff(t *testing.T) {
 	dbConn := setupPostgresTestDB(t)
 	store := db.NewSQLStore(dbConn)

--- a/db/store_impl_test.go
+++ b/db/store_impl_test.go
@@ -183,6 +183,7 @@ func TestDotProjectSyncState(t *testing.T) {
 			MaintainersFileETag:     "\"maintainers-etag\"",
 			ProjectFileBodyHash:     "abc123",
 			MaintainersFileBodyHash: "def456",
+			MaintainersFileBody:     strPtr("maintainers:\n  - teams: []\n"),
 			SecurityFileBodyHash:    "ghi789",
 			GovernanceFileBodyHash:  "jkl012",
 			LastCheckedAt:           &now,
@@ -202,6 +203,8 @@ func TestDotProjectSyncState(t *testing.T) {
 		assert.Equal(t, "MAINTAINERS.yaml", reloaded.MaintainersFilename)
 		assert.Equal(t, "1.0.0", reloaded.SchemaVersion)
 		assert.Equal(t, "dot-project-sync/v1", reloaded.ImporterVersion)
+		require.NotNil(t, reloaded.MaintainersFileBody)
+		assert.Equal(t, "maintainers:\n  - teams: []\n", *reloaded.MaintainersFileBody)
 		require.NotNil(t, reloaded.LastCheckedAt)
 		assert.True(t, reloaded.LastCheckedAt.Equal(now))
 		require.NotNil(t, reloaded.SyncError)

--- a/dot-project.md
+++ b/dot-project.md
@@ -499,6 +499,7 @@ What changed:
   - summarized run errors
 - Added a run-level audit-log entry with action `DOT_PROJECT_SYNC_RUN`.
 - Included GitHub/rate-limit failures in the audit metadata summary.
+- Prefixed each sync error in the audit metadata with the project name so the log can be traced back to the failing project directly.
 - Added post-sync Postgres size and coverage metrics to the same audit metadata summary:
   - total database size
   - `dot_project_sync_states` total relation size

--- a/dot-project.md
+++ b/dot-project.md
@@ -499,12 +499,19 @@ What changed:
   - summarized run errors
 - Added a run-level audit-log entry with action `DOT_PROJECT_SYNC_RUN`.
 - Included GitHub/rate-limit failures in the audit metadata summary.
+- Added post-sync Postgres size and coverage metrics to the same audit metadata summary:
+  - total database size
+  - `dot_project_sync_states` total relation size
+  - cached maintainer-body count
+  - cached maintainer-body bytes, average bytes, and max bytes
+  - sync-state coverage counts for total rows, repos found, and cached bodies
 
 Operational details:
 
 - The older generic `maintainer-sync` CronJob and image remain unchanged.
 - The dot-project sync deployment is intentionally separate so it can evolve independently from the Kubernetes resource sync job.
 - The run summary is now visible through the existing audit log view instead of only through pod logs.
+- The post-sync DB size metrics are collected directly from the production Postgres database used by maintainer-d.
 
 Verification:
 
@@ -517,6 +524,39 @@ Verification:
 - Accept any filename casing variant, but keep the file plural: `maintainers.yaml`.
 - Prefer cached file bodies in the web UI instead of fetching GitHub live on page load.
 - Expose the cached maintainer-file body and related metadata through the project detail API.
+
+#### Implementation report
+
+Commit B is complete.
+
+What changed:
+
+- Extended `dot_project_sync_states` to persist the raw cached maintainer-file body alongside the existing maintainer-file hash and ETag.
+- Updated dot-project discovery to accept any root-level filename casing variant of `maintainers.yaml` while preserving the actual filename found.
+- Persisted the cached maintainer-file body during `dot-project-sync`.
+- Exposed the cached maintainer-file payload through the project detail API, including:
+  - filename
+  - ETag
+  - body hash
+  - cached body
+  - last checked time
+- Updated the dot-project roll call UI to render the cached maintainer file from persisted state instead of relying on a live GitHub fetch.
+- Seeded cached maintainer-file body data for the web test fixture and added focused tests for:
+  - mixed-case maintainer filename discovery
+  - persisted maintainer-file body storage
+  - project detail API exposure of cached maintainer-file metadata
+
+Operational details:
+
+- The new cache is persisted only for the dot-project maintainer file, not for the other recommended `.project` files.
+- The sync path remains authoritative: the web UI renders the cached maintainer body captured by the background sync job.
+- Filename matching is case-insensitive for discovery, but the implementation still treats the plural filename `maintainers.yaml` as the supported contract.
+
+Verification:
+
+- `GOCACHE=/tmp/go-build go test ./dotproject ./db ./cmd/web-bff ./cmd/dot-project-sync`
+- `npm --prefix web run lint`
+- `npm --prefix web run typecheck`
 
 Operational goals:
 

--- a/dotproject/discovery.go
+++ b/dotproject/discovery.go
@@ -18,6 +18,7 @@ const (
 	DefaultRepoName        = ".project"
 	ImporterVersion        = "dot-project-discovery/v1"
 	SupportedSchemaVersion = "1.0.0"
+	maintainersFileName    = "maintainers.yaml"
 )
 
 var (
@@ -38,6 +39,7 @@ const (
 type RepositoryClient interface {
 	GetDefaultBranch(ctx context.Context, owner, repo string) (string, error)
 	GetFile(ctx context.Context, owner, repo, ref, path string) (*FetchedFile, error)
+	ListFiles(ctx context.Context, owner, repo, ref, path string) ([]ListedFile, error)
 }
 
 type FetchedFile struct {
@@ -46,6 +48,10 @@ type FetchedFile struct {
 	RawURL  string
 	ETag    string
 	Body    string
+}
+
+type ListedFile struct {
+	Path string
 }
 
 type FileDiscovery struct {
@@ -125,7 +131,7 @@ func (d *Discoverer) Discover(ctx context.Context, project model.Project) (*Disc
 			parseProjectYAML(result.ProjectFile)
 	}
 
-	maintainersFile, err := d.fetchFirstOptionalFile(ctx, org, defaultBranch, "MAINTAINERS.yaml", "maintainers.yaml")
+	maintainersFile, err := d.fetchMaintainersFile(ctx, org, defaultBranch)
 	if err != nil {
 		return nil, err
 	}
@@ -159,17 +165,29 @@ func (d *Discoverer) Discover(ctx context.Context, project model.Project) (*Disc
 	return result, nil
 }
 
-func (d *Discoverer) fetchFirstOptionalFile(ctx context.Context, org, ref string, paths ...string) (FileDiscovery, error) {
-	for _, path := range paths {
-		file, err := d.fetchOptionalFile(ctx, org, ref, path)
-		if err != nil {
-			return FileDiscovery{}, err
-		}
-		if file.Exists {
-			return file, nil
+func (d *Discoverer) fetchMaintainersFile(ctx context.Context, org, ref string) (FileDiscovery, error) {
+	path, ok, err := d.findMaintainersPath(ctx, org, ref)
+	if err != nil {
+		return FileDiscovery{}, err
+	}
+	if !ok {
+		return FileDiscovery{}, nil
+	}
+	return d.fetchOptionalFile(ctx, org, ref, path)
+}
+
+func (d *Discoverer) findMaintainersPath(ctx context.Context, org, ref string) (string, bool, error) {
+	files, err := d.Client.ListFiles(ctx, org, DefaultRepoName, ref, "")
+	if err != nil {
+		return "", false, fmt.Errorf("list %s/%s root: %w", org, DefaultRepoName, err)
+	}
+	for _, file := range files {
+		path := strings.TrimSpace(file.Path)
+		if strings.EqualFold(path, maintainersFileName) {
+			return path, true, nil
 		}
 	}
-	return FileDiscovery{}, nil
+	return "", false, nil
 }
 
 func (d *Discoverer) fetchOptionalFile(ctx context.Context, org, ref, path string) (FileDiscovery, error) {
@@ -325,6 +343,27 @@ func (c *GitHubRepositoryClient) GetFile(ctx context.Context, owner, repo, ref, 
 		fetched.RawURL = rawRef(owner, ref, path)
 	}
 	return fetched, nil
+}
+
+func (c *GitHubRepositoryClient) ListFiles(ctx context.Context, owner, repo, ref, path string) ([]ListedFile, error) {
+	if c == nil || c.Client == nil {
+		return nil, errors.New("github client is required")
+	}
+	_, dir, resp, err := c.Client.Repositories.GetContents(ctx, owner, repo, path, &github.RepositoryContentGetOptions{Ref: ref})
+	if err != nil {
+		if isGitHubNotFound(resp, err) {
+			return nil, ErrDotProjectFileNotFound
+		}
+		return nil, err
+	}
+	files := make([]ListedFile, 0, len(dir))
+	for _, entry := range dir {
+		if entry == nil {
+			continue
+		}
+		files = append(files, ListedFile{Path: strings.TrimSpace(entry.GetPath())})
+	}
+	return files, nil
 }
 
 func isGitHubNotFound(resp *github.Response, err error) bool {

--- a/dotproject/discovery_test.go
+++ b/dotproject/discovery_test.go
@@ -3,6 +3,7 @@ package dotproject
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"maintainerd/model"
@@ -32,6 +33,30 @@ func (f *fakeRepositoryClient) GetFile(_ context.Context, owner, repo, ref, path
 		return nil, ErrDotProjectFileNotFound
 	}
 	return file, nil
+}
+
+func (f *fakeRepositoryClient) ListFiles(_ context.Context, owner, repo, ref, path string) ([]ListedFile, error) {
+	if strings.TrimSpace(path) != "" {
+		return nil, ErrDotProjectFileNotFound
+	}
+	prefix := fmt.Sprintf("%s/%s@%s:", owner, repo, ref)
+	seen := make(map[string]struct{})
+	files := make([]ListedFile, 0, len(f.files))
+	for key := range f.files {
+		if !strings.HasPrefix(key, prefix) {
+			continue
+		}
+		relative := strings.TrimPrefix(key, prefix)
+		if relative == "" || strings.Contains(relative, "/") {
+			continue
+		}
+		if _, ok := seen[relative]; ok {
+			continue
+		}
+		seen[relative] = struct{}{}
+		files = append(files, ListedFile{Path: relative})
+	}
+	return files, nil
 }
 
 func TestDiscoverRepoMissing(t *testing.T) {
@@ -141,6 +166,41 @@ func TestDiscoverUnsupportedSchemaVersion(t *testing.T) {
 	assert.Equal(t, ParseStatusUnsupportedSchema, result.ProjectParseStatus)
 	assert.Contains(t, result.ProjectParseError, "unsupported schema version")
 	assert.Equal(t, "MAINTAINERS.yaml", result.MaintainersFilename)
+	require.NotNil(t, result.MaintainerCount)
+	assert.Equal(t, uint(1), *result.MaintainerCount)
+}
+
+func TestDiscoverMixedCaseMaintainersFile(t *testing.T) {
+	t.Parallel()
+
+	client := &fakeRepositoryClient{
+		defaultBranches: map[string]string{
+			"example-org/.project": "main",
+		},
+		files: map[string]*FetchedFile{
+			"example-org/.project@main:project.yaml": {
+				Path: "project.yaml",
+				Body: "schema_version: \"1.0.0\"\nname: Example\n",
+			},
+			"example-org/.project@main:Maintainers.YAML": {
+				Path: "Maintainers.YAML",
+				Body: `maintainers:
+  - teams:
+      - name: project-maintainers
+        members:
+          - alice
+`,
+			},
+		},
+	}
+
+	discoverer := &Discoverer{Client: client}
+	result, err := discoverer.Discover(context.Background(), model.Project{GitHubOrg: "example-org"})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.True(t, result.MaintainersFile.Exists)
+	assert.Equal(t, "Maintainers.YAML", result.MaintainersFilename)
 	require.NotNil(t, result.MaintainerCount)
 	assert.Equal(t, uint(1), *result.MaintainerCount)
 }

--- a/dotproject/sync.go
+++ b/dotproject/sync.go
@@ -208,6 +208,10 @@ func buildSyncState(projectID uint, now time.Time, result *DiscoveryResult) *mod
 	state.GovernanceFileETag = strings.TrimSpace(result.GovernanceFile.ETag)
 	state.ProjectFileBodyHash = strings.TrimSpace(result.ProjectFile.BodyHash)
 	state.MaintainersFileBodyHash = strings.TrimSpace(result.MaintainersFile.BodyHash)
+	if result.MaintainersFile.Exists {
+		body := result.MaintainersFile.Body
+		state.MaintainersFileBody = &body
+	}
 	state.SecurityFileBodyHash = strings.TrimSpace(result.SecurityFile.BodyHash)
 	state.ContributingFileBodyHash = strings.TrimSpace(result.ContributingFile.BodyHash)
 	state.GovernanceFileBodyHash = strings.TrimSpace(result.GovernanceFile.BodyHash)

--- a/dotproject/sync.go
+++ b/dotproject/sync.go
@@ -78,7 +78,7 @@ func (s *Syncer) SyncAll(ctx context.Context) (SyncSummary, error) {
 		status, err := s.SyncProject(ctx, project)
 		if err != nil {
 			summary.Errored++
-			summary.recordError(err)
+			summary.recordError(projectLabel(project), err)
 			continue
 		}
 		summary.Synced++
@@ -96,7 +96,7 @@ func (s *Syncer) SyncAll(ctx context.Context) (SyncSummary, error) {
 	return summary, nil
 }
 
-func (s *SyncSummary) recordError(err error) {
+func (s *SyncSummary) recordError(projectLabel string, err error) {
 	if err == nil {
 		return
 	}
@@ -110,6 +110,11 @@ func (s *SyncSummary) recordError(err error) {
 	if message == "" {
 		return
 	}
+	label := strings.TrimSpace(projectLabel)
+	if label == "" {
+		label = "unknown project"
+	}
+	message = fmt.Sprintf("%s: %s", label, message)
 	for _, existing := range s.ErrorSummaries {
 		if existing == message {
 			return
@@ -119,6 +124,13 @@ func (s *SyncSummary) recordError(err error) {
 		return
 	}
 	s.ErrorSummaries = append(s.ErrorSummaries, message)
+}
+
+func projectLabel(project model.Project) string {
+	if name := strings.TrimSpace(project.Name); name != "" {
+		return name
+	}
+	return fmt.Sprintf("project %d", project.ID)
 }
 
 func (s *Syncer) SyncProject(ctx context.Context, project model.Project) (string, error) {

--- a/dotproject/sync_test.go
+++ b/dotproject/sync_test.go
@@ -205,10 +205,10 @@ func TestSyncAllSummarizesStatuses(t *testing.T) {
 	now := time.Date(2026, 5, 9, 10, 11, 12, 0, time.UTC)
 	store := &fakeSyncStore{
 		projects: []model.Project{
-			{Model: gorm.Model{ID: 1}, GitHubOrg: "org-one"},
-			{Model: gorm.Model{ID: 2}, GitHubOrg: "org-two"},
-			{Model: gorm.Model{ID: 3}, GitHubOrg: "org-three"},
-			{Model: gorm.Model{ID: 4}, GitHubOrg: "org-four"},
+			{Model: gorm.Model{ID: 1}, Name: "Project One", GitHubOrg: "org-one"},
+			{Model: gorm.Model{ID: 2}, Name: "Project Two", GitHubOrg: "org-two"},
+			{Model: gorm.Model{ID: 3}, Name: "Project Three", GitHubOrg: "org-three"},
+			{Model: gorm.Model{ID: 4}, Name: "Project Four", GitHubOrg: "org-four"},
 		},
 	}
 	syncer := &Syncer{
@@ -237,6 +237,7 @@ func TestSyncAllSummarizesStatuses(t *testing.T) {
 	assert.Equal(t, 1, summary.Adopted)
 	assert.Equal(t, 0, summary.Partial)
 	assert.Len(t, summary.ErrorSummaries, 1)
+	assert.Contains(t, summary.ErrorSummaries[0], "Project Four")
 	assert.Contains(t, summary.ErrorSummaries[0], "boom")
 }
 

--- a/dotproject/sync_test.go
+++ b/dotproject/sync_test.go
@@ -73,7 +73,7 @@ func TestSyncProjectPersistsAdoptedDiscovery(t *testing.T) {
 					RepoRef:                "https://github.com/example-org/.project",
 					DefaultBranch:          "main",
 					ProjectFile:            FileDiscovery{Exists: true, BlobURL: "https://github.com/example-org/.project/blob/main/project.yaml", ETag: "\"project\"", BodyHash: "hash-project"},
-					MaintainersFile:        FileDiscovery{Exists: true, Path: "MAINTAINERS.yaml", BlobURL: "https://github.com/example-org/.project/blob/main/MAINTAINERS.yaml", ETag: "\"maintainers\"", BodyHash: "hash-maintainers"},
+					MaintainersFile:        FileDiscovery{Exists: true, Path: "MAINTAINERS.yaml", BlobURL: "https://github.com/example-org/.project/blob/main/MAINTAINERS.yaml", ETag: "\"maintainers\"", BodyHash: "hash-maintainers", Body: "maintainers:\n  - teams: []\n"},
 					SecurityFile:           FileDiscovery{Exists: true, BlobURL: "https://github.com/example-org/.project/blob/main/SECURITY.md", ETag: "\"security\"", BodyHash: "hash-security"},
 					ContributingFile:       FileDiscovery{Exists: true, BlobURL: "https://github.com/example-org/.project/blob/main/CONTRIBUTING.md", ETag: "\"contributing\"", BodyHash: "hash-contributing"},
 					GovernanceFile:         FileDiscovery{Exists: true, BlobURL: "https://github.com/example-org/.project/blob/main/GOVERNANCE.md", ETag: "\"governance\"", BodyHash: "hash-governance"},
@@ -112,6 +112,8 @@ func TestSyncProjectPersistsAdoptedDiscovery(t *testing.T) {
 	assert.Equal(t, "MAINTAINERS.yaml", persisted.state.MaintainersFilename)
 	assert.Equal(t, "1.0.0", persisted.state.SchemaVersion)
 	assert.Equal(t, ImporterVersion, persisted.state.ImporterVersion)
+	require.NotNil(t, persisted.state.MaintainersFileBody)
+	assert.Equal(t, "maintainers:\n  - teams: []\n", *persisted.state.MaintainersFileBody)
 	require.NotNil(t, persisted.state.LastCheckedAt)
 	assert.True(t, persisted.state.LastCheckedAt.Equal(now))
 	assert.Nil(t, persisted.state.ParseError)

--- a/model/main.go
+++ b/model/main.go
@@ -129,16 +129,17 @@ type DotProjectSyncState struct {
 	SchemaVersion       string `gorm:"size:64"`
 	ImporterVersion     string `gorm:"size:64"`
 
-	ProjectFileETag          string `gorm:"size:255"`
-	MaintainersFileETag      string `gorm:"size:255"`
-	SecurityFileETag         string `gorm:"size:255"`
-	ContributingFileETag     string `gorm:"size:255"`
-	GovernanceFileETag       string `gorm:"size:255"`
-	ProjectFileBodyHash      string `gorm:"size:128"` // sha256 hex
-	MaintainersFileBodyHash  string `gorm:"size:128"` // sha256 hex
-	SecurityFileBodyHash     string `gorm:"size:128"` // sha256 hex
-	ContributingFileBodyHash string `gorm:"size:128"` // sha256 hex
-	GovernanceFileBodyHash   string `gorm:"size:128"` // sha256 hex
+	ProjectFileETag          string  `gorm:"size:255"`
+	MaintainersFileETag      string  `gorm:"size:255"`
+	SecurityFileETag         string  `gorm:"size:255"`
+	ContributingFileETag     string  `gorm:"size:255"`
+	GovernanceFileETag       string  `gorm:"size:255"`
+	ProjectFileBodyHash      string  `gorm:"size:128"` // sha256 hex
+	MaintainersFileBodyHash  string  `gorm:"size:128"` // sha256 hex
+	MaintainersFileBody      *string `gorm:"type:text"`
+	SecurityFileBodyHash     string  `gorm:"size:128"` // sha256 hex
+	ContributingFileBodyHash string  `gorm:"size:128"` // sha256 hex
+	GovernanceFileBodyHash   string  `gorm:"size:128"` // sha256 hex
 
 	LastCheckedAt *time.Time `gorm:"index"`
 	SyncError     *string    `gorm:"type:text"`

--- a/web/src/app/projects/[id]/ProjectRouteClient.tsx
+++ b/web/src/app/projects/[id]/ProjectRouteClient.tsx
@@ -40,6 +40,14 @@ type DotProjectSyncState = {
   parseError?: string;
 };
 
+type DotProjectMaintainerCache = {
+  filename?: string;
+  etag?: string;
+  bodyHash?: string;
+  body?: string;
+  lastCheckedAt?: string | null;
+};
+
 type ProjectDetail = {
   id: number;
   name: string;
@@ -57,6 +65,7 @@ type ProjectDetail = {
   dotProjectLastSyncedAt?: string | null;
   dotProjectAdoptionStatus?: string;
   dotProjectSyncState?: DotProjectSyncState | null;
+  dotProjectMaintainerCache?: DotProjectMaintainerCache | null;
   maintainerRefStatus: {
     url?: string;
     status: string;
@@ -156,6 +165,11 @@ const projectDataHasChanged = (current: ProjectDetail | null, next: ProjectDetai
     current.dotProjectSyncState?.lastCheckedAt !== next.dotProjectSyncState?.lastCheckedAt ||
     current.dotProjectSyncState?.syncError !== next.dotProjectSyncState?.syncError ||
     current.dotProjectSyncState?.parseError !== next.dotProjectSyncState?.parseError ||
+    current.dotProjectMaintainerCache?.filename !== next.dotProjectMaintainerCache?.filename ||
+    current.dotProjectMaintainerCache?.etag !== next.dotProjectMaintainerCache?.etag ||
+    current.dotProjectMaintainerCache?.bodyHash !== next.dotProjectMaintainerCache?.bodyHash ||
+    current.dotProjectMaintainerCache?.body !== next.dotProjectMaintainerCache?.body ||
+    current.dotProjectMaintainerCache?.lastCheckedAt !== next.dotProjectMaintainerCache?.lastCheckedAt ||
     current.maintainerRefStatus.status !== next.maintainerRefStatus.status ||
     current.maintainerRefStatus.url !== next.maintainerRefStatus.url ||
     current.maintainerRefStatus.checkedAt !== next.maintainerRefStatus.checkedAt ||
@@ -443,6 +457,7 @@ export default function ProjectRouteClient({ children }: ProjectRouteClientProps
                 dotProjectLastSyncedAt={project.dotProjectLastSyncedAt}
                 dotProjectAdoptionStatus={project.dotProjectAdoptionStatus}
                 dotProjectSyncState={project.dotProjectSyncState}
+                dotProjectMaintainerCache={project.dotProjectMaintainerCache}
                 maintainerRefStatus={project.maintainerRefStatus}
                 maintainerRefBody={project.legacyMaintainerRefBody}
                 refOnlyGitHub={project.refOnlyGitHub}

--- a/web/src/components/ProjectReconciliationCard.tsx
+++ b/web/src/components/ProjectReconciliationCard.tsx
@@ -79,6 +79,14 @@ type DotProjectSyncStateSummary = {
   parseError?: string | null;
 };
 
+type DotProjectMaintainerCacheSummary = {
+  filename?: string | null;
+  etag?: string | null;
+  bodyHash?: string | null;
+  body?: string | null;
+  lastCheckedAt?: string | null;
+};
+
 type SortDirection = "asc" | "desc";
 
 type SortState<Key extends string> = {
@@ -129,6 +137,7 @@ type ProjectReconciliationCardProps = {
   dotProjectLastSyncedAt?: string | null;
   dotProjectAdoptionStatus?: string | null;
   dotProjectSyncState?: DotProjectSyncStateSummary | null;
+  dotProjectMaintainerCache?: DotProjectMaintainerCacheSummary | null;
   maintainerRefStatus: {
     url?: string;
     status: string;
@@ -253,6 +262,17 @@ const isYamlRef = (value: string) => /\.(ya?ml)(\?|#|$)/i.test(value);
 const buildStatusBadgeClassName = (stylesMap: Record<string, string>, found: boolean) =>
   `${stylesMap.statusBadge} ${found ? stylesMap.statusOk : stylesMap.statusWarn}`;
 
+const shortenHash = (value?: string | null) => {
+  const trimmed = value?.trim() ?? "";
+  if (trimmed === "") {
+    return "Unavailable";
+  }
+  if (trimmed.length <= 16) {
+    return trimmed;
+  }
+  return `${trimmed.slice(0, 16)}…`;
+};
+
 export default function ProjectReconciliationCard({
   projectId,
   name,
@@ -269,6 +289,7 @@ export default function ProjectReconciliationCard({
   dotProjectLastSyncedAt,
   dotProjectAdoptionStatus,
   dotProjectSyncState,
+  dotProjectMaintainerCache,
   maintainerRefStatus,
   maintainerRefBody,
   refLines,
@@ -308,6 +329,11 @@ export default function ProjectReconciliationCard({
   const dotProjectLastCheckedAt = dotProjectSyncState?.lastCheckedAt || dotProjectLastSyncedAt || null;
   const dotProjectSchema = dotProjectSyncState?.schemaVersion || dotProjectSchemaVersion || "";
   const dotProjectMaintainersFilename = dotProjectSyncState?.maintainersFilename || "MAINTAINERS.yaml";
+  const dotProjectMaintainerCacheBody = dotProjectMaintainerCache?.body?.trim() ?? "";
+  const dotProjectMaintainerCacheFilename =
+    dotProjectMaintainerCache?.filename || dotProjectMaintainersFilename || "maintainers.yaml";
+  const dotProjectMaintainerCacheCheckedAt =
+    dotProjectMaintainerCache?.lastCheckedAt || dotProjectLastCheckedAt || null;
   const dotProjectFiles = [
     {
       label: ".project repo",
@@ -947,6 +973,41 @@ export default function ProjectReconciliationCard({
           </table>
         </div>
       </div>
+      {dotProjectMaintainerCacheBody ? (
+        <div className={styles.tableSection}>
+          <div className={styles.tableHeader}>
+            <h3 className={styles.tableTitle}>Cached maintainer file</h3>
+          </div>
+          <div className={styles.dotProjectSummaryGrid}>
+            <div className={styles.dotProjectSummaryCard}>
+              <span className={styles.detailLabel}>Filename</span>
+              <span className={styles.secondary}>{dotProjectMaintainerCacheFilename}</span>
+            </div>
+            <div className={styles.dotProjectSummaryCard}>
+              <span className={styles.detailLabel}>Cached at</span>
+              <span className={styles.secondary}>{formatDateTime(dotProjectMaintainerCacheCheckedAt)}</span>
+            </div>
+            <div className={styles.dotProjectSummaryCard}>
+              <span className={styles.detailLabel}>ETag</span>
+              <span className={styles.secondary}>{dotProjectMaintainerCache?.etag?.trim() || "Unavailable"}</span>
+            </div>
+            <div className={styles.dotProjectSummaryCard}>
+              <span className={styles.detailLabel}>Body hash</span>
+              <span className={styles.secondary}>{shortenHash(dotProjectMaintainerCache?.bodyHash)}</span>
+            </div>
+          </div>
+          <div className={styles.refYaml}>
+            <SyntaxHighlighter
+              language="yaml"
+              style={atomDark}
+              customStyle={{ margin: 0, background: "transparent" }}
+              codeTagProps={{ style: { fontFamily: "var(--font-geist-mono)" } }}
+            >
+              {dotProjectMaintainerCacheBody}
+            </SyntaxHighlighter>
+          </div>
+        </div>
+      ) : null}
       {dotProjectSyncState?.syncError || dotProjectSyncState?.parseError ? (
         <div className={styles.statusCallout}>
           <div className={styles.statusCalloutTitle}>Recorded sync issues</div>


### PR DESCRIPTION
dotproject sync job now caches the contents of the maintainers.yaml file in the database

**Change notes**

1. Updates AGENTS.MD to remove the reference to sqlite, this has been a Postgres-only application for a long time now. I used sqlite during prototyping and migrated to using a managed Postgres service at the start of this year.
3. sync job audit entry includes a db size report focusing on the file body data storage size. Initial concernes about size of cache were allayed by the report but keeping it in.
5. The sync job error reports now prefixing the name of the project that generated the error during the sync run

