### PR TITLE
ci(web-bdd): declare contents: read + actions: write

### DIFF
--- a/.github/workflows/web-bdd.yml
+++ b/.github/workflows/web-bdd.yml
@@ -4,6 +4,11 @@ on:
   push:
   pull_request:
 
+# actions/cache@v5 saves the Playwright browser cache on miss.
+permissions:
+  contents: read
+  actions: write
+
 jobs:
   web-bdd:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The single workflow here previously inherited the default `GITHUB_TOKEN` scope. `actions/cache@v5` is used for the Playwright browser cache, which saves on miss — so the default token needs `actions: write` for the cache save path. Everything else (postgres-backed Go BDD tests) is read-only.

YAML validated locally.