### PR TITLE
adds UAT refinements to maintainers.yaml PR workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1582,27 +1582,18 @@ ci-local:
 	NPROC=$$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4); \
 	export GOCACHE=$(GOCACHE_DIR); \
 	export GOLANGCI_LINT_CACHE=/tmp/golangci-lint; \
-	echo "→ Running all checks in parallel on $$NPROC cores..."; \
-	pids=""; \
-	run() { \
-		local name="$$1"; shift; \
-		( "$$@" && echo "✓ $$name" || { echo "✗ $$name FAILED"; exit 1; } ) & \
-		pids="$$pids $$!"; \
-	}; \
-	run "go vet"        go vet ./...; \
-	run "staticcheck"   staticcheck ./...; \
-	run "golangci-lint" golangci-lint run ./...; \
-	run "go test -race" go test -race -p "$$NPROC" -coverprofile=coverage.out -covermode=atomic ./...; \
-	run "web lint"      npm --prefix web run lint -- --max-warnings=$(ESLINT_MAX_WARNINGS); \
-	run "web typecheck" npm --prefix web run typecheck; \
-	( MD_DB_DRIVER=postgres MD_DB_DSN="$$MD_DB_DSN" WEB_BDD_USE_MICROCKS=true NO_BDD_OPEN=1 $(MAKE) web-bdd \
-		&& echo "✓ web BDD" || { echo "✗ web BDD FAILED"; exit 1; } ) & \
-	pids="$$pids $$!"; \
-	fail=0; \
-	for pid in $$pids; do \
-		wait "$$pid" || fail=1; \
-	done; \
-	[ $$fail -eq 0 ] || { echo "❌ One or more CI checks failed"; exit 1; }; \
+	echo "→ Running all checks sequentially..."; \
+	go vet ./...                  && echo "✓ go vet"; \
+	npm --prefix web run lint -- --max-warnings=$(ESLINT_MAX_WARNINGS) \
+	                              && echo "✓ web lint"; \
+	npm --prefix web run typecheck \
+	                              && echo "✓ web typecheck"; \
+	staticcheck ./...             && echo "✓ staticcheck"; \
+	golangci-lint run ./...       && echo "✓ golangci-lint"; \
+	go test -race -p "$$NPROC" -coverprofile=coverage.out -covermode=atomic ./... \
+	                              && echo "✓ go test -race"; \
+	MD_DB_DRIVER=postgres MD_DB_DSN="$$MD_DB_DSN" WEB_BDD_USE_MICROCKS=true NO_BDD_OPEN=1 $(MAKE) web-bdd \
+	                              && echo "✓ web BDD"; \
 	echo "→ Coverage report:"; \
 	go tool cover -func=coverage.out | tail -n 1; \
 	echo "✅ All CI checks passed!"; \

--- a/cmd/web-bff/main.go
+++ b/cmd/web-bff/main.go
@@ -5640,11 +5640,17 @@ func (s *server) createDotProjectMaintainerPullRequest(ctx context.Context, inpu
 		return nil, fmt.Errorf("create branch in fork %s/%s: %w", forkOwner, forkRepo, err)
 	}
 
+	commitAuthor, err := dotProjectCommitAuthor(ctx, client, input)
+	if err != nil {
+		return nil, err
+	}
 	contentResponse, _, err := client.Repositories.UpdateFile(ctx, forkOwner, forkRepo, input.FilePath, &github.RepositoryContentFileOptions{
-		Message: github.String(fmt.Sprintf("Update %s maintainers", input.ProjectName)),
-		Content: []byte(input.Proposed),
-		SHA:     github.String(content.GetSHA()),
-		Branch:  github.String(input.HeadBranch),
+		Message:   github.String(dotProjectMaintainerCommitMessage(input.ProjectName, commitAuthor)),
+		Content:   []byte(input.Proposed),
+		SHA:       github.String(content.GetSHA()),
+		Branch:    github.String(input.HeadBranch),
+		Author:    commitAuthor,
+		Committer: commitAuthor,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("update maintainer file in fork %s/%s: %w", forkOwner, forkRepo, err)
@@ -5659,6 +5665,16 @@ func (s *server) createDotProjectMaintainerPullRequest(ctx context.Context, inpu
 	})
 	if err != nil {
 		return nil, fmt.Errorf("create pull request: %w", err)
+	}
+	reviewers := dotProjectMaintainerReviewers(input.AddedHandles)
+	teamReviewers := dotProjectMaintainerTeamReviewers()
+	if len(reviewers) > 0 || len(teamReviewers) > 0 {
+		if _, _, err := client.PullRequests.RequestReviewers(ctx, input.Owner, input.Repo, pr.GetNumber(), github.ReviewersRequest{
+			Reviewers:     reviewers,
+			TeamReviewers: teamReviewers,
+		}); err != nil {
+			return nil, fmt.Errorf("request maintainer reviews: %w", err)
+		}
 	}
 
 	commitSHA := ""
@@ -5744,6 +5760,44 @@ func waitForDotProjectFork(ctx context.Context, client *github.Client, forkOwner
 	return nil, fmt.Errorf("fork %s/%s was not ready before timeout", forkOwner, forkRepo)
 }
 
+func dotProjectCommitAuthor(ctx context.Context, client *github.Client, input dotProjectPullRequestInput) (*github.CommitAuthor, error) {
+	user, _, err := client.Users.Get(ctx, "")
+	if err != nil {
+		return nil, fmt.Errorf("load github user for commit sign-off: %w", err)
+	}
+	name := strings.TrimSpace(user.GetName())
+	if name == "" {
+		name = strings.TrimSpace(input.SubmittedByName)
+	}
+	if name == "" {
+		name = strings.TrimSpace(input.SubmittedByLogin)
+	}
+	email := strings.TrimSpace(user.GetEmail())
+	if email == "" && user.GetID() > 0 && strings.TrimSpace(user.GetLogin()) != "" {
+		email = fmt.Sprintf("%d+%s@users.noreply.github.com", user.GetID(), strings.TrimSpace(user.GetLogin()))
+	}
+	if email == "" && strings.TrimSpace(input.SubmittedByLogin) != "" {
+		email = strings.TrimSpace(input.SubmittedByLogin) + "@users.noreply.github.com"
+	}
+	if name == "" || email == "" {
+		return nil, fmt.Errorf("github user name and email are required for commit sign-off")
+	}
+	return &github.CommitAuthor{
+		Name:  github.String(name),
+		Email: github.String(email),
+	}, nil
+}
+
+func dotProjectMaintainerCommitMessage(projectName string, author *github.CommitAuthor) string {
+	name := ""
+	email := ""
+	if author != nil {
+		name = strings.TrimSpace(author.GetName())
+		email = strings.TrimSpace(author.GetEmail())
+	}
+	return fmt.Sprintf("Update %s maintainers\n\nSigned-off-by: %s <%s>", strings.TrimSpace(projectName), name, email)
+}
+
 func repositoryIsForkOf(repo *github.Repository, upstreamOwner, upstreamRepo string) bool {
 	if repo == nil || !repo.GetFork() || repo.Parent == nil {
 		return false
@@ -5803,7 +5857,7 @@ func buildDotProjectPullRequestBody(input dotProjectPullRequestInput) string {
 		"Changes:",
 	}
 	if len(input.AddedHandles) > 0 {
-		lines = append(lines, fmt.Sprintf("- Add active maintainer-d handles missing from `%s`: %s", input.FilePath, strings.Join(input.AddedHandles, ", ")))
+		lines = append(lines, fmt.Sprintf("- Add active maintainer-d handles missing from `%s`: %s", input.FilePath, strings.Join(dotProjectMentionedMaintainers(input.AddedHandles), ", ")))
 	}
 	if len(input.RemovedPlaceholders) > 0 {
 		lines = append(lines, fmt.Sprintf("- Remove placeholder maintainer lines: %s", strings.Join(input.RemovedPlaceholders, ", ")))
@@ -5816,6 +5870,36 @@ func buildDotProjectPullRequestBody(input dotProjectPullRequestInput) string {
 		lines = append(lines, fmt.Sprintf("Cached source body hash: `%s`", input.OriginalBodyHash))
 	}
 	return strings.Join(lines, "\n")
+}
+
+func dotProjectMentionedMaintainers(handles []string) []string {
+	reviewers := dotProjectMaintainerReviewers(handles)
+	mentions := make([]string, 0, len(reviewers))
+	for _, reviewer := range reviewers {
+		mentions = append(mentions, "@"+reviewer)
+	}
+	return mentions
+}
+
+func dotProjectMaintainerReviewers(handles []string) []string {
+	reviewers := make([]string, 0, len(handles))
+	seen := make(map[string]struct{}, len(handles))
+	for _, raw := range handles {
+		handle := dotproject.NormalizeGitHubHandle(raw)
+		if handle == "" {
+			continue
+		}
+		if _, ok := seen[handle]; ok {
+			continue
+		}
+		seen[handle] = struct{}{}
+		reviewers = append(reviewers, handle)
+	}
+	return reviewers
+}
+
+func dotProjectMaintainerTeamReviewers() []string {
+	return []string{"cncf-projects"}
 }
 
 func groupCompanyDuplicates(companies []companyDetailResponse) []companyDuplicateGroup {

--- a/cmd/web-bff/main_test.go
+++ b/cmd/web-bff/main_test.go
@@ -15,6 +15,7 @@ import (
 	"maintainerd/db"
 	"maintainerd/model"
 
+	"github.com/google/go-github/v55/github"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
@@ -476,6 +477,34 @@ func TestDotProjectForkRepoNamePrefixesSourceRepoWithProjectSlug(t *testing.T) {
 	assert.Equal(t, "cohdi.project", dotProjectForkRepoName("CoHDI", ".project"))
 	assert.Equal(t, "cadence-workflow.project", dotProjectForkRepoName("Cadence Workflow", ".project"))
 	assert.Equal(t, "project.project", dotProjectForkRepoName("...", ".project"))
+}
+
+func TestDotProjectMaintainerCommitMessageIncludesDCOSignoff(t *testing.T) {
+	message := dotProjectMaintainerCommitMessage("CoHDI", &github.CommitAuthor{
+		Name:  github.String("Robert Kielty"),
+		Email: github.String("123+RobertKielty@users.noreply.github.com"),
+	})
+
+	assert.Equal(t, "Update CoHDI maintainers\n\nSigned-off-by: Robert Kielty <123+RobertKielty@users.noreply.github.com>", message)
+}
+
+func TestBuildDotProjectPullRequestBodyMentionsAddedMaintainers(t *testing.T) {
+	body := buildDotProjectPullRequestBody(dotProjectPullRequestInput{
+		FilePath:            "MAINTAINERS.yaml",
+		AddedHandles:        []string{"alice", "@Bob", "alice"},
+		RemovedPlaceholders: []string{"# TODO: Add maintainer handles"},
+		SubmittedByName:     "Staff Tester",
+		SubmittedByLogin:    "staff-tester",
+	})
+
+	assert.Contains(t, body, "Changes:\n- Add active maintainer-d handles missing from `MAINTAINERS.yaml`: @alice, @bob")
+	assert.Contains(t, body, "- Remove placeholder maintainer lines: # TODO: Add maintainer handles")
+	assert.NotContains(t, body, "@@")
+}
+
+func TestDotProjectMaintainerReviewersNormalizesHandles(t *testing.T) {
+	assert.Equal(t, []string{"alice", "bob"}, dotProjectMaintainerReviewers([]string{"@Alice", "bob", "alice", ""}))
+	assert.Equal(t, []string{"cncf-projects"}, dotProjectMaintainerTeamReviewers())
 }
 
 func TestMaintainerServiceAssociationsForStaff(t *testing.T) {

--- a/dot-project.md
+++ b/dot-project.md
@@ -693,6 +693,11 @@ Implementation report:
 - The proposed PR removes placeholder lines such as `# TODO: Add maintainer GitHub handles` and `- github-handle`.
 - The GitHub write path uses the signed-in staff member’s OAuth token, creates or reuses a project-prefixed fork, updates the maintainer file on a generated branch in that fork, and opens a pull request against the upstream project `.project` repository.
 - The GitHub OAuth login scope now includes `public_repo`; existing sessions must sign out and sign in again before submitting dot-project PRs.
+- Generated commits include a `Signed-off-by` trailer that matches the signed-in GitHub user so repository DCO checks can pass.
+- Refinements tracked in [cncf/maintainer-d#114](https://github.com/cncf/maintainer-d/issues/114):
+  - Added maintainer handles are rendered as GitHub mentions in the PR body `Changes:` section, for example `@alice`, so maintainers are notified and reviewers can open maintainer profiles directly.
+  - The GitHub write path requests review from each maintainer added to the update and from the `@cncf/cncf-projects` team.
+  - The proposed PR also removes the shorter placeholder comment `# TODO: Add maintainer handles` when it is present in the maintainer file.
 - PR creation is recorded in the audit log with the submitting staff member and PR metadata.
 - The dot-project UI now exposes a real `Submit Pull Request` action from the preview and shows the resulting PR details.
 

--- a/dotproject/maintainers_patch.go
+++ b/dotproject/maintainers_patch.go
@@ -18,7 +18,7 @@ var (
 	projectMaintainersNameRE = regexp.MustCompile(`(?i)^\s*(?:-\s*)?name:\s*["']?project-maintainers["']?\s*(?:#.*)?$`)
 	membersLineRE            = regexp.MustCompile(`(?i)^\s*members:\s*(?:#.*)?$`)
 	sequenceItemRE           = regexp.MustCompile(`^\s*-\s*(\S+)\s*(?:#.*)?$`)
-	todoMaintainerHandlesRE  = regexp.MustCompile(`(?i)^\s*#\s*TODO:\s*Add maintainer GitHub handles\s*$`)
+	todoMaintainerHandlesRE  = regexp.MustCompile(`(?i)^\s*#\s*TODO:\s*Add maintainer (?:GitHub )?handles\s*$`)
 )
 
 func BuildMaintainerRosterPatch(source string, activeHandles []string) (*MaintainerPatch, error) {

--- a/dotproject/maintainers_patch_test.go
+++ b/dotproject/maintainers_patch_test.go
@@ -13,6 +13,7 @@ func TestBuildMaintainerRosterPatchAddsMissingMaintainersAndRemovesPlaceholders(
       - name: project-maintainers
         members:
           # TODO: Add maintainer GitHub handles
+          # TODO: Add maintainer handles
           - github-handle
           - alice
 `
@@ -21,7 +22,7 @@ func TestBuildMaintainerRosterPatchAddsMissingMaintainersAndRemovesPlaceholders(
 	require.NoError(t, err)
 
 	assert.Equal(t, []string{"bob", "carol"}, patch.AddedHandles)
-	assert.Equal(t, []string{"# TODO: Add maintainer GitHub handles", "- github-handle"}, patch.RemovedPlaceholders)
+	assert.Equal(t, []string{"# TODO: Add maintainer GitHub handles", "# TODO: Add maintainer handles", "- github-handle"}, patch.RemovedPlaceholders)
 	assert.Equal(t, `maintainers:
   - teams:
       - name: project-maintainers


### PR DESCRIPTION
Adds the following refinements based on yesterday's UAT for #114 

-   signs commits on the PR so that DCO checks pass
-   removes TODOs pertaining to adding maintainers 
-   mentions maintainers in first PR comment
-   requests review from project maintainers and @cncf/cncf-projects
-   serialises make ci-local tasks