### PR TITLE
renders formatted maintainers.yaml file

### DIFF
--- a/cmd/web-bff-seed/main.go
+++ b/cmd/web-bff-seed/main.go
@@ -242,7 +242,8 @@ func main() {
 		GovernanceFileETag:      "seed-governance",
 		ProjectFileBodyHash:     "seed-project-hash",
 		MaintainersFileBodyHash: "seed-maintainers-hash",
-		MaintainersFileBody: strPtr(`maintainers:
+		MaintainersFileBody: strPtr(`# Project Atlas dot-project maintainers
+maintainers:
   - teams:
       - name: project-maintainers
         members:

--- a/dot-project.md
+++ b/dot-project.md
@@ -576,6 +576,30 @@ Operational goals:
 - Establish a strong file-viewing experience before adding inline diff and PR behaviors.
 - Preserve enough source fidelity that later edit/PR generation can patch the original file cleanly.
 
+#### Implementation report
+
+Commit C is complete.
+
+What changed:
+
+- Added a dedicated formatted maintainer-file viewer for the dot-project route.
+- Parses the cached YAML with an AST-backed renderer path before deriving team and member structure.
+- Shows a read-only structured team/member summary above the source view.
+- Renders the cached source text with YAML-aware coloring while preserving whitespace and comments.
+- Stopped trimming the cached maintainer-file body before rendering, so source fidelity is retained for later patch/diff work.
+- Added route-level BDD coverage for the formatted cached maintainer-file view.
+
+Operational details:
+
+- The view remains read-only; maintainer-d matching, inline validation, diffing, and PR behavior are left for later commits.
+- The source of truth remains the cached body populated by `dot-project-sync`, not a live GitHub fetch during page render.
+
+Verification:
+
+- `npm --prefix web run lint`
+- `npm --prefix web run typecheck`
+- `GOCACHE=/tmp/go-build go test ./cmd/web-bff-seed`
+
 ### Commit D: Add Inline Maintainer-D Awareness to the Rendered YAML
 
 - Match GitHub handles case-insensitively against active maintainer records in maintainer-d.

--- a/features/web/project_routes.feature
+++ b/features/web/project_routes.feature
@@ -34,3 +34,4 @@ Feature: Project route navigation
     And I open the DOT-PROJECT ROLL CALL route
     Then the dot-project roll call shows the persisted discovery summary
     And the dot-project roll call lists the tracked .project files
+    And the dot-project roll call renders the cached maintainer file as formatted YAML

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -17,7 +17,8 @@
         "rehype-raw": "^7.0.0",
         "rehype-sanitize": "^6.0.0",
         "remark-gfm": "^4.0.1",
-        "sass": "^1.97.1"
+        "sass": "^1.97.1",
+        "yaml": "^2.9.0"
       },
       "devDependencies": {
         "@cucumber/cucumber": "^12.5.0",
@@ -10602,10 +10603,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
-      "dev": true,
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/web/package.json
+++ b/web/package.json
@@ -20,7 +20,8 @@
     "rehype-raw": "^7.0.0",
     "rehype-sanitize": "^6.0.0",
     "remark-gfm": "^4.0.1",
-    "sass": "^1.97.1"
+    "sass": "^1.97.1",
+    "yaml": "^2.9.0"
   },
   "devDependencies": {
     "@cucumber/cucumber": "^12.5.0",

--- a/web/src/components/DotProjectMaintainerFileViewer.tsx
+++ b/web/src/components/DotProjectMaintainerFileViewer.tsx
@@ -1,0 +1,235 @@
+"use client";
+
+import { useMemo } from "react";
+import { isMap, isScalar, isSeq, parseDocument, type Node } from "yaml";
+import styles from "./ProjectReconciliationCard.module.css";
+
+type DotProjectMaintainerFileViewerProps = {
+  source: string;
+  filename: string;
+};
+
+type MaintainerTeam = {
+  name: string;
+  members: string[];
+};
+
+type SourceToken = {
+  text: string;
+  tone?: "comment" | "key" | "punctuation" | "scalar";
+};
+
+const scalarText = (node: unknown): string => {
+  if (!isScalar(node)) {
+    return "";
+  }
+  return String(node.value ?? "").trim();
+};
+
+const mapValue = (node: unknown, key: string): unknown => {
+  if (!isMap(node)) {
+    return undefined;
+  }
+  const pair = node.items.find((item) => scalarText(item.key) === key);
+  return pair?.value;
+};
+
+const scalarSeqValues = (node: unknown): string[] => {
+  if (!isSeq(node)) {
+    return [];
+  }
+  return node.items.map(scalarText).filter(Boolean);
+};
+
+const parseMaintainerTeams = (source: string): { teams: MaintainerTeam[]; errors: string[] } => {
+  const document = parseDocument<Node>(source, { keepSourceTokens: true });
+  const maintainers = mapValue(document.contents, "maintainers");
+  const teams: MaintainerTeam[] = [];
+
+  if (isSeq(maintainers)) {
+    for (const maintainerGroup of maintainers.items) {
+      const groupTeams = mapValue(maintainerGroup, "teams");
+      if (!isSeq(groupTeams)) {
+        continue;
+      }
+      for (const team of groupTeams.items) {
+        const name = scalarText(mapValue(team, "name"));
+        if (!name) {
+          continue;
+        }
+        teams.push({
+          name,
+          members: scalarSeqValues(mapValue(team, "members")),
+        });
+      }
+    }
+  }
+
+  return {
+    teams,
+    errors: document.errors.map((error) => error.message),
+  };
+};
+
+const findCommentStart = (line: string): number => {
+  let quote: "'" | "\"" | null = null;
+
+  for (let index = 0; index < line.length; index += 1) {
+    const char = line[index];
+    const previous = index > 0 ? line[index - 1] : "";
+
+    if (char === "\"" && quote !== "'" && previous !== "\\") {
+      quote = quote === "\"" ? null : "\"";
+      continue;
+    }
+    if (char === "'" && quote !== "\"") {
+      quote = quote === "'" ? null : "'";
+      continue;
+    }
+    if (char === "#" && !quote && (index === 0 || /\s/.test(previous))) {
+      return index;
+    }
+  }
+
+  return -1;
+};
+
+const tokenizeYamlCode = (code: string): SourceToken[] => {
+  if (!code) {
+    return [];
+  }
+
+  const indentMatch = code.match(/^(\s*)(-\s*)?/);
+  const indent = indentMatch?.[1] ?? "";
+  const dash = indentMatch?.[2] ?? "";
+  const contentStart = indent.length + dash.length;
+  const content = code.slice(contentStart);
+  const tokens: SourceToken[] = [];
+
+  if (indent) {
+    tokens.push({ text: indent });
+  }
+  if (dash) {
+    tokens.push({ text: dash, tone: "punctuation" });
+  }
+
+  const keyMatch = content.match(/^([^:\s][^:]*)(:)(\s*)(.*)$/);
+  if (keyMatch) {
+    tokens.push({ text: keyMatch[1], tone: "key" });
+    tokens.push({ text: keyMatch[2], tone: "punctuation" });
+    if (keyMatch[3]) {
+      tokens.push({ text: keyMatch[3] });
+    }
+    if (keyMatch[4]) {
+      tokens.push({ text: keyMatch[4], tone: "scalar" });
+    }
+    return tokens;
+  }
+
+  if (content) {
+    tokens.push({ text: content, tone: "scalar" });
+  }
+
+  return tokens;
+};
+
+const tokenizeYamlLine = (line: string): SourceToken[] => {
+  const commentStart = findCommentStart(line);
+  if (commentStart < 0) {
+    return tokenizeYamlCode(line);
+  }
+
+  return [
+    ...tokenizeYamlCode(line.slice(0, commentStart)),
+    { text: line.slice(commentStart), tone: "comment" },
+  ];
+};
+
+const tokenClassName = (token: SourceToken): string | undefined => {
+  switch (token.tone) {
+    case "comment":
+      return styles.yamlTokenComment;
+    case "key":
+      return styles.yamlTokenKey;
+    case "punctuation":
+      return styles.yamlTokenPunctuation;
+    case "scalar":
+      return styles.yamlTokenScalar;
+    default:
+      return undefined;
+  }
+};
+
+export default function DotProjectMaintainerFileViewer({
+  source,
+  filename,
+}: DotProjectMaintainerFileViewerProps) {
+  const parsed = useMemo(() => parseMaintainerTeams(source), [source]);
+  const lines = useMemo(() => source.replace(/\r\n/g, "\n").replace(/\r/g, "\n").split("\n"), [source]);
+  const memberCount = parsed.teams.reduce((total, team) => total + team.members.length, 0);
+
+  return (
+    <div className={styles.dotProjectYamlViewer}>
+      <div className={styles.dotProjectYamlHeader}>
+        <div>
+          <h4 className={styles.dotProjectYamlTitle}>Formatted maintainer file</h4>
+          <p className={styles.dotProjectYamlSubtitle}>
+            Parsed from <code>{filename}</code>; source text remains read-only and whitespace-preserving.
+          </p>
+        </div>
+        <div className={styles.dotProjectYamlStats}>
+          <span>{parsed.teams.length} teams</span>
+          <span>{memberCount} members</span>
+        </div>
+      </div>
+
+      {parsed.errors.length > 0 ? (
+        <div className={styles.dotProjectYamlParseError}>
+          YAML parse issue: <strong>{parsed.errors[0]}</strong>
+        </div>
+      ) : null}
+
+      {parsed.teams.length > 0 ? (
+        <div className={styles.dotProjectTeamGrid}>
+          {parsed.teams.map((team) => (
+            <section className={styles.dotProjectTeamCard} key={team.name}>
+              <div className={styles.dotProjectTeamHeader}>
+                <span className={styles.dotProjectTeamName}>{team.name}</span>
+                <span className={styles.dotProjectTeamMeta}>{team.members.length} members</span>
+              </div>
+              <div className={styles.dotProjectMemberList}>
+                {team.members.map((member) => (
+                  <span className={styles.dotProjectMemberChip} key={`${team.name}-${member}`}>
+                    {member}
+                  </span>
+                ))}
+              </div>
+            </section>
+          ))}
+        </div>
+      ) : (
+        <div className={styles.dotProjectYamlParseError}>No maintainer teams were parsed from the cached file.</div>
+      )}
+
+      <div className={styles.dotProjectSource} aria-label={`${filename} source`}>
+        {lines.map((line, lineIndex) => {
+          const tokens = tokenizeYamlLine(line);
+          return (
+            <div className={styles.dotProjectSourceLine} key={`${lineIndex}-${line}`}>
+              <span className={styles.dotProjectLineNumber}>{lineIndex + 1}</span>
+              <code className={styles.dotProjectLineCode}>
+                {tokens.length > 0
+                  ? tokens.map((token, tokenIndex) => (
+                      <span className={tokenClassName(token)} key={`${tokenIndex}-${token.text}`}>
+                        {token.text}
+                      </span>
+                    ))
+                  : "\u00a0"}
+              </code>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/ProjectReconciliationCard.module.css
+++ b/web/src/components/ProjectReconciliationCard.module.css
@@ -620,6 +620,160 @@
   color: var(--md-card-text-strong, #0b1220);
 }
 
+.dotProjectYamlViewer {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  margin-top: 14px;
+  border: 1px solid var(--md-border, rgba(15, 23, 42, 0.1));
+  border-radius: 14px;
+  padding: 14px;
+  background: var(--md-card-bg, #ffffff);
+}
+
+.dotProjectYamlHeader {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 14px;
+  flex-wrap: wrap;
+}
+
+.dotProjectYamlTitle {
+  margin: 0;
+  font-size: 14px;
+  color: var(--md-card-text-strong, #0b1220);
+}
+
+.dotProjectYamlSubtitle {
+  margin: 5px 0 0;
+  color: var(--md-card-muted, rgba(15, 23, 42, 0.65));
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.dotProjectYamlStats {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  color: var(--md-card-text-strong, #0b1220);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.dotProjectYamlStats span {
+  border: 1px solid var(--md-border, rgba(15, 23, 42, 0.12));
+  border-radius: 999px;
+  padding: 5px 9px;
+  background: var(--md-surface, rgba(15, 23, 42, 0.04));
+}
+
+.dotProjectYamlParseError {
+  border: 1px solid var(--md-status-danger-border, #fca5a5);
+  border-radius: 10px;
+  padding: 10px 12px;
+  color: var(--md-status-danger-text, #b91c1c);
+  background: var(--md-status-danger-bg, #fee2e2);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.dotProjectTeamGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 10px;
+}
+
+.dotProjectTeamCard {
+  border: 1px solid var(--md-border, rgba(15, 23, 42, 0.1));
+  border-radius: 12px;
+  padding: 12px;
+  background: var(--md-surface, rgba(15, 23, 42, 0.03));
+}
+
+.dotProjectTeamHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
+.dotProjectTeamName {
+  color: var(--md-card-text-strong, #0b1220);
+  font-weight: 700;
+}
+
+.dotProjectTeamMeta {
+  color: var(--md-card-muted, rgba(15, 23, 42, 0.65));
+  font-size: 12px;
+}
+
+.dotProjectMemberList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+}
+
+.dotProjectMemberChip {
+  border: 1px solid rgba(11, 61, 46, 0.18);
+  border-radius: 999px;
+  padding: 4px 8px;
+  color: var(--md-link, #0b3d2e);
+  background: rgba(11, 61, 46, 0.06);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.dotProjectSource {
+  overflow: auto;
+  border: 1px solid var(--md-border, rgba(15, 23, 42, 0.1));
+  border-radius: 12px;
+  background: #0b1220;
+  color: #dbeafe;
+  font-family: var(--font-geist-mono), ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  font-size: 12px;
+  line-height: 1.55;
+}
+
+.dotProjectSourceLine {
+  display: grid;
+  grid-template-columns: 3rem minmax(max-content, 1fr);
+  min-width: max-content;
+}
+
+.dotProjectLineNumber {
+  user-select: none;
+  text-align: right;
+  padding: 0 10px;
+  color: rgba(203, 213, 225, 0.45);
+  border-right: 1px solid rgba(148, 163, 184, 0.22);
+  background: rgba(15, 23, 42, 0.55);
+}
+
+.dotProjectLineCode {
+  padding: 0 12px;
+  white-space: pre;
+}
+
+.yamlTokenComment {
+  color: #94a3b8;
+  font-style: italic;
+}
+
+.yamlTokenKey {
+  color: #93c5fd;
+}
+
+.yamlTokenPunctuation {
+  color: #fbbf24;
+}
+
+.yamlTokenScalar {
+  color: #bbf7d0;
+}
+
 .tableWrap {
   border: 1px solid var(--md-border, rgba(15, 23, 42, 0.08));
   border-radius: 12px;
@@ -810,6 +964,34 @@
 
 [data-theme="dark"] .tableTitle {
   color: #f8fafc;
+}
+
+[data-theme="dark"] .dotProjectYamlViewer {
+  background: #0b1220;
+  border-color: rgba(148, 163, 184, 0.2);
+}
+
+[data-theme="dark"] .dotProjectYamlTitle,
+[data-theme="dark"] .dotProjectYamlStats,
+[data-theme="dark"] .dotProjectTeamName {
+  color: #f8fafc;
+}
+
+[data-theme="dark"] .dotProjectYamlSubtitle,
+[data-theme="dark"] .dotProjectTeamMeta {
+  color: rgba(226, 232, 240, 0.7);
+}
+
+[data-theme="dark"] .dotProjectYamlStats span,
+[data-theme="dark"] .dotProjectTeamCard {
+  background: rgba(15, 23, 42, 0.6);
+  border-color: rgba(148, 163, 184, 0.22);
+}
+
+[data-theme="dark"] .dotProjectMemberChip {
+  border-color: rgba(74, 222, 128, 0.28);
+  color: #86efac;
+  background: rgba(74, 222, 128, 0.12);
 }
 
 [data-theme="dark"] .tableWrap {

--- a/web/src/components/ProjectReconciliationCard.tsx
+++ b/web/src/components/ProjectReconciliationCard.tsx
@@ -12,6 +12,7 @@ import Link from "next/link";
 import styles from "./ProjectReconciliationCard.module.css";
 import ProjectDiffControl from "./ProjectDiffControl";
 import ProjectAddMaintainerModal from "./ProjectAddMaintainerModal";
+import DotProjectMaintainerFileViewer from "./DotProjectMaintainerFileViewer";
 
 type MaintainerSummary = {
   id: number;
@@ -329,7 +330,7 @@ export default function ProjectReconciliationCard({
   const dotProjectLastCheckedAt = dotProjectSyncState?.lastCheckedAt || dotProjectLastSyncedAt || null;
   const dotProjectSchema = dotProjectSyncState?.schemaVersion || dotProjectSchemaVersion || "";
   const dotProjectMaintainersFilename = dotProjectSyncState?.maintainersFilename || "MAINTAINERS.yaml";
-  const dotProjectMaintainerCacheBody = dotProjectMaintainerCache?.body?.trim() ?? "";
+  const dotProjectMaintainerCacheBody = dotProjectMaintainerCache?.body ?? "";
   const dotProjectMaintainerCacheFilename =
     dotProjectMaintainerCache?.filename || dotProjectMaintainersFilename || "maintainers.yaml";
   const dotProjectMaintainerCacheCheckedAt =
@@ -973,7 +974,7 @@ export default function ProjectReconciliationCard({
           </table>
         </div>
       </div>
-      {dotProjectMaintainerCacheBody ? (
+      {dotProjectMaintainerCacheBody.trim() ? (
         <div className={styles.tableSection}>
           <div className={styles.tableHeader}>
             <h3 className={styles.tableTitle}>Cached maintainer file</h3>
@@ -996,16 +997,10 @@ export default function ProjectReconciliationCard({
               <span className={styles.secondary}>{shortenHash(dotProjectMaintainerCache?.bodyHash)}</span>
             </div>
           </div>
-          <div className={styles.refYaml}>
-            <SyntaxHighlighter
-              language="yaml"
-              style={atomDark}
-              customStyle={{ margin: 0, background: "transparent" }}
-              codeTagProps={{ style: { fontFamily: "var(--font-geist-mono)" } }}
-            >
-              {dotProjectMaintainerCacheBody}
-            </SyntaxHighlighter>
-          </div>
+          <DotProjectMaintainerFileViewer
+            filename={dotProjectMaintainerCacheFilename}
+            source={dotProjectMaintainerCacheBody}
+          />
         </div>
       ) : null}
       {dotProjectSyncState?.syncError || dotProjectSyncState?.parseError ? (

--- a/web/tests/steps/project_routes.steps.js
+++ b/web/tests/steps/project_routes.steps.js
@@ -114,3 +114,21 @@ Then("the dot-project roll call lists the tracked .project files", async functio
     });
   }
 });
+
+Then("the dot-project roll call renders the cached maintainer file as formatted YAML", async function () {
+  const contentColumn = this.page.locator('[class*="contentColumn"]');
+  const viewer = contentColumn.locator('[class*="dotProjectYamlViewer"]');
+
+  await expect(viewer.getByRole("heading", { name: "Formatted maintainer file", exact: true })).toBeVisible({
+    timeout: 15000,
+  });
+  await expect(viewer.locator('[class*="dotProjectTeamName"]').getByText("project-maintainers")).toBeVisible({
+    timeout: 15000,
+  });
+  await expect(viewer.locator('[class*="dotProjectMemberChip"]').getByText("antonio-example")).toBeVisible({
+    timeout: 15000,
+  });
+  await expect(viewer.locator('[class*="yamlTokenComment"]')).toContainText(
+    "# Project Atlas dot-project maintainers"
+  );
+});


### PR DESCRIPTION
 - renders the cached `maintainers.yaml` body in the dot-project route
 - uses a structured, AST-backed YAML renderer rather than a generic syntax highlighter.
 - colorizes the YAML while preserving existing whitespace and comments in the rendered view
 - keeps the first version read-only.