### PR TITLE
shows open dot-project maintainer pull request on the dot-project page

### DIFF
--- a/cmd/web-bff/main.go
+++ b/cmd/web-bff/main.go
@@ -96,6 +96,7 @@ type server struct {
 	onboardingCache             *onboardingIssueCache
 	fetchIssues                 func(ctx context.Context) ([]onboardingIssueSummary, error)
 	createDotProjectPullRequest func(ctx context.Context, input dotProjectPullRequestInput, githubToken string) (*dotProjectPullRequestResponse, error)
+	githubClient                func(ctx context.Context, token string) *github.Client
 	fossaTeamCacheMu            sync.RWMutex
 	fossaTeamCache              map[uint]cachedFossaTeam
 }
@@ -684,6 +685,7 @@ type projectDetailResponse struct {
 	DotProjectAdoptionStatus  string                         `json:"dotProjectAdoptionStatus,omitempty"`
 	DotProjectSyncState       *dotProjectSyncStateResponse   `json:"dotProjectSyncState,omitempty"`
 	DotProjectMaintainerCache *dotProjectMaintainerCacheBody `json:"dotProjectMaintainerCache,omitempty"`
+	DotProjectMaintainerPR    *dotProjectMaintainerPRStatus  `json:"dotProjectMaintainerPullRequest,omitempty"`
 	RefStatus                 maintainerRefStatus            `json:"maintainerRefStatus"`
 	LegacyMaintainerRefBody   string                         `json:"legacyMaintainerRefBody,omitempty"`
 	RefOnlyGitHub             []string                       `json:"refOnlyGitHub"`
@@ -725,6 +727,30 @@ type dotProjectMaintainerCacheBody struct {
 	BodyHash      string     `json:"bodyHash,omitempty"`
 	Body          string     `json:"body,omitempty"`
 	LastCheckedAt *time.Time `json:"lastCheckedAt,omitempty"`
+}
+
+type dotProjectMaintainerPRStatus struct {
+	Status    string     `json:"status"`
+	URL       string     `json:"url,omitempty"`
+	Number    int        `json:"number,omitempty"`
+	Title     string     `json:"title,omitempty"`
+	Author    string     `json:"author,omitempty"`
+	Source    string     `json:"source,omitempty"`
+	CreatedAt *time.Time `json:"createdAt,omitempty"`
+	UpdatedAt *time.Time `json:"updatedAt,omitempty"`
+	Warning   string     `json:"warning,omitempty"`
+}
+
+type dotProjectPRAuditMetadata struct {
+	PullRequest struct {
+		URL    string `json:"url"`
+		Number int    `json:"number"`
+	} `json:"pull_request"`
+	Repository struct {
+		Owner string `json:"owner"`
+		Repo  string `json:"repo"`
+		Path  string `json:"path"`
+	} `json:"repository"`
 }
 
 func (s *server) handleProjects(w http.ResponseWriter, r *http.Request) {
@@ -1442,6 +1468,19 @@ func (s *server) handleProject(w http.ResponseWriter, r *http.Request) {
 			}
 			response.DotProjectMaintainerCache = maintainerCache
 		}
+		maintainerFilePath := strings.TrimSpace(dotProjectSyncState.MaintainersFilename)
+		if maintainerFilePath == "" {
+			maintainerFilePath = pathpkg.Base(strings.TrimSpace(project.DotProjectMaintainerRef))
+		}
+		owner := strings.TrimSpace(project.GitHubOrg)
+		if owner == "" {
+			if parsedOwner, err := parseGitHubOrgFromURL(project.DotProjectMaintainerRef); err == nil {
+				owner = parsedOwner
+			}
+		}
+		if status := s.dotProjectMaintainerPullRequestStatus(r.Context(), project.ID, owner, ".project", maintainerFilePath, session.AccessToken); status != nil {
+			response.DotProjectMaintainerPR = status
+		}
 	}
 	if project.OnboardingIssue != nil {
 		onboardingIssue := strings.TrimSpace(*project.OnboardingIssue)
@@ -1863,7 +1902,6 @@ func (s *server) handleDotProjectPullRequest(w http.ResponseWriter, r *http.Requ
 		result.ForkRepo = input.ForkRepo
 	}
 	result.ProjectMaintainerRef = input.ProjectMaintainerRef
-
 	metadata := map[string]any{
 		"actor": map[string]string{
 			"login": session.Login,
@@ -5567,6 +5605,133 @@ func parseGitHubOrgFromURL(raw string) (string, error) {
 	return parts[0], nil
 }
 
+func (s *server) dotProjectMaintainerPullRequestStatus(ctx context.Context, projectID uint, owner, repo, filePath, githubToken string) *dotProjectMaintainerPRStatus {
+	owner = strings.TrimSpace(owner)
+	repo = strings.TrimSpace(repo)
+	filePath = normalizeGitHubPath(filePath)
+	if owner == "" || repo == "" || filePath == "" {
+		return nil
+	}
+	client := s.githubClientForToken(ctx, firstNonEmpty(githubToken, s.githubToken))
+	if status := s.auditedDotProjectMaintainerPullRequestStatus(ctx, client, projectID, owner, repo, filePath); status != nil {
+		return status
+	}
+	status, err := openGitHubMaintainerPullRequestStatus(ctx, client, owner, repo, filePath)
+	if err != nil {
+		s.logger.Printf("web-bff: dot-project open maintainer PR lookup failed project=%d owner=%s repo=%s path=%s err=%v", projectID, owner, repo, filePath, err)
+		return &dotProjectMaintainerPRStatus{
+			Status:  "unknown",
+			Warning: "Unable to check GitHub for open maintainer-file pull requests.",
+		}
+	}
+	return status
+}
+
+func (s *server) auditedDotProjectMaintainerPullRequestStatus(ctx context.Context, client *github.Client, projectID uint, owner, repo, filePath string) *dotProjectMaintainerPRStatus {
+	var audits []model.AuditLog
+	if err := s.store.DB().
+		Where("project_id = ? AND action = ?", projectID, "DOT_PROJECT_MAINTAINER_PR_CREATE").
+		Order("created_at DESC").
+		Limit(20).
+		Find(&audits).Error; err != nil {
+		s.logger.Printf("web-bff: dot-project PR audit lookup failed project=%d err=%v", projectID, err)
+		return nil
+	}
+	for _, audit := range audits {
+		var metadata dotProjectPRAuditMetadata
+		if err := json.Unmarshal([]byte(audit.Metadata), &metadata); err != nil {
+			continue
+		}
+		if !sameGitHubRepo(metadata.Repository.Owner, metadata.Repository.Repo, owner, repo) || !sameGitHubPath(metadata.Repository.Path, filePath) || metadata.PullRequest.Number <= 0 {
+			continue
+		}
+		pr, _, err := client.PullRequests.Get(ctx, owner, repo, metadata.PullRequest.Number)
+		if err != nil {
+			s.logger.Printf("web-bff: dot-project audited PR lookup failed project=%d owner=%s repo=%s number=%d err=%v", projectID, owner, repo, metadata.PullRequest.Number, err)
+			continue
+		}
+		if pr.GetState() == "open" {
+			return dotProjectMaintainerStatusFromPullRequest(pr, "maintainer-d")
+		}
+	}
+	return nil
+}
+
+func openGitHubMaintainerPullRequestStatus(ctx context.Context, client *github.Client, owner, repo, filePath string) (*dotProjectMaintainerPRStatus, error) {
+	pulls, _, err := client.PullRequests.List(ctx, owner, repo, &github.PullRequestListOptions{
+		State:     "open",
+		Sort:      "updated",
+		Direction: "desc",
+		ListOptions: github.ListOptions{
+			PerPage: 20,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	for _, pr := range pulls {
+		files, _, err := client.PullRequests.ListFiles(ctx, owner, repo, pr.GetNumber(), &github.ListOptions{PerPage: 100})
+		if err != nil {
+			return nil, err
+		}
+		for _, file := range files {
+			if sameGitHubPath(file.GetFilename(), filePath) {
+				return dotProjectMaintainerStatusFromPullRequest(pr, "github"), nil
+			}
+		}
+	}
+	return nil, nil
+}
+
+func dotProjectMaintainerStatusFromPullRequest(pr *github.PullRequest, source string) *dotProjectMaintainerPRStatus {
+	if pr == nil {
+		return nil
+	}
+	createdAt := pr.GetCreatedAt().Time
+	updatedAt := pr.GetUpdatedAt().Time
+	return &dotProjectMaintainerPRStatus{
+		Status:    pr.GetState(),
+		URL:       pr.GetHTMLURL(),
+		Number:    pr.GetNumber(),
+		Title:     pr.GetTitle(),
+		Author:    pr.GetUser().GetLogin(),
+		Source:    source,
+		CreatedAt: &createdAt,
+		UpdatedAt: &updatedAt,
+	}
+}
+
+func (s *server) githubClientForToken(ctx context.Context, token string) *github.Client {
+	if s.githubClient != nil {
+		return s.githubClient(ctx, token)
+	}
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return github.NewClient(nil)
+	}
+	return github.NewClient(oauth2.NewClient(ctx, oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})))
+}
+
+func sameGitHubRepo(leftOwner, leftRepo, rightOwner, rightRepo string) bool {
+	return strings.EqualFold(strings.TrimSpace(leftOwner), strings.TrimSpace(rightOwner)) && strings.EqualFold(strings.TrimSpace(leftRepo), strings.TrimSpace(rightRepo))
+}
+
+func sameGitHubPath(left, right string) bool {
+	return strings.EqualFold(normalizeGitHubPath(left), normalizeGitHubPath(right))
+}
+
+func normalizeGitHubPath(value string) string {
+	value = strings.TrimSpace(strings.ReplaceAll(value, "\\", "/"))
+	if value == "" {
+		return ""
+	}
+	cleaned := pathpkg.Clean(value)
+	if cleaned == "." || cleaned == "/" {
+		return ""
+	}
+	return strings.TrimPrefix(cleaned, "/")
+}
+
 func (s *server) fetchIssueTitleFromGitHub(ctx context.Context, owner, repo string, number int) (string, error) {
 	client := github.NewClient(oauth2.NewClient(ctx, oauth2.StaticTokenSource(&oauth2.Token{
 		AccessToken: s.githubToken,
@@ -5665,16 +5830,6 @@ func (s *server) createDotProjectMaintainerPullRequest(ctx context.Context, inpu
 	})
 	if err != nil {
 		return nil, fmt.Errorf("create pull request: %w", err)
-	}
-	reviewers := dotProjectMaintainerReviewers(input.AddedHandles)
-	teamReviewers := dotProjectMaintainerTeamReviewers()
-	if len(reviewers) > 0 || len(teamReviewers) > 0 {
-		if _, _, err := client.PullRequests.RequestReviewers(ctx, input.Owner, input.Repo, pr.GetNumber(), github.ReviewersRequest{
-			Reviewers:     reviewers,
-			TeamReviewers: teamReviewers,
-		}); err != nil {
-			return nil, fmt.Errorf("request maintainer reviews: %w", err)
-		}
 	}
 
 	commitSHA := ""
@@ -5873,16 +6028,16 @@ func buildDotProjectPullRequestBody(input dotProjectPullRequestInput) string {
 }
 
 func dotProjectMentionedMaintainers(handles []string) []string {
-	reviewers := dotProjectMaintainerReviewers(handles)
-	mentions := make([]string, 0, len(reviewers))
-	for _, reviewer := range reviewers {
-		mentions = append(mentions, "@"+reviewer)
+	mentionHandles := dotProjectMaintainerMentionHandles(handles)
+	mentions := make([]string, 0, len(mentionHandles))
+	for _, handle := range mentionHandles {
+		mentions = append(mentions, "@"+handle)
 	}
 	return mentions
 }
 
-func dotProjectMaintainerReviewers(handles []string) []string {
-	reviewers := make([]string, 0, len(handles))
+func dotProjectMaintainerMentionHandles(handles []string) []string {
+	mentionHandles := make([]string, 0, len(handles))
 	seen := make(map[string]struct{}, len(handles))
 	for _, raw := range handles {
 		handle := dotproject.NormalizeGitHubHandle(raw)
@@ -5893,13 +6048,9 @@ func dotProjectMaintainerReviewers(handles []string) []string {
 			continue
 		}
 		seen[handle] = struct{}{}
-		reviewers = append(reviewers, handle)
+		mentionHandles = append(mentionHandles, handle)
 	}
-	return reviewers
-}
-
-func dotProjectMaintainerTeamReviewers() []string {
-	return []string{"cncf-projects"}
+	return mentionHandles
 }
 
 func groupCompanyDuplicates(companies []companyDetailResponse) []companyDuplicateGroup {

--- a/cmd/web-bff/main_test.go
+++ b/cmd/web-bff/main_test.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -94,6 +95,17 @@ func setupPostgresTestDB(t *testing.T) *gorm.DB {
 	require.NoError(t, err)
 
 	return gormDB
+}
+
+func githubTestClient(t *testing.T, handler http.Handler) *github.Client {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	client := github.NewClient(server.Client())
+	baseURL, err := url.Parse(server.URL + "/")
+	require.NoError(t, err)
+	client.BaseURL = baseURL
+	return client
 }
 
 func performMaintainerGet(t *testing.T, s *server, maintainerID uint, sessionID string) *httptest.ResponseRecorder {
@@ -245,6 +257,13 @@ func TestMaintainerCanAccessAllProjectsAndMaintainers(t *testing.T) {
 		sessions:   newSessionStore(log.New(io.Discard, "", 0)),
 		cookieName: defaultSessionCookieName,
 		logger:     log.New(io.Discard, "", 0),
+		githubClient: func(context.Context, string) *github.Client {
+			return githubTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, "/repos/project-cache/.project/pulls", r.URL.Path)
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`[]`))
+			}))
+		},
 	}
 
 	maintainerSessionID := "alice-session"
@@ -322,6 +341,13 @@ func TestProjectDetailIncludesDotProjectMaintainerCache(t *testing.T) {
 		sessions:   newSessionStore(log.New(io.Discard, "", 0)),
 		cookieName: defaultSessionCookieName,
 		logger:     log.New(io.Discard, "", 0),
+		githubClient: func(context.Context, string) *github.Client {
+			return githubTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, "/repos/project-cache/.project/pulls", r.URL.Path)
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`[]`))
+			}))
+		},
 	}
 
 	staffSessionID := "staff-session"
@@ -351,6 +377,83 @@ func TestProjectDetailIncludesDotProjectMaintainerCache(t *testing.T) {
 	assert.Equal(t, body, response.DotProjectMaintainerCache.Body)
 	require.NotNil(t, response.DotProjectMaintainerCache.LastCheckedAt)
 	assert.True(t, response.DotProjectMaintainerCache.LastCheckedAt.Equal(now))
+}
+
+func TestProjectDetailIncludesOpenDotProjectMaintainerPullRequestFromGitHub(t *testing.T) {
+	dbConn := setupPostgresTestDB(t)
+	store := db.NewSQLStore(dbConn)
+	now := time.Now().UTC().Truncate(time.Second)
+
+	staff := model.StaffMember{
+		Name:          "Staff Tester",
+		GitHubAccount: "staff-tester",
+		Email:         "staff@example.org",
+	}
+	require.NoError(t, dbConn.Create(&staff).Error)
+
+	project := model.Project{
+		Name:                    "Project Cache",
+		Maturity:                model.Graduated,
+		GitHubOrg:               "project-cache",
+		DotProjectRepoRef:       "https://github.com/project-cache/.project",
+		DotProjectMaintainerRef: "https://github.com/project-cache/.project/blob/main/Maintainers.YAML",
+	}
+	require.NoError(t, dbConn.Create(&project).Error)
+
+	body := "maintainers:\n  - teams:\n      - name: project-maintainers\n        members:\n          - alice-example\n"
+	syncState := model.DotProjectSyncState{
+		ProjectID:             project.ID,
+		RepoExists:            true,
+		MaintainersFileExists: true,
+		MaintainersFilename:   "Maintainers.YAML",
+		MaintainersFileBody:   &body,
+		LastCheckedAt:         &now,
+	}
+	require.NoError(t, dbConn.Create(&syncState).Error)
+
+	s := &server{
+		store:      store,
+		sessions:   newSessionStore(log.New(io.Discard, "", 0)),
+		cookieName: defaultSessionCookieName,
+		logger:     log.New(io.Discard, "", 0),
+		githubClient: func(context.Context, string) *github.Client {
+			return githubTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				switch r.URL.Path {
+				case "/repos/project-cache/.project/pulls":
+					_, _ = w.Write([]byte(`[{"number":7,"state":"open","html_url":"https://github.com/project-cache/.project/pull/7","title":"Manual maintainer update","user":{"login":"outside-user"},"created_at":"2026-05-21T09:00:00Z","updated_at":"2026-05-21T09:05:00Z"}]`))
+				case "/repos/project-cache/.project/pulls/7/files":
+					_, _ = w.Write([]byte(`[{"filename":"Maintainers.YAML"}]`))
+				default:
+					http.NotFound(w, r)
+				}
+			}))
+		},
+	}
+
+	staffSessionID := "staff-session"
+	s.sessions.Set(session{
+		ID:        staffSessionID,
+		Login:     staff.GitHubAccount,
+		Role:      roleStaff,
+		CreatedAt: now,
+		ExpiresAt: now.Add(time.Hour),
+	})
+
+	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/projects/%d", project.ID), nil)
+	req.AddCookie(&http.Cookie{Name: s.cookieName, Value: staffSessionID})
+	rec := httptest.NewRecorder()
+	handler := s.requireSession(http.HandlerFunc(s.handleProject))
+	handler.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	var response projectDetailResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&response))
+	require.NotNil(t, response.DotProjectMaintainerPR)
+	assert.Equal(t, "open", response.DotProjectMaintainerPR.Status)
+	assert.Equal(t, 7, response.DotProjectMaintainerPR.Number)
+	assert.Equal(t, "github", response.DotProjectMaintainerPR.Source)
+	assert.Equal(t, "https://github.com/project-cache/.project/pull/7", response.DotProjectMaintainerPR.URL)
 }
 
 func TestHandleDotProjectPullRequestCreatesAuditLog(t *testing.T) {
@@ -502,9 +605,8 @@ func TestBuildDotProjectPullRequestBodyMentionsAddedMaintainers(t *testing.T) {
 	assert.NotContains(t, body, "@@")
 }
 
-func TestDotProjectMaintainerReviewersNormalizesHandles(t *testing.T) {
-	assert.Equal(t, []string{"alice", "bob"}, dotProjectMaintainerReviewers([]string{"@Alice", "bob", "alice", ""}))
-	assert.Equal(t, []string{"cncf-projects"}, dotProjectMaintainerTeamReviewers())
+func TestDotProjectMaintainerMentionHandlesNormalizesHandles(t *testing.T) {
+	assert.Equal(t, []string{"alice", "bob"}, dotProjectMaintainerMentionHandles([]string{"@Alice", "bob", "alice", ""}))
 }
 
 func TestMaintainerServiceAssociationsForStaff(t *testing.T) {

--- a/dot-project.md
+++ b/dot-project.md
@@ -696,8 +696,9 @@ Implementation report:
 - Generated commits include a `Signed-off-by` trailer that matches the signed-in GitHub user so repository DCO checks can pass.
 - Refinements tracked in [cncf/maintainer-d#114](https://github.com/cncf/maintainer-d/issues/114):
   - Added maintainer handles are rendered as GitHub mentions in the PR body `Changes:` section, for example `@alice`, so maintainers are notified and reviewers can open maintainer profiles directly.
-  - The GitHub write path requests review from each maintainer added to the update and from the `@cncf/cncf-projects` team.
-  - The proposed PR also removes the shorter placeholder comment `# TODO: Add maintainer handles` when it is present in the maintainer file.
+  - Reviewer requests on `.project` repositories were removed; GitHub mentions in the PR body are the notification mechanism for now.
+  - The dot-project route checks maintainer-d audit logs first, then scans open GitHub PRs for changes to the maintainer file, and shows an open maintainer-file PR notice when one exists.
+  - The proposed PR and UI preview remove maintainer-block comments starting with `# TODO`, plus the placeholder `- github-handle`, when present in the maintainer file.
 - PR creation is recorded in the audit log with the submitting staff member and PR metadata.
 - The dot-project UI now exposes a real `Submit Pull Request` action from the preview and shows the resulting PR details.
 

--- a/dotproject/maintainers_patch.go
+++ b/dotproject/maintainers_patch.go
@@ -18,7 +18,7 @@ var (
 	projectMaintainersNameRE = regexp.MustCompile(`(?i)^\s*(?:-\s*)?name:\s*["']?project-maintainers["']?\s*(?:#.*)?$`)
 	membersLineRE            = regexp.MustCompile(`(?i)^\s*members:\s*(?:#.*)?$`)
 	sequenceItemRE           = regexp.MustCompile(`^\s*-\s*(\S+)\s*(?:#.*)?$`)
-	todoMaintainerHandlesRE  = regexp.MustCompile(`(?i)^\s*#\s*TODO:\s*Add maintainer (?:GitHub )?handles\s*$`)
+	todoCommentRE            = regexp.MustCompile(`(?i)^\s*#\s*TODO\b.*$`)
 )
 
 func BuildMaintainerRosterPatch(source string, activeHandles []string) (*MaintainerPatch, error) {
@@ -72,7 +72,7 @@ func BuildMaintainerRosterPatch(source string, activeHandles []string) (*Maintai
 		if lineIndent <= membersIndent {
 			break
 		}
-		if todoMaintainerHandlesRE.MatchString(line) {
+		if todoCommentRE.MatchString(line) {
 			placeholderIndexes[index] = strings.TrimSpace(line)
 			continue
 		}

--- a/dotproject/maintainers_patch_test.go
+++ b/dotproject/maintainers_patch_test.go
@@ -14,6 +14,7 @@ func TestBuildMaintainerRosterPatchAddsMissingMaintainersAndRemovesPlaceholders(
         members:
           # TODO: Add maintainer GitHub handles
           # TODO: Add maintainer handles
+          # TODO: reconcile this roster after launch
           - github-handle
           - alice
 `
@@ -22,7 +23,7 @@ func TestBuildMaintainerRosterPatchAddsMissingMaintainersAndRemovesPlaceholders(
 	require.NoError(t, err)
 
 	assert.Equal(t, []string{"bob", "carol"}, patch.AddedHandles)
-	assert.Equal(t, []string{"# TODO: Add maintainer GitHub handles", "# TODO: Add maintainer handles", "- github-handle"}, patch.RemovedPlaceholders)
+	assert.Equal(t, []string{"# TODO: Add maintainer GitHub handles", "# TODO: Add maintainer handles", "# TODO: reconcile this roster after launch", "- github-handle"}, patch.RemovedPlaceholders)
 	assert.Equal(t, `maintainers:
   - teams:
       - name: project-maintainers

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -27,6 +27,9 @@ body {
   --md-status-danger-bg: #fee2e2;
   --md-status-danger-border: #fca5a5;
   --md-status-danger-text: #b91c1c;
+  --md-status-warning-bg: #fff7e6;
+  --md-status-warning-border: #f4d08a;
+  --md-status-warning-text: #6d4d00;
   --md-callout-bg: linear-gradient(180deg, rgba(250, 250, 252, 1) 0%, rgba(245, 247, 250, 1) 100%);
 }
 
@@ -52,6 +55,9 @@ body {
   --md-status-danger-bg: rgba(239, 68, 68, 0.14);
   --md-status-danger-border: rgba(248, 113, 113, 0.4);
   --md-status-danger-text: #fca5a5;
+  --md-status-warning-bg: rgba(245, 158, 11, 0.14);
+  --md-status-warning-border: rgba(251, 191, 36, 0.4);
+  --md-status-warning-text: #fcd34d;
   --md-callout-bg: linear-gradient(180deg, rgba(255, 255, 255, 0.03) 0%, rgba(255, 255, 255, 0.06) 100%);
 }
 

--- a/web/src/app/projects/[id]/ProjectRouteClient.tsx
+++ b/web/src/app/projects/[id]/ProjectRouteClient.tsx
@@ -48,6 +48,18 @@ type DotProjectMaintainerCache = {
   lastCheckedAt?: string | null;
 };
 
+type DotProjectMaintainerPullRequest = {
+  status: string;
+  url?: string;
+  number?: number;
+  title?: string;
+  author?: string;
+  source?: string;
+  createdAt?: string | null;
+  updatedAt?: string | null;
+  warning?: string;
+};
+
 type ProjectDetail = {
   id: number;
   name: string;
@@ -66,6 +78,7 @@ type ProjectDetail = {
   dotProjectAdoptionStatus?: string;
   dotProjectSyncState?: DotProjectSyncState | null;
   dotProjectMaintainerCache?: DotProjectMaintainerCache | null;
+  dotProjectMaintainerPullRequest?: DotProjectMaintainerPullRequest | null;
   maintainerRefStatus: {
     url?: string;
     status: string;
@@ -170,6 +183,11 @@ const projectDataHasChanged = (current: ProjectDetail | null, next: ProjectDetai
     current.dotProjectMaintainerCache?.bodyHash !== next.dotProjectMaintainerCache?.bodyHash ||
     current.dotProjectMaintainerCache?.body !== next.dotProjectMaintainerCache?.body ||
     current.dotProjectMaintainerCache?.lastCheckedAt !== next.dotProjectMaintainerCache?.lastCheckedAt ||
+    current.dotProjectMaintainerPullRequest?.status !== next.dotProjectMaintainerPullRequest?.status ||
+    current.dotProjectMaintainerPullRequest?.url !== next.dotProjectMaintainerPullRequest?.url ||
+    current.dotProjectMaintainerPullRequest?.number !== next.dotProjectMaintainerPullRequest?.number ||
+    current.dotProjectMaintainerPullRequest?.updatedAt !== next.dotProjectMaintainerPullRequest?.updatedAt ||
+    current.dotProjectMaintainerPullRequest?.warning !== next.dotProjectMaintainerPullRequest?.warning ||
     current.maintainerRefStatus.status !== next.maintainerRefStatus.status ||
     current.maintainerRefStatus.url !== next.maintainerRefStatus.url ||
     current.maintainerRefStatus.checkedAt !== next.maintainerRefStatus.checkedAt ||
@@ -458,6 +476,7 @@ export default function ProjectRouteClient({ children }: ProjectRouteClientProps
                 dotProjectAdoptionStatus={project.dotProjectAdoptionStatus}
                 dotProjectSyncState={project.dotProjectSyncState}
                 dotProjectMaintainerCache={project.dotProjectMaintainerCache}
+                dotProjectMaintainerPullRequest={project.dotProjectMaintainerPullRequest}
                 maintainerRefStatus={project.maintainerRefStatus}
                 maintainerRefBody={project.legacyMaintainerRefBody}
                 refOnlyGitHub={project.refOnlyGitHub}

--- a/web/src/components/DotProjectMaintainerFileViewer.tsx
+++ b/web/src/components/DotProjectMaintainerFileViewer.tsx
@@ -244,7 +244,7 @@ const isSequenceItemLine = (line: string): boolean => /^\s*-\s*\S/.test(line);
 
 const isMaintainerPlaceholderLine = (line: string): boolean => {
   const trimmed = line.trim();
-  return /^#\s*TODO:\s*Add maintainer GitHub handles\s*$/i.test(trimmed) || /^-\s*github-handle\s*(?:#.*)?$/i.test(trimmed);
+  return /^#\s*TODO\b.*$/i.test(trimmed) || /^-\s*github-handle\s*(?:#.*)?$/i.test(trimmed);
 };
 
 const splitSourceLines = (source: string): string[] =>

--- a/web/src/components/ProjectReconciliationCard.module.css
+++ b/web/src/components/ProjectReconciliationCard.module.css
@@ -731,13 +731,32 @@
 }
 
 .dotProjectYamlValidation {
-  border: 1px solid #f4d08a;
+  border: 1px solid var(--md-status-warning-border, #f4d08a);
   border-radius: 10px;
   padding: 10px 12px;
-  color: #6d4d00;
-  background: #fff7e6;
+  color: var(--md-status-warning-text, #6d4d00);
+  background: var(--md-status-warning-bg, #fff7e6);
   font-size: 12px;
   line-height: 1.5;
+}
+
+.dotProjectPullRequestNotice {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  border: 1px solid var(--md-status-warning-border, #f4d08a);
+  border-radius: 10px;
+  padding: 10px 12px;
+  color: var(--md-status-warning-text, #6d4d00);
+  background: var(--md-status-warning-bg, #fff7e6);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.dotProjectPullRequestNotice p {
+  margin: 2px 0 0;
+  color: inherit;
 }
 
 .dotProjectYamlSuccess {

--- a/web/src/components/ProjectReconciliationCard.tsx
+++ b/web/src/components/ProjectReconciliationCard.tsx
@@ -88,6 +88,18 @@ type DotProjectMaintainerCacheSummary = {
   lastCheckedAt?: string | null;
 };
 
+type DotProjectMaintainerPullRequestSummary = {
+  status: string;
+  url?: string | null;
+  number?: number | null;
+  title?: string | null;
+  author?: string | null;
+  source?: string | null;
+  createdAt?: string | null;
+  updatedAt?: string | null;
+  warning?: string | null;
+};
+
 type SortDirection = "asc" | "desc";
 
 type SortState<Key extends string> = {
@@ -139,6 +151,7 @@ type ProjectReconciliationCardProps = {
   dotProjectAdoptionStatus?: string | null;
   dotProjectSyncState?: DotProjectSyncStateSummary | null;
   dotProjectMaintainerCache?: DotProjectMaintainerCacheSummary | null;
+  dotProjectMaintainerPullRequest?: DotProjectMaintainerPullRequestSummary | null;
   maintainerRefStatus: {
     url?: string;
     status: string;
@@ -280,6 +293,7 @@ export default function ProjectReconciliationCard({
   dotProjectAdoptionStatus,
   dotProjectSyncState,
   dotProjectMaintainerCache,
+  dotProjectMaintainerPullRequest,
   maintainerRefStatus,
   maintainerRefBody,
   refLines,
@@ -322,6 +336,8 @@ export default function ProjectReconciliationCard({
   const dotProjectMaintainerCacheBody = dotProjectMaintainerCache?.body ?? "";
   const dotProjectMaintainerCacheFilename =
     dotProjectMaintainerCache?.filename || dotProjectMaintainersFilename || "maintainers.yaml";
+  const openDotProjectMaintainerPR =
+    dotProjectMaintainerPullRequest?.status === "open" ? dotProjectMaintainerPullRequest : null;
   const dotProjectFiles = [
     {
       label: ".project repo",
@@ -892,6 +908,26 @@ export default function ProjectReconciliationCard({
               </a>
             ) : null}
           </div>
+          {openDotProjectMaintainerPR ? (
+            <div className={styles.dotProjectPullRequestNotice}>
+              <div>
+                <strong>Open maintainer-file pull request</strong>
+                <p>
+                  #{openDotProjectMaintainerPR.number} {openDotProjectMaintainerPR.title || "Untitled pull request"}
+                  {openDotProjectMaintainerPR.author ? ` by ${openDotProjectMaintainerPR.author}` : ""}
+                  {openDotProjectMaintainerPR.updatedAt ? `, updated ${formatDateTime(openDotProjectMaintainerPR.updatedAt)}` : ""}.
+                </p>
+              </div>
+              {openDotProjectMaintainerPR.url ? (
+                <a className={styles.link} href={openDotProjectMaintainerPR.url} target="_blank" rel="noreferrer">
+                  Open PR
+                </a>
+              ) : null}
+            </div>
+          ) : null}
+          {dotProjectMaintainerPullRequest?.status === "unknown" && dotProjectMaintainerPullRequest.warning ? (
+            <div className={styles.dotProjectYamlValidation}>{dotProjectMaintainerPullRequest.warning}</div>
+          ) : null}
           <DotProjectMaintainerFileViewer
             apiBaseUrl={apiBaseUrl}
             filename={dotProjectMaintainerCacheFilename}


### PR DESCRIPTION
  - detects maintainer-file PRs from maintainer-d audit logs first
  - scans open GitHub PRs for changes to the current maintainers.yaml file
  - surfaces an open PR notice on the dot-project route
  - removes reviewer requests for .project PRs and keeps GitHub mentions as the notification path
  - removes generic TODO comments from maintainer-file previews and submitted patches