### PR TITLE
adds DB-vs-File Diff Summary and PR Preview

### DIFF
--- a/cmd/web-bff-seed/main.go
+++ b/cmd/web-bff-seed/main.go
@@ -168,7 +168,7 @@ func main() {
 			DotProjectContributingRef: "https://github.com/project-atlas/.project/blob/main/CONTRIBUTING.md",
 			DotProjectGovernanceRef:   "https://github.com/project-atlas/.project/blob/main/GOVERNANCE.md",
 			DotProjectSchemaVersion:   "1.0.0",
-			DotProjectMaintainerCount: uintPtr(4),
+			DotProjectMaintainerCount: uintPtr(3),
 			DotProjectLastSyncedAt:    atlasSyncedAt,
 			DotProjectAdoptionStatus:  "adopted",
 		},
@@ -228,8 +228,8 @@ func main() {
 		ProjectFileExists:       true,
 		MaintainersFileExists:   true,
 		SecurityFileExists:      true,
-		ContributingFileExists:  true,
-		GovernanceFileExists:    true,
+		ContributingFileExists:  false,
+		GovernanceFileExists:    false,
 		DefaultBranch:           "main",
 		MaintainersFilename:     "MAINTAINERS.yaml",
 		SchemaVersion:           "1.0.0",
@@ -249,7 +249,6 @@ maintainers:
         members:
           - antonio-example
           - renee-sample
-          - alex-example
           - unmapped-dotproject
 `),
 		SecurityFileBodyHash:     "seed-security-hash",

--- a/dot-project.md
+++ b/dot-project.md
@@ -644,12 +644,29 @@ Verification:
 - Compare active project maintainers in maintainer-d against the members of the `project-maintainers` team only.
 - Show active maintainers that exist in maintainer-d but are missing from `maintainers.yaml`.
 - Add a `Create Pull Request` action that patches the rendered file in the UI preview with the missing GitHub handles.
-- Render a suggested updated `maintainers.yaml` preview that respects the existing comments, formatting, and ordering as much as possible.
+- Render a suggested updated `maintainers.yaml` preview that respects the existing comments, formatting, and ordering as much as possible. Have the suggested update appear in a side-by-side presentation of the proposed changes. For lines that are to be added to by the PR give those line numbers a green backgroud on the proposed PR, for lines being deleted from the file, make the line numbers background red on the existing file. As much as possible make the side-by-side presentation intuitive for a human read to proposed PR improves the file.
 
 Operational goals:
 
 - Replicate the existing roll-call diff behavior for dot-project, but in a better UI.
 - Keep the preview faithful to the original file so maintainers can trust the generated patch.
+
+Implementation report:
+
+- The formatted maintainer-file viewer now compares active maintainer-d project maintainers against the `project-maintainers` team parsed from cached `maintainers.yaml`.
+- When active maintainer-d maintainers are missing from the file, the UI shows a DB-vs-file summary and a side-by-side PR preview.
+- The preview inserts the missing GitHub handles into the existing `members:` list without rewriting the rest of the file, preserving comments, formatting, and surrounding line order.
+- The proposed patch is rendered side-by-side with line numbers; added proposed lines are highlighted green and the existing side leaves aligned blank rows for readability.
+- The seeded web BDD fixture now includes one maintainer-d active maintainer missing from `MAINTAINERS.yaml` so the preview path is covered.
+
+Layout follow-up:
+
+- Make the cached `maintainers.yaml` body the primary focus of the DOT-PROJECT ROLL CALL page.
+- Render the maintainer file before discovery and tracked-file implementation details.
+- Remove the prototype-oriented `Persisted dot-project roll call` callout from the end-user route.
+- Hide cache metadata such as ETag and body hash from the primary page layout.
+- Show the proposed PR diff by default whenever maintainer-d has active maintainers missing from the `project-maintainers` team.
+- Keep GitHub PR creation out of this layout step; the button must not claim to create a PR until Commit F wires the backend write path.
 
 ### Commit F: Submit Pull Request Workflow
 
@@ -657,11 +674,23 @@ Operational goals:
 - Create a branch and PR against the project’s `.project` repository using maintainer-d’s service credentials.
 - Record the PR creation in the audit log.
 - Show PR result details back in the UI.
+- Replace the current preview-only `Create Pull Request` control with a real submit action.
 
 Operational goals:
 
 - Turn missing-maintainer detection into an actionable remediation workflow.
 - Keep the write path bot-driven first rather than depending on each end user’s GitHub OAuth identity.
+
+### Commit F.1: Add Maintainer File Provenance
+
+- Show provenance for each rendered `maintainers.yaml` line when available.
+- Link line provenance to the upstream commit or pull request that last introduced or changed that line.
+- Prefer GitHub blame/commit metadata from the project’s `.project` repository over local audit data, because provenance must refer to the source file history.
+
+Operational goals:
+
+- Help LF support staff validate maintainer identity through source-history evidence.
+- Keep the main maintainer view human-centered while still allowing a trust trail for online-only support interactions.
 
 ### Commit G: Return to Deferred `project.yaml` Metadata Import
 

--- a/features/web/project_routes.feature
+++ b/features/web/project_routes.feature
@@ -13,7 +13,7 @@ Feature: Project route navigation
     Then the project route navigation exposes these routes
       | label                         | path-suffix            | heading                       | body-snippet                                                                     |
       | LEGACY ROLL CALL              | /github                | LEGACY ROLL CALL              | This project has a maintainer file in its .project repo.                         |
-      | DOT-PROJECT ROLL CALL         | /dot-project           | DOT-PROJECT ROLL CALL         | Review the persisted .project discovery state captured by the background sync job. |
+      | DOT-PROJECT ROLL CALL         | /dot-project           | DOT-PROJECT ROLL CALL         | Formatted maintainer file                                                       |
       | LICENSE CHECKER - FOSSA       | /fossa                 | LICENSE CHECKER - FOSSA       | This project has not selected a license checker.                                 |
       | MAILING LISTS / MAINTAINERS   | /mailing-maintainers   | MAILING LISTS / MAINTAINERS   | Placeholder for maintainer mailing list references                               |
       | MAILING LISTS / SECURITY      | /mailing-security      | MAILING LISTS / SECURITY      | Placeholder for security mailing list references.                                |

--- a/web/src/components/DotProjectMaintainerFileViewer.tsx
+++ b/web/src/components/DotProjectMaintainerFileViewer.tsx
@@ -1,11 +1,13 @@
 "use client";
 
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { isMap, isScalar, isSeq, parseDocument, type Node } from "yaml";
+import GitHubHandle from "./GitHubHandle";
 import styles from "./ProjectReconciliationCard.module.css";
 
 type KnownMaintainer = {
   id: number;
+  name: string;
   github: string;
   status?: string;
 };
@@ -27,6 +29,21 @@ type SourceToken = {
   text: string;
   tone?: "comment" | "key" | "punctuation" | "scalar";
   maintainerHandle?: string;
+};
+
+type PatchPreviewLine = {
+  key: string;
+  text: string;
+  lineNumber: number | null;
+  tone: "context" | "added" | "deleted" | "empty";
+};
+
+type PatchPreview = {
+  existing: PatchPreviewLine[];
+  proposed: PatchPreviewLine[];
+  addedCount: number;
+  deletedCount: number;
+  error?: string;
 };
 
 const scalarText = (node: unknown): string => {
@@ -185,6 +202,193 @@ const tokenClassName = (token: SourceToken): string | undefined => {
   }
 };
 
+const activeMaintainerHandles = (maintainers: KnownMaintainer[]): KnownMaintainer[] => {
+  const seen = new Set<string>();
+  const active: KnownMaintainer[] = [];
+
+  for (const maintainer of maintainers) {
+    if ((maintainer.status || "").toLowerCase() !== "active") {
+      continue;
+    }
+    const normalized = normalizeHandle(maintainer.github);
+    if (!normalized || seen.has(normalized)) {
+      continue;
+    }
+    seen.add(normalized);
+    active.push(maintainer);
+  }
+
+  return active;
+};
+
+const leadingWhitespaceLength = (line: string): number => line.match(/^\s*/)?.[0].length ?? 0;
+
+const isProjectMaintainersNameLine = (line: string): boolean =>
+  /^\s*(?:-\s*)?name:\s*["']?project-maintainers["']?\s*(?:#.*)?$/i.test(line);
+
+const isMembersLine = (line: string): boolean => /^\s*members:\s*(?:#.*)?$/i.test(line);
+
+const isSequenceItemLine = (line: string): boolean => /^\s*-\s*\S/.test(line);
+
+const splitSourceLines = (source: string): string[] =>
+  source.replace(/\r\n/g, "\n").replace(/\r/g, "\n").split("\n");
+
+const buildPatchRows = (
+  originalLines: string[],
+  proposedLines: string[],
+  insertedAt: number,
+  insertedCount: number,
+): PatchPreview => {
+  const existing: PatchPreviewLine[] = [];
+  const proposed: PatchPreviewLine[] = [];
+
+  for (let index = 0; index <= originalLines.length; index += 1) {
+    if (index === insertedAt) {
+      for (let offset = 0; offset < insertedCount; offset += 1) {
+        const proposedIndex = insertedAt + offset;
+        existing.push({
+          key: `existing-added-${offset}`,
+          text: "",
+          lineNumber: null,
+          tone: "empty",
+        });
+        proposed.push({
+          key: `proposed-added-${offset}`,
+          text: proposedLines[proposedIndex] ?? "",
+          lineNumber: proposedIndex + 1,
+          tone: "added",
+        });
+      }
+    }
+
+    if (index >= originalLines.length) {
+      continue;
+    }
+    const proposedIndex = index + (index >= insertedAt ? insertedCount : 0);
+    existing.push({
+      key: `existing-${index}`,
+      text: originalLines[index],
+      lineNumber: index + 1,
+      tone: "context",
+    });
+    proposed.push({
+      key: `proposed-${proposedIndex}`,
+      text: proposedLines[proposedIndex] ?? "",
+      lineNumber: proposedIndex + 1,
+      tone: "context",
+    });
+  }
+
+  return {
+    existing,
+    proposed,
+    addedCount: insertedCount,
+    deletedCount: 0,
+  };
+};
+
+const buildMaintainerPatchPreview = (source: string, missingHandles: string[]): PatchPreview => {
+  const uniqueMissingHandles = Array.from(
+    new Map(missingHandles.map((handle) => [normalizeHandle(handle), handle.trim()])).values(),
+  ).filter(Boolean);
+
+  if (uniqueMissingHandles.length === 0) {
+    return {
+      existing: [],
+      proposed: [],
+      addedCount: 0,
+      deletedCount: 0,
+    };
+  }
+
+  const originalLines = splitSourceLines(source);
+  const teamNameIndex = originalLines.findIndex(isProjectMaintainersNameLine);
+
+  if (teamNameIndex < 0) {
+    return {
+      existing: [],
+      proposed: [],
+      addedCount: 0,
+      deletedCount: 0,
+      error: "Cannot generate a patch preview because the project-maintainers team was not found.",
+    };
+  }
+
+  const teamIndent = leadingWhitespaceLength(originalLines[teamNameIndex]);
+  let membersIndex = -1;
+
+  for (let index = teamNameIndex + 1; index < originalLines.length; index += 1) {
+    const line = originalLines[index];
+    const trimmed = line.trim();
+    if (trimmed && leadingWhitespaceLength(line) <= teamIndent && isSequenceItemLine(line)) {
+      break;
+    }
+    if (isMembersLine(line)) {
+      membersIndex = index;
+      break;
+    }
+  }
+
+  const proposedLines = [...originalLines];
+
+  if (membersIndex < 0) {
+    const insertLines = [`${" ".repeat(teamIndent + 2)}members:`, ...uniqueMissingHandles.map((handle) => `${" ".repeat(teamIndent + 4)}- ${handle}`)];
+    const insertedAt = teamNameIndex + 1;
+    proposedLines.splice(insertedAt, 0, ...insertLines);
+    return buildPatchRows(originalLines, proposedLines, insertedAt, insertLines.length);
+  }
+
+  const membersIndent = leadingWhitespaceLength(originalLines[membersIndex]);
+  let insertAt = membersIndex + 1;
+  let itemIndent = " ".repeat(membersIndent + 2);
+
+  for (let index = membersIndex + 1; index < originalLines.length; index += 1) {
+    const line = originalLines[index];
+    const trimmed = line.trim();
+    if (!trimmed) {
+      continue;
+    }
+    const lineIndent = leadingWhitespaceLength(line);
+    if (lineIndent <= membersIndent) {
+      break;
+    }
+    if (isSequenceItemLine(line)) {
+      itemIndent = line.match(/^\s*/)?.[0] ?? itemIndent;
+      insertAt = index + 1;
+      continue;
+    }
+    insertAt = index + 1;
+  }
+
+  const insertLines = uniqueMissingHandles.map((handle) => `${itemIndent}- ${handle}`);
+  proposedLines.splice(insertAt, 0, ...insertLines);
+  return buildPatchRows(originalLines, proposedLines, insertAt, insertLines.length);
+};
+
+const diffLineClassName = (tone: PatchPreviewLine["tone"]): string => {
+  switch (tone) {
+    case "added":
+      return `${styles.dotProjectSourceLine} ${styles.dotProjectDiffLineAdded}`;
+    case "deleted":
+      return `${styles.dotProjectSourceLine} ${styles.dotProjectDiffLineDeleted}`;
+    case "empty":
+      return `${styles.dotProjectSourceLine} ${styles.dotProjectDiffLineEmpty}`;
+    default:
+      return styles.dotProjectSourceLine;
+  }
+};
+
+const diffLineNumberClassName = (tone: PatchPreviewLine["tone"]): string => {
+  switch (tone) {
+    case "added":
+      return `${styles.dotProjectLineNumber} ${styles.dotProjectLineNumberAdded}`;
+    case "deleted":
+      return `${styles.dotProjectLineNumber} ${styles.dotProjectLineNumberDeleted}`;
+    default:
+      return styles.dotProjectLineNumber;
+  }
+};
+
 export default function DotProjectMaintainerFileViewer({
   source,
   filename,
@@ -192,21 +396,20 @@ export default function DotProjectMaintainerFileViewer({
   canEdit = false,
   onAddMissingMaintainer,
 }: DotProjectMaintainerFileViewerProps) {
+  const [showPatchPreview, setShowPatchPreview] = useState(true);
   const parsed = useMemo(() => parseMaintainerTeams(source), [source]);
-  const lines = useMemo(() => source.replace(/\r\n/g, "\n").replace(/\r/g, "\n").split("\n"), [source]);
+  const lines = useMemo(() => splitSourceLines(source), [source]);
+  const activeMaintainers = useMemo(() => activeMaintainerHandles(maintainers), [maintainers]);
   const activeMaintainersByHandle = useMemo(() => {
     const known = new Map<string, KnownMaintainer>();
-    for (const maintainer of maintainers) {
-      if ((maintainer.status || "").toLowerCase() !== "active") {
-        continue;
-      }
+    for (const maintainer of activeMaintainers) {
       const normalized = normalizeHandle(maintainer.github);
       if (normalized) {
         known.set(normalized, maintainer);
       }
     }
     return known;
-  }, [maintainers]);
+  }, [activeMaintainers]);
   const projectMaintainerTeam = parsed.teams.find((team) => normalizeHandle(team.name) === "project-maintainers");
   const projectMaintainerHandles = useMemo(
     () => new Set((projectMaintainerTeam?.members ?? []).map(normalizeHandle).filter(Boolean)),
@@ -216,6 +419,30 @@ export default function DotProjectMaintainerFileViewer({
   const missingProjectMaintainers = (projectMaintainerTeam?.members ?? []).filter(
     (member) => !activeMaintainersByHandle.has(normalizeHandle(member)),
   );
+  const missingFileMaintainers = activeMaintainers.filter(
+    (maintainer) => !projectMaintainerHandles.has(normalizeHandle(maintainer.github)),
+  );
+  const patchPreview = useMemo(
+    () => buildMaintainerPatchPreview(source, missingFileMaintainers.map((maintainer) => maintainer.github)),
+    [source, missingFileMaintainers],
+  );
+
+  const renderYamlLine = (line: string, keyPrefix: string) => {
+    const tokens = tokenizeYamlLine(line, projectMaintainerHandles);
+    return tokens.length > 0
+      ? tokens.map((token, tokenIndex) =>
+          token.maintainerHandle ? (
+            <span className={tokenClassName(token)} key={`${keyPrefix}-${tokenIndex}-${token.text}`}>
+              {renderMaintainerHandle(token.text, line)}
+            </span>
+          ) : (
+            <span className={tokenClassName(token)} key={`${keyPrefix}-${tokenIndex}-${token.text}`}>
+              {token.text}
+            </span>
+          ),
+        )
+      : "\u00a0";
+  };
 
   const renderMaintainerHandle = (handle: string, refLine: string) => {
     const normalized = normalizeHandle(handle);
@@ -272,6 +499,40 @@ export default function DotProjectMaintainerFileViewer({
           {missingProjectMaintainers.length === 1 ? " is" : "s are"} not active in maintainer-d.
         </div>
       ) : null}
+      {missingFileMaintainers.length > 0 ? (
+        <div className={styles.dotProjectDiffSummary}>
+          <div>
+            <h5 className={styles.dotProjectDiffSummaryTitle}>DB-vs-file diff</h5>
+            <p className={styles.dotProjectDiffSummaryBody}>
+              {missingFileMaintainers.length} active maintainer-d maintainer
+              {missingFileMaintainers.length === 1 ? " is" : "s are"} missing from the{" "}
+              <strong>project-maintainers</strong> team in <code>{filename}</code>:
+            </p>
+            <div className={styles.dotProjectDiffMaintainerList}>
+              {missingFileMaintainers.map((maintainer) => (
+                <GitHubHandle
+                  github={maintainer.github}
+                  id={maintainer.id}
+                  key={maintainer.github}
+                  name={maintainer.name}
+                  prefixName
+                />
+              ))}
+            </div>
+          </div>
+          <button
+            className={styles.dotProjectPreviewButton}
+            type="button"
+            onClick={() => setShowPatchPreview((current) => !current)}
+          >
+            {showPatchPreview ? "Hide PR Preview" : "Show PR Preview"}
+          </button>
+        </div>
+      ) : projectMaintainerTeam ? (
+        <div className={styles.dotProjectYamlSuccess}>
+          All active maintainer-d maintainers are present in the project-maintainers team.
+        </div>
+      ) : null}
 
       {parsed.teams.length > 0 ? (
         <div className={styles.dotProjectTeamGrid}>
@@ -299,29 +560,59 @@ export default function DotProjectMaintainerFileViewer({
 
       <div className={styles.dotProjectSource} aria-label={`${filename} source`}>
         {lines.map((line, lineIndex) => {
-          const tokens = tokenizeYamlLine(line, projectMaintainerHandles);
           return (
             <div className={styles.dotProjectSourceLine} key={`${lineIndex}-${line}`}>
               <span className={styles.dotProjectLineNumber}>{lineIndex + 1}</span>
-              <code className={styles.dotProjectLineCode}>
-                {tokens.length > 0
-                  ? tokens.map((token, tokenIndex) =>
-                      token.maintainerHandle ? (
-                        <span className={tokenClassName(token)} key={`${tokenIndex}-${token.text}`}>
-                          {renderMaintainerHandle(token.text, line)}
-                        </span>
-                      ) : (
-                        <span className={tokenClassName(token)} key={`${tokenIndex}-${token.text}`}>
-                          {token.text}
-                        </span>
-                      ),
-                    )
-                  : "\u00a0"}
-              </code>
+              <code className={styles.dotProjectLineCode}>{renderYamlLine(line, `source-${lineIndex}`)}</code>
             </div>
           );
         })}
       </div>
+
+      {showPatchPreview ? (
+        <section className={styles.dotProjectPatchPreview} aria-label="Pull request preview">
+          <div className={styles.dotProjectPatchHeader}>
+            <div>
+              <h4 className={styles.dotProjectYamlTitle}>Pull request preview</h4>
+              <p className={styles.dotProjectYamlSubtitle}>
+                Review the maintainer-d generated patch before a follow-up workflow submits it to GitHub.
+              </p>
+            </div>
+            <div className={styles.dotProjectYamlStats}>
+              <span>+{patchPreview.addedCount}</span>
+              <span>-{patchPreview.deletedCount}</span>
+            </div>
+          </div>
+          {patchPreview.error ? (
+            <div className={styles.dotProjectYamlParseError}>{patchPreview.error}</div>
+          ) : (
+            <div className={styles.dotProjectDiffGrid}>
+              <div className={styles.dotProjectDiffPane}>
+                <div className={styles.dotProjectDiffPaneHeader}>Existing {filename}</div>
+                <div className={styles.dotProjectSource}>
+                  {patchPreview.existing.map((line) => (
+                    <div className={diffLineClassName(line.tone)} key={line.key}>
+                      <span className={diffLineNumberClassName(line.tone)}>{line.lineNumber ?? ""}</span>
+                      <code className={styles.dotProjectLineCode}>{renderYamlLine(line.text, line.key)}</code>
+                    </div>
+                  ))}
+                </div>
+              </div>
+              <div className={styles.dotProjectDiffPane}>
+                <div className={styles.dotProjectDiffPaneHeader}>Proposed {filename}</div>
+                <div className={styles.dotProjectSource}>
+                  {patchPreview.proposed.map((line) => (
+                    <div className={diffLineClassName(line.tone)} key={line.key}>
+                      <span className={diffLineNumberClassName(line.tone)}>{line.lineNumber ?? ""}</span>
+                      <code className={styles.dotProjectLineCode}>{renderYamlLine(line.text, line.key)}</code>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+          )}
+        </section>
+      ) : null}
     </div>
   );
 }

--- a/web/src/components/GitHubHandle.tsx
+++ b/web/src/components/GitHubHandle.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import styles from "./ProjectReconciliationCard.module.css";
+
+type GitHubHandleProps = {
+  id: number;
+  github: string;
+  name: string;
+  prefixName?: boolean;
+};
+
+export default function GitHubHandle({ id, github, name, prefixName = false }: GitHubHandleProps) {
+  const displayHandle = github.startsWith("@") ? github : `@${github}`;
+  const label = prefixName ? `${name} ${displayHandle}` : displayHandle;
+
+  return (
+    <a className={styles.githubHandle} href={`/maintainers/${id}`} title={name}>
+      <span>{label}</span>
+      <span className={styles.githubHandleTooltip} role="tooltip">
+        {name}
+      </span>
+    </a>
+  );
+}

--- a/web/src/components/ProjectReconciliationCard.module.css
+++ b/web/src/components/ProjectReconciliationCard.module.css
@@ -620,6 +620,57 @@
   color: var(--md-card-text-strong, #0b1220);
 }
 
+.dotProjectArtifactLink {
+  display: inline-grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 8px;
+  max-width: 100%;
+  color: var(--md-card-text-strong, #0b1220);
+  text-decoration: none;
+}
+
+.dotProjectArtifactLink:hover .dotProjectArtifactName,
+.dotProjectArtifactLink:hover .dotProjectArtifactUrl {
+  color: #d62293;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.dotProjectArtifactUrl {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--md-card-muted, rgba(15, 23, 42, 0.65));
+  font-size: 12px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.externalLinkIcon {
+  color: #d62293;
+  font-size: 13px;
+  line-height: 1;
+}
+
+.dotProjectMissingArtifact {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .dotProjectYamlViewer {
   display: flex;
   flex-direction: column;
@@ -687,6 +738,112 @@
   background: #fff7e6;
   font-size: 12px;
   line-height: 1.5;
+}
+
+.dotProjectYamlSuccess {
+  border: 1px solid var(--md-status-success-border, #86efac);
+  border-radius: 10px;
+  padding: 10px 12px;
+  color: var(--md-status-success-text, #166534);
+  background: var(--md-status-success-bg, #dcfce7);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.dotProjectDiffSummary {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 14px;
+  border: 1px solid #f4d08a;
+  border-radius: 12px;
+  padding: 12px;
+  color: #6d4d00;
+  background: #fff7e6;
+}
+
+.dotProjectDiffSummaryTitle {
+  margin: 0;
+  color: inherit;
+  font-size: 13px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.dotProjectDiffSummaryBody {
+  margin: 6px 0 0;
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.dotProjectDiffMaintainerList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.githubHandle {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid rgba(214, 34, 147, 0.28);
+  border-radius: 999px;
+  padding: 5px 9px;
+  background: rgba(214, 34, 147, 0.08);
+  color: #d62293;
+  font-size: 12px;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.githubHandle:hover,
+.githubHandle:focus-visible {
+  background: rgba(214, 34, 147, 0.14);
+  box-shadow: 0 0 0 2px rgba(214, 34, 147, 0.12);
+}
+
+.githubHandleTooltip {
+  position: absolute;
+  left: 50%;
+  bottom: calc(100% + 8px);
+  z-index: 20;
+  pointer-events: none;
+  transform: translateX(-50%) translateY(4px);
+  opacity: 0;
+  border: 1px solid var(--md-border, rgba(15, 23, 42, 0.14));
+  border-radius: 8px;
+  padding: 5px 8px;
+  background: var(--md-card-text-strong, #0b1220);
+  color: var(--md-card-bg, #ffffff);
+  font-size: 11px;
+  font-weight: 700;
+  white-space: nowrap;
+  transition: opacity 120ms ease, transform 120ms ease;
+}
+
+.githubHandle:hover .githubHandleTooltip,
+.githubHandle:focus-visible .githubHandleTooltip {
+  transform: translateX(-50%) translateY(0);
+  opacity: 1;
+}
+
+.dotProjectPreviewButton {
+  flex: 0 0 auto;
+  border: none;
+  border-radius: 999px;
+  padding: 8px 12px;
+  background: #d62293;
+  color: #ffffff;
+  font-size: 12px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: opacity 120ms ease, box-shadow 120ms ease;
+}
+
+.dotProjectPreviewButton:hover {
+  opacity: 0.92;
+  box-shadow: 0 6px 14px rgba(214, 34, 147, 0.35);
 }
 
 .dotProjectTeamGrid {
@@ -796,6 +953,74 @@
 .dotProjectLineCode {
   padding: 0 12px;
   white-space: pre;
+}
+
+.dotProjectPatchPreview {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  border-top: 1px solid var(--md-border, rgba(15, 23, 42, 0.1));
+  padding-top: 14px;
+}
+
+.dotProjectPatchHeader {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.dotProjectDiffGrid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: 12px;
+}
+
+.dotProjectDiffPane {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.dotProjectDiffPaneHeader {
+  border: 1px solid var(--md-border, rgba(15, 23, 42, 0.1));
+  border-bottom: none;
+  border-radius: 12px 12px 0 0;
+  padding: 8px 10px;
+  background: var(--md-surface, rgba(15, 23, 42, 0.04));
+  color: var(--md-card-text-strong, #0b1220);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.dotProjectDiffPane .dotProjectSource {
+  flex: 1 1 auto;
+  border-radius: 0 0 12px 12px;
+}
+
+.dotProjectDiffLineAdded {
+  background: rgba(22, 163, 74, 0.16);
+}
+
+.dotProjectDiffLineDeleted {
+  background: rgba(220, 38, 38, 0.16);
+}
+
+.dotProjectDiffLineEmpty {
+  opacity: 0.65;
+}
+
+.dotProjectLineNumberAdded {
+  color: #052e16;
+  background: #86efac;
+  border-right-color: rgba(22, 101, 52, 0.45);
+}
+
+.dotProjectLineNumberDeleted {
+  color: #450a0a;
+  background: #fca5a5;
+  border-right-color: rgba(153, 27, 27, 0.45);
 }
 
 .yamlTokenComment {
@@ -1367,6 +1592,25 @@
   color: #e0c6ff;
 }
 
+[data-theme="dark"] .dotProjectYamlValidation,
+[data-theme="dark"] .dotProjectDiffSummary {
+  background: rgba(120, 83, 13, 0.26);
+  border-color: rgba(251, 191, 36, 0.5);
+  color: #fde68a;
+}
+
+[data-theme="dark"] .dotProjectLineNumberAdded {
+  color: #052e16;
+  background: #4ade80;
+  border-right-color: rgba(187, 247, 208, 0.55);
+}
+
+[data-theme="dark"] .dotProjectLineNumberDeleted {
+  color: #450a0a;
+  background: #f87171;
+  border-right-color: rgba(254, 202, 202, 0.55);
+}
+
 [data-theme="dark"] .refMissing {
   background: #2a2012;
   border-color: #5b3c1b;
@@ -1411,6 +1655,14 @@
   .menuItem {
     flex: 1 1 45%;
     text-align: center;
+  }
+
+  .dotProjectDiffGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .dotProjectDiffSummary {
+    flex-direction: column;
   }
 }
 

--- a/web/src/components/ProjectReconciliationCard.tsx
+++ b/web/src/components/ProjectReconciliationCard.tsx
@@ -263,17 +263,6 @@ const isYamlRef = (value: string) => /\.(ya?ml)(\?|#|$)/i.test(value);
 const buildStatusBadgeClassName = (stylesMap: Record<string, string>, found: boolean) =>
   `${stylesMap.statusBadge} ${found ? stylesMap.statusOk : stylesMap.statusWarn}`;
 
-const shortenHash = (value?: string | null) => {
-  const trimmed = value?.trim() ?? "";
-  if (trimmed === "") {
-    return "Unavailable";
-  }
-  if (trimmed.length <= 16) {
-    return trimmed;
-  }
-  return `${trimmed.slice(0, 16)}…`;
-};
-
 export default function ProjectReconciliationCard({
   projectId,
   name,
@@ -333,8 +322,6 @@ export default function ProjectReconciliationCard({
   const dotProjectMaintainerCacheBody = dotProjectMaintainerCache?.body ?? "";
   const dotProjectMaintainerCacheFilename =
     dotProjectMaintainerCache?.filename || dotProjectMaintainersFilename || "maintainers.yaml";
-  const dotProjectMaintainerCacheCheckedAt =
-    dotProjectMaintainerCache?.lastCheckedAt || dotProjectLastCheckedAt || null;
   const dotProjectFiles = [
     {
       label: ".project repo",
@@ -895,19 +882,38 @@ export default function ProjectReconciliationCard({
 
   const dotProjectSection = (
     <div className={styles.section}>
-      <div className={styles.statusCallout}>
-        <div className={styles.statusCalloutTitle}>Persisted dot-project roll call</div>
-        <div className={styles.statusCalloutBody}>
-          Review the persisted <code>.project</code> discovery state captured by the background sync job.
+      {dotProjectMaintainerCacheBody.trim() ? (
+        <div className={styles.tableSection}>
+          <div className={styles.tableHeader}>
+            <h3 className={styles.tableTitle}>{dotProjectMaintainerCacheFilename}</h3>
+            {dotProjectMaintainerRef ? (
+              <a className={styles.link} href={dotProjectMaintainerRef} target="_blank" rel="noreferrer">
+                Open source file
+              </a>
+            ) : null}
+          </div>
+          <DotProjectMaintainerFileViewer
+            filename={dotProjectMaintainerCacheFilename}
+            maintainers={maintainers}
+            canEdit={canEdit}
+            onAddMissingMaintainer={(handle, refLine) => {
+              setDraft({
+                githubHandle: handle,
+                name: "",
+                email: "",
+                company: "",
+                companyMode: "select",
+                refLine,
+              });
+              setModalOpen(true);
+            }}
+            source={dotProjectMaintainerCacheBody}
+          />
         </div>
-        <div className={styles.statusCalloutMeta}>
-          Status: <strong>{dotProjectAdoptionStatus || "not_checked"}</strong>
-          {dotProjectLastCheckedAt ? ` · Last checked ${formatDateTime(dotProjectLastCheckedAt)}` : ""}
-        </div>
-      </div>
+      ) : null}
       <div className={styles.tableSection}>
         <div className={styles.tableHeader}>
-          <h3 className={styles.tableTitle}>Discovery summary</h3>
+          <h3 className={styles.tableTitle}>Discovery details</h3>
         </div>
         <div className={styles.dotProjectSummaryGrid}>
           <div className={styles.dotProjectSummaryCard}>
@@ -930,8 +936,8 @@ export default function ProjectReconciliationCard({
             </span>
           </div>
           <div className={styles.dotProjectSummaryCard}>
-            <span className={styles.detailLabel}>Maintainer filename</span>
-            <span className={styles.secondary}>{dotProjectMaintainersFilename}</span>
+            <span className={styles.detailLabel}>Last checked</span>
+            <span className={styles.secondary}>{formatDateTime(dotProjectLastCheckedAt)}</span>
           </div>
         </div>
       </div>
@@ -944,78 +950,36 @@ export default function ProjectReconciliationCard({
             <thead>
               <tr>
                 <th>Artifact</th>
-                <th>Status</th>
                 <th>Notes</th>
-                <th>Link</th>
               </tr>
             </thead>
             <tbody>
               {dotProjectFiles.map((file) => (
                 <tr key={file.label}>
-                  <td className={styles.dotProjectArtifactName}>{file.label}</td>
                   <td>
-                    <span className={buildStatusBadgeClassName(styles, file.present)}>
-                      {file.present ? "FOUND" : "MISSING"}
-                    </span>
-                  </td>
-                  <td>{file.detail}</td>
-                  <td>
-                    {file.href ? (
-                      <a className={styles.link} href={file.href} target="_blank" rel="noreferrer">
-                        Open
+                    {file.present && file.href ? (
+                      <a className={styles.dotProjectArtifactLink} href={file.href} target="_blank" rel="noreferrer">
+                        <span className={styles.dotProjectArtifactName}>{file.label}</span>
+                        <span className={styles.dotProjectArtifactUrl}>{file.href}</span>
+                        <span className={styles.externalLinkIcon} aria-hidden="true">
+                          ↗
+                        </span>
+                        <span className={styles.srOnly}>Opens on GitHub</span>
                       </a>
                     ) : (
-                      <span className={styles.secondary}>—</span>
+                      <span className={styles.dotProjectMissingArtifact}>
+                        <span className={styles.dotProjectArtifactName}>{file.label}</span>
+                        <span className={`${styles.statusBadge} ${styles.statusWarn}`}>NOT FOUND</span>
+                      </span>
                     )}
                   </td>
+                  <td>{file.detail}</td>
                 </tr>
               ))}
             </tbody>
           </table>
         </div>
       </div>
-      {dotProjectMaintainerCacheBody.trim() ? (
-        <div className={styles.tableSection}>
-          <div className={styles.tableHeader}>
-            <h3 className={styles.tableTitle}>Cached maintainer file</h3>
-          </div>
-          <div className={styles.dotProjectSummaryGrid}>
-            <div className={styles.dotProjectSummaryCard}>
-              <span className={styles.detailLabel}>Filename</span>
-              <span className={styles.secondary}>{dotProjectMaintainerCacheFilename}</span>
-            </div>
-            <div className={styles.dotProjectSummaryCard}>
-              <span className={styles.detailLabel}>Cached at</span>
-              <span className={styles.secondary}>{formatDateTime(dotProjectMaintainerCacheCheckedAt)}</span>
-            </div>
-            <div className={styles.dotProjectSummaryCard}>
-              <span className={styles.detailLabel}>ETag</span>
-              <span className={styles.secondary}>{dotProjectMaintainerCache?.etag?.trim() || "Unavailable"}</span>
-            </div>
-            <div className={styles.dotProjectSummaryCard}>
-              <span className={styles.detailLabel}>Body hash</span>
-              <span className={styles.secondary}>{shortenHash(dotProjectMaintainerCache?.bodyHash)}</span>
-            </div>
-          </div>
-          <DotProjectMaintainerFileViewer
-            filename={dotProjectMaintainerCacheFilename}
-            maintainers={maintainers}
-            canEdit={canEdit}
-            onAddMissingMaintainer={(handle, refLine) => {
-              setDraft({
-                githubHandle: handle,
-                name: "",
-                email: "",
-                company: "",
-                companyMode: "select",
-                refLine,
-              });
-              setModalOpen(true);
-            }}
-            source={dotProjectMaintainerCacheBody}
-          />
-        </div>
-      ) : null}
       {dotProjectSyncState?.syncError || dotProjectSyncState?.parseError ? (
         <div className={styles.statusCallout}>
           <div className={styles.statusCalloutTitle}>Recorded sync issues</div>

--- a/web/tests/steps/project_routes.steps.js
+++ b/web/tests/steps/project_routes.steps.js
@@ -89,30 +89,46 @@ Then("the project route navigation shows a green tick on DOT-PROJECT ROLL CALL",
 
 Then("the dot-project roll call shows the persisted discovery summary", async function () {
   const contentColumn = this.page.locator('[class*="contentColumn"]');
-  await expect(contentColumn.getByText("Persisted dot-project roll call", { exact: true })).toBeVisible({
+  await expect(contentColumn.getByText("Discovery details", { exact: true })).toBeVisible({
     timeout: 15000,
   });
   await expect(contentColumn.getByText("Schema version", { exact: true })).toBeVisible({ timeout: 15000 });
   await expect(contentColumn.getByText("1.0.0", { exact: true })).toBeVisible({ timeout: 15000 });
   await expect(contentColumn.getByText("Maintainer count", { exact: true })).toBeVisible({ timeout: 15000 });
-  await expect(contentColumn.getByText("4 maintainers", { exact: true })).toBeVisible({ timeout: 15000 });
+  await expect(
+    contentColumn.locator('[class*="dotProjectSummaryCard"]').filter({ hasText: "Maintainer count" }).getByText("3", {
+      exact: true,
+    })
+  ).toBeVisible({ timeout: 15000 });
 });
 
 Then("the dot-project roll call lists the tracked .project files", async function () {
   const contentColumn = this.page.locator('[class*="contentColumn"]');
   const trackedFilesTable = contentColumn.locator("table").first();
-  for (const label of [
-    ".project repo",
-    "project.yaml",
-    "MAINTAINERS.yaml",
-    "SECURITY.md",
-    "CONTRIBUTING.md",
-    "GOVERNANCE.md",
-  ]) {
-    await expect(trackedFilesTable.getByRole("cell", { name: label, exact: true })).toBeVisible({
-      timeout: 15000,
-    });
+  await expect(trackedFilesTable.getByRole("columnheader", { name: "Artifact", exact: true })).toBeVisible({
+    timeout: 15000,
+  });
+  await expect(trackedFilesTable.getByRole("columnheader", { name: "Notes", exact: true })).toBeVisible({
+    timeout: 15000,
+  });
+  await expect(trackedFilesTable.getByRole("columnheader", { name: "Status", exact: true })).toHaveCount(0);
+  await expect(trackedFilesTable.getByRole("columnheader", { name: "Link", exact: true })).toHaveCount(0);
+  for (const label of [".project repo", "project.yaml", "MAINTAINERS.yaml", "SECURITY.md"]) {
+    const link = trackedFilesTable.getByRole("link", { name: new RegExp(label.replace(".", "\\.")) });
+    await expect(link).toBeVisible({ timeout: 15000 });
+    await expect(link).toHaveAttribute("href", /https:\/\/github\.com\/project-atlas\/\.project/);
   }
+  await expect(
+    trackedFilesTable
+      .getByRole("row", { name: /\.project repo/ })
+      .getByText("https://github.com/project-atlas/.project", { exact: true })
+  ).toBeVisible({ timeout: 15000 });
+  await expect(trackedFilesTable.getByRole("cell", { name: /CONTRIBUTING\.md NOT FOUND/ })).toBeVisible({
+    timeout: 15000,
+  });
+  await expect(trackedFilesTable.getByRole("cell", { name: /GOVERNANCE\.md NOT FOUND/ })).toBeVisible({
+    timeout: 15000,
+  });
 });
 
 Then("the dot-project roll call renders the cached maintainer file as formatted YAML", async function () {
@@ -143,7 +159,23 @@ Then("the dot-project roll call renders the cached maintainer file as formatted 
   });
   await expect(modal.getByLabel("GitHub Handle")).toHaveValue("unmapped-dotproject", { timeout: 15000 });
   await modal.getByRole("button", { name: "Close" }).click();
-  await expect(viewer.locator('[class*="yamlTokenComment"]')).toContainText(
+  await expect(viewer.getByLabel("MAINTAINERS.yaml source").locator('[class*="yamlTokenComment"]')).toContainText(
     "# Project Atlas dot-project maintainers"
   );
+  const missingDbMaintainer = viewer.getByRole("link", { name: /Alex Example @alex-example/ });
+  await expect(missingDbMaintainer).toBeVisible({
+    timeout: 15000,
+  });
+  await expect(missingDbMaintainer).toHaveAttribute("href", /\/maintainers\/3$/);
+  await expect(missingDbMaintainer).toHaveAttribute("title", "Alex Example");
+  await expect(viewer.getByRole("button", { name: "Hide PR Preview" })).toBeVisible({ timeout: 15000 });
+  const preview = viewer.locator('[aria-label="Pull request preview"]');
+  await expect(preview.getByText("Existing MAINTAINERS.yaml")).toBeVisible({ timeout: 15000 });
+  await expect(preview.getByText("Proposed MAINTAINERS.yaml")).toBeVisible({ timeout: 15000 });
+  await expect(preview.locator('[class*="dotProjectLineNumberAdded"]').getByText("9", { exact: true })).toBeVisible({
+    timeout: 15000,
+  });
+  await expect(preview.locator('[class*="dotProjectDiffLineAdded"]').getByText("alex-example")).toBeVisible({
+    timeout: 15000,
+  });
 });


### PR DESCRIPTION
 - Compares active project maintainers in maintainer-d against the members of the `project-maintainers` team only.
 - Shows active maintainers that exist in maintainer-d but are missing from `maintainers.yaml`.
 - Adds a `Create Pull Request` action that patches the rendered file in the UI preview with the missing GitHub handles.
 - Renders a suggested updated `maintainers.yaml` preview that respects the existing comments, formatting, and ordering as much as possible. Have the suggested update appear in a side-by-side presentation of the proposed changes. For lines that are to be added to by the PR give those line numbers a green backgroud on the proposed PR, for lines being deleted from the file, make the line numbers background red on the existing file. As much as possible make the side-by-side presentation intuitive for a human read to proposed PR improves the file.

 Operational goals:

 - Replicates the existing roll-call diff behavior for dot-project, but in a better UI.
 - Keeps the preview faithful to the original file so maintainers can trust the generated patch.

 Implementation report:

 - The formatted maintainer-file viewer now compares active maintainer-d project maintainers against the `project-maintainers` team parsed from cached `maintainers.yaml`.
 - When active maintainer-d maintainers are missing from the file, the UI shows a DB-vs-file summary and a side-by-side PR preview.
 - The preview inserts the missing GitHub handles into the existing `members:` list without rewriting the rest of the file, preserving comments, formatting, and surrounding line order.
 - The proposed patch is rendered side-by-side with line numbers; added proposed lines are highlighted green and the existing side leaves aligned blank rows for readability.
 - The seeded web BDD fixture now includes one maintainer-d active maintainer missing from `MAINTAINERS.yaml` so the preview path is covered.

 Layout follow-up:

 - Make the cached `maintainers.yaml` body the primary focus of the DOT-PROJECT ROLL CALL page.
 - Render the maintainer file before discovery and tracked-file implementation details.
 - Remove the prototype-oriented `Persisted dot-project roll call` callout from the end-user route.
 - Hide cache metadata such as ETag and body hash from the primary page layout.
 - Show the proposed PR diff by default whenever maintainer-d has active maintainers missing from the `project-maintainers` team.
 - Keep GitHub PR creation out of this layout step; the button must not claim to create a PR until Commit F wires the backend write path.