### PR TITLE
makes rendered maintainers.yaml maintainer-d record aware

### DIFF
--- a/cmd/web-bff-seed/main.go
+++ b/cmd/web-bff-seed/main.go
@@ -168,7 +168,7 @@ func main() {
 			DotProjectContributingRef: "https://github.com/project-atlas/.project/blob/main/CONTRIBUTING.md",
 			DotProjectGovernanceRef:   "https://github.com/project-atlas/.project/blob/main/GOVERNANCE.md",
 			DotProjectSchemaVersion:   "1.0.0",
-			DotProjectMaintainerCount: uintPtr(3),
+			DotProjectMaintainerCount: uintPtr(4),
 			DotProjectLastSyncedAt:    atlasSyncedAt,
 			DotProjectAdoptionStatus:  "adopted",
 		},
@@ -250,6 +250,7 @@ maintainers:
           - antonio-example
           - renee-sample
           - alex-example
+          - unmapped-dotproject
 `),
 		SecurityFileBodyHash:     "seed-security-hash",
 		ContributingFileBodyHash: "seed-contributing-hash",

--- a/dot-project.md
+++ b/dot-project.md
@@ -613,6 +613,32 @@ Operational goals:
 - Move missing-maintainer feedback into the rendered file itself.
 - Keep the interaction clearly focused on the standardized `project-maintainers` team.
 
+#### Implementation report
+
+Commit D is complete.
+
+What changed:
+
+- Added maintainer-d awareness to the formatted dot-project maintainer-file viewer.
+- Matched `project-maintainers` members case-insensitively against active project maintainer records.
+- Rendered matched handles as links to their maintainer routes.
+- Rendered unmatched `project-maintainers` handles with a red wavy underline.
+- Wired unmatched handle clicks to the existing `Add Maintainer to CNCF INTERNAL DB` modal, prefilled with the GitHub handle and source line.
+- Added a validation message when the cached file does not contain a `project-maintainers` team.
+- Extended the web BDD fixture with an unmapped dot-project handle and covered the matched-link and add-modal paths.
+
+Operational details:
+
+- The inline awareness is intentionally limited to the standardized `project-maintainers` team.
+- The file view remains read-only; DB-vs-file diffing and PR generation are still deferred to later commits.
+
+Verification:
+
+- `npm --prefix web run lint`
+- `npm --prefix web run typecheck`
+- `GOCACHE=/tmp/go-build go test ./cmd/web-bff-seed`
+- `WEB_BDD_USE_MICROCKS=true BDD_FEATURE=../features/web/project_routes.feature make test-web`
+
 ### Commit E: Add DB-vs-File Diff Summary and PR Preview
 
 - Compare active project maintainers in maintainer-d against the members of the `project-maintainers` team only.

--- a/web/src/components/DotProjectMaintainerFileViewer.tsx
+++ b/web/src/components/DotProjectMaintainerFileViewer.tsx
@@ -4,9 +4,18 @@ import { useMemo } from "react";
 import { isMap, isScalar, isSeq, parseDocument, type Node } from "yaml";
 import styles from "./ProjectReconciliationCard.module.css";
 
+type KnownMaintainer = {
+  id: number;
+  github: string;
+  status?: string;
+};
+
 type DotProjectMaintainerFileViewerProps = {
   source: string;
   filename: string;
+  maintainers: KnownMaintainer[];
+  canEdit?: boolean;
+  onAddMissingMaintainer?: (handle: string, refLine: string) => void;
 };
 
 type MaintainerTeam = {
@@ -17,6 +26,7 @@ type MaintainerTeam = {
 type SourceToken = {
   text: string;
   tone?: "comment" | "key" | "punctuation" | "scalar";
+  maintainerHandle?: string;
 };
 
 const scalarText = (node: unknown): string => {
@@ -40,6 +50,8 @@ const scalarSeqValues = (node: unknown): string[] => {
   }
   return node.items.map(scalarText).filter(Boolean);
 };
+
+const normalizeHandle = (handle: string): string => handle.trim().replace(/^@/, "").toLowerCase();
 
 const parseMaintainerTeams = (source: string): { teams: MaintainerTeam[]; errors: string[] } => {
   const document = parseDocument<Node>(source, { keepSourceTokens: true });
@@ -94,7 +106,12 @@ const findCommentStart = (line: string): number => {
   return -1;
 };
 
-const tokenizeYamlCode = (code: string): SourceToken[] => {
+const tokenHandle = (value: string, projectMaintainerHandles: Set<string>): string | undefined => {
+  const normalized = normalizeHandle(value);
+  return projectMaintainerHandles.has(normalized) ? normalized : undefined;
+};
+
+const tokenizeYamlCode = (code: string, projectMaintainerHandles: Set<string>): SourceToken[] => {
   if (!code) {
     return [];
   }
@@ -121,26 +138,34 @@ const tokenizeYamlCode = (code: string): SourceToken[] => {
       tokens.push({ text: keyMatch[3] });
     }
     if (keyMatch[4]) {
-      tokens.push({ text: keyMatch[4], tone: "scalar" });
+      tokens.push({
+        text: keyMatch[4],
+        tone: "scalar",
+        maintainerHandle: tokenHandle(keyMatch[4], projectMaintainerHandles),
+      });
     }
     return tokens;
   }
 
   if (content) {
-    tokens.push({ text: content, tone: "scalar" });
+    tokens.push({
+      text: content,
+      tone: "scalar",
+      maintainerHandle: tokenHandle(content, projectMaintainerHandles),
+    });
   }
 
   return tokens;
 };
 
-const tokenizeYamlLine = (line: string): SourceToken[] => {
+const tokenizeYamlLine = (line: string, projectMaintainerHandles: Set<string>): SourceToken[] => {
   const commentStart = findCommentStart(line);
   if (commentStart < 0) {
-    return tokenizeYamlCode(line);
+    return tokenizeYamlCode(line, projectMaintainerHandles);
   }
 
   return [
-    ...tokenizeYamlCode(line.slice(0, commentStart)),
+    ...tokenizeYamlCode(line.slice(0, commentStart), projectMaintainerHandles),
     { text: line.slice(commentStart), tone: "comment" },
   ];
 };
@@ -163,10 +188,58 @@ const tokenClassName = (token: SourceToken): string | undefined => {
 export default function DotProjectMaintainerFileViewer({
   source,
   filename,
+  maintainers,
+  canEdit = false,
+  onAddMissingMaintainer,
 }: DotProjectMaintainerFileViewerProps) {
   const parsed = useMemo(() => parseMaintainerTeams(source), [source]);
   const lines = useMemo(() => source.replace(/\r\n/g, "\n").replace(/\r/g, "\n").split("\n"), [source]);
+  const activeMaintainersByHandle = useMemo(() => {
+    const known = new Map<string, KnownMaintainer>();
+    for (const maintainer of maintainers) {
+      if ((maintainer.status || "").toLowerCase() !== "active") {
+        continue;
+      }
+      const normalized = normalizeHandle(maintainer.github);
+      if (normalized) {
+        known.set(normalized, maintainer);
+      }
+    }
+    return known;
+  }, [maintainers]);
+  const projectMaintainerTeam = parsed.teams.find((team) => normalizeHandle(team.name) === "project-maintainers");
+  const projectMaintainerHandles = useMemo(
+    () => new Set((projectMaintainerTeam?.members ?? []).map(normalizeHandle).filter(Boolean)),
+    [projectMaintainerTeam],
+  );
   const memberCount = parsed.teams.reduce((total, team) => total + team.members.length, 0);
+  const missingProjectMaintainers = (projectMaintainerTeam?.members ?? []).filter(
+    (member) => !activeMaintainersByHandle.has(normalizeHandle(member)),
+  );
+
+  const renderMaintainerHandle = (handle: string, refLine: string) => {
+    const normalized = normalizeHandle(handle);
+    const maintainer = activeMaintainersByHandle.get(normalized);
+    if (maintainer) {
+      return (
+        <a className={styles.dotProjectMaintainerLink} href={`/maintainers/${maintainer.id}`}>
+          {handle}
+        </a>
+      );
+    }
+    if (canEdit && onAddMissingMaintainer) {
+      return (
+        <button
+          className={styles.dotProjectMissingMaintainerButton}
+          type="button"
+          onClick={() => onAddMissingMaintainer(handle, refLine)}
+        >
+          {handle}
+        </button>
+      );
+    }
+    return <span className={styles.dotProjectMissingMaintainer}>{handle}</span>;
+  };
 
   return (
     <div className={styles.dotProjectYamlViewer}>
@@ -188,6 +261,17 @@ export default function DotProjectMaintainerFileViewer({
           YAML parse issue: <strong>{parsed.errors[0]}</strong>
         </div>
       ) : null}
+      {parsed.errors.length === 0 && !projectMaintainerTeam ? (
+        <div className={styles.dotProjectYamlParseError}>
+          Validation issue: <strong>project-maintainers</strong> team was not found in the cached maintainer file.
+        </div>
+      ) : null}
+      {missingProjectMaintainers.length > 0 ? (
+        <div className={styles.dotProjectYamlValidation}>
+          {missingProjectMaintainers.length} project-maintainers handle
+          {missingProjectMaintainers.length === 1 ? " is" : "s are"} not active in maintainer-d.
+        </div>
+      ) : null}
 
       {parsed.teams.length > 0 ? (
         <div className={styles.dotProjectTeamGrid}>
@@ -200,7 +284,9 @@ export default function DotProjectMaintainerFileViewer({
               <div className={styles.dotProjectMemberList}>
                 {team.members.map((member) => (
                   <span className={styles.dotProjectMemberChip} key={`${team.name}-${member}`}>
-                    {member}
+                    {normalizeHandle(team.name) === "project-maintainers"
+                      ? renderMaintainerHandle(member, `- ${member}`)
+                      : member}
                   </span>
                 ))}
               </div>
@@ -213,17 +299,23 @@ export default function DotProjectMaintainerFileViewer({
 
       <div className={styles.dotProjectSource} aria-label={`${filename} source`}>
         {lines.map((line, lineIndex) => {
-          const tokens = tokenizeYamlLine(line);
+          const tokens = tokenizeYamlLine(line, projectMaintainerHandles);
           return (
             <div className={styles.dotProjectSourceLine} key={`${lineIndex}-${line}`}>
               <span className={styles.dotProjectLineNumber}>{lineIndex + 1}</span>
               <code className={styles.dotProjectLineCode}>
                 {tokens.length > 0
-                  ? tokens.map((token, tokenIndex) => (
-                      <span className={tokenClassName(token)} key={`${tokenIndex}-${token.text}`}>
-                        {token.text}
-                      </span>
-                    ))
+                  ? tokens.map((token, tokenIndex) =>
+                      token.maintainerHandle ? (
+                        <span className={tokenClassName(token)} key={`${tokenIndex}-${token.text}`}>
+                          {renderMaintainerHandle(token.text, line)}
+                        </span>
+                      ) : (
+                        <span className={tokenClassName(token)} key={`${tokenIndex}-${token.text}`}>
+                          {token.text}
+                        </span>
+                      ),
+                    )
                   : "\u00a0"}
               </code>
             </div>

--- a/web/src/components/ProjectReconciliationCard.module.css
+++ b/web/src/components/ProjectReconciliationCard.module.css
@@ -679,6 +679,16 @@
   line-height: 1.5;
 }
 
+.dotProjectYamlValidation {
+  border: 1px solid #f4d08a;
+  border-radius: 10px;
+  padding: 10px 12px;
+  color: #6d4d00;
+  background: #fff7e6;
+  font-size: 12px;
+  line-height: 1.5;
+}
+
 .dotProjectTeamGrid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
@@ -724,6 +734,37 @@
   background: rgba(11, 61, 46, 0.06);
   font-size: 12px;
   font-weight: 600;
+}
+
+.dotProjectMaintainerLink {
+  color: inherit;
+  font-weight: 700;
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
+}
+
+.dotProjectMissingMaintainer,
+.dotProjectMissingMaintainerButton {
+  color: #b91c1c;
+  text-decoration-line: underline;
+  text-decoration-style: wavy;
+  text-decoration-color: #ef4444;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 3px;
+}
+
+.dotProjectMissingMaintainerButton {
+  appearance: none;
+  border: none;
+  padding: 0;
+  background: transparent;
+  font: inherit;
+  cursor: pointer;
+}
+
+.dotProjectMissingMaintainerButton:hover {
+  color: #7f1d1d;
 }
 
 .dotProjectSource {
@@ -992,6 +1033,21 @@
   border-color: rgba(74, 222, 128, 0.28);
   color: #86efac;
   background: rgba(74, 222, 128, 0.12);
+}
+
+[data-theme="dark"] .dotProjectMissingMaintainer,
+[data-theme="dark"] .dotProjectMissingMaintainerButton {
+  color: #fca5a5;
+}
+
+[data-theme="dark"] .dotProjectMissingMaintainerButton:hover {
+  color: #fecaca;
+}
+
+[data-theme="dark"] .dotProjectYamlValidation {
+  border-color: rgba(251, 191, 36, 0.35);
+  color: #fde68a;
+  background: rgba(251, 191, 36, 0.12);
 }
 
 [data-theme="dark"] .tableWrap {

--- a/web/src/components/ProjectReconciliationCard.tsx
+++ b/web/src/components/ProjectReconciliationCard.tsx
@@ -999,6 +999,19 @@ export default function ProjectReconciliationCard({
           </div>
           <DotProjectMaintainerFileViewer
             filename={dotProjectMaintainerCacheFilename}
+            maintainers={maintainers}
+            canEdit={canEdit}
+            onAddMissingMaintainer={(handle, refLine) => {
+              setDraft({
+                githubHandle: handle,
+                name: "",
+                email: "",
+                company: "",
+                companyMode: "select",
+                refLine,
+              });
+              setModalOpen(true);
+            }}
             source={dotProjectMaintainerCacheBody}
           />
         </div>

--- a/web/tests/steps/project_routes.steps.js
+++ b/web/tests/steps/project_routes.steps.js
@@ -95,7 +95,7 @@ Then("the dot-project roll call shows the persisted discovery summary", async fu
   await expect(contentColumn.getByText("Schema version", { exact: true })).toBeVisible({ timeout: 15000 });
   await expect(contentColumn.getByText("1.0.0", { exact: true })).toBeVisible({ timeout: 15000 });
   await expect(contentColumn.getByText("Maintainer count", { exact: true })).toBeVisible({ timeout: 15000 });
-  await expect(contentColumn.getByText("3 maintainers", { exact: true })).toBeVisible({ timeout: 15000 });
+  await expect(contentColumn.getByText("4 maintainers", { exact: true })).toBeVisible({ timeout: 15000 });
 });
 
 Then("the dot-project roll call lists the tracked .project files", async function () {
@@ -128,6 +128,21 @@ Then("the dot-project roll call renders the cached maintainer file as formatted 
   await expect(viewer.locator('[class*="dotProjectMemberChip"]').getByText("antonio-example")).toBeVisible({
     timeout: 15000,
   });
+  const memberList = viewer.locator('[class*="dotProjectMemberList"]');
+  await expect(memberList.locator('a[href^="/maintainers/"]').getByText("antonio-example")).toBeVisible({
+    timeout: 15000,
+  });
+  const missingHandle = memberList
+    .locator('[class*="dotProjectMissingMaintainerButton"]')
+    .getByText("unmapped-dotproject");
+  await expect(missingHandle).toBeVisible({ timeout: 15000 });
+  await missingHandle.click();
+  const modal = this.page.getByRole("dialog");
+  await expect(modal.getByRole("heading", { name: "Add Maintainer to CNCF INTERNAL DB" })).toBeVisible({
+    timeout: 15000,
+  });
+  await expect(modal.getByLabel("GitHub Handle")).toHaveValue("unmapped-dotproject", { timeout: 15000 });
+  await modal.getByRole("button", { name: "Close" }).click();
   await expect(viewer.locator('[class*="yamlTokenComment"]')).toContainText(
     "# Project Atlas dot-project maintainers"
   );


### PR DESCRIPTION
  in the rendered project-maintainers team in maintainer.yaml
  - github handles that exist in the db become hrefs that refer to the maintainer route
  - github handles not in the db become hrefs that refer to the create maintainer popup