### PR TITLE
tightens dot-project sync audit logging and gist reports

### DIFF
--- a/cmd/dot-project-sync/main.go
+++ b/cmd/dot-project-sync/main.go
@@ -81,6 +81,10 @@ func main() {
 	}
 
 	store := db.NewSQLStore(dbConn)
+	logger := zap.NewNop().Sugar()
+	if err := store.LogAuditEvent(logger, buildStartAuditEvent(cfg)); err != nil {
+		log.Printf("dot-project sync start audit log failed: %v", err)
+	}
 	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: githubToken})
 	tc := oauth2.NewClient(ctx, ts)
 	client := github.NewClient(tc)
@@ -129,7 +133,6 @@ func main() {
 		log.Printf("dot-project sync post-sync metrics failed: %v", metricsErr)
 	}
 
-	logger := zap.NewNop().Sugar()
 	if err := store.LogAuditEvent(logger, buildAuditEvent(summary, metrics, metricsErr, cfg)); err != nil {
 		log.Printf("dot-project sync audit log failed: %v", err)
 	}
@@ -175,10 +178,10 @@ func parseFlags() syncConfig {
 	flag.StringVar(&cfg.FoundationRepo, "foundation-csv-repo", "foundation", "GitHub repository for foundation project-maintainers.csv")
 	flag.StringVar(&cfg.FoundationRef, "foundation-csv-ref", "main", "Git ref for foundation project-maintainers.csv")
 	flag.StringVar(&cfg.FoundationPath, "foundation-csv-path", "project-maintainers.csv", "Path to foundation project-maintainers.csv")
-	flag.BoolVar(&cfg.WriteGist, "write-gist", false, "write a public gist containing the dot-project CSV report")
+	flag.BoolVar(&cfg.WriteGist, "write-gist", false, "write a public gist containing the dot-project Markdown report")
 	flag.StringVar(&cfg.GistID, "gist-id", "", "existing gist ID to update; leave empty to create a new public gist")
-	flag.StringVar(&cfg.GistFilename, "gist-filename", "dot-project-repos.csv", "filename for the dot-project CSV gist")
-	flag.StringVar(&cfg.GistDescription, "gist-description", "maintainer-d dot-project repository report", "description for the dot-project CSV gist")
+	flag.StringVar(&cfg.GistFilename, "gist-filename", "dot-project-repos.md", "filename for the dot-project Markdown gist")
+	flag.StringVar(&cfg.GistDescription, "gist-description", "maintainer-d dot-project repository report", "description for the dot-project Markdown gist")
 	flag.Parse()
 	return cfg
 }
@@ -187,13 +190,13 @@ func publishDotProjectGist(ctx context.Context, client *github.Client, cfg syncC
 	if client == nil {
 		return nil, fmt.Errorf("github client is required")
 	}
-	content, err := dotproject.GistReportCSV(rows)
+	content, err := dotproject.GistReportMarkdown(rows)
 	if err != nil {
 		return nil, err
 	}
 	filename := strings.TrimSpace(cfg.GistFilename)
 	if filename == "" {
-		filename = "dot-project-repos.csv"
+		filename = "dot-project-repos.md"
 	}
 	gist := &github.Gist{
 		Description: github.String(strings.TrimSpace(cfg.GistDescription)),
@@ -575,12 +578,6 @@ func buildAuditEvent(summary dotproject.SyncSummary, metrics *postSyncMetrics, m
 		"gist_filename":                 strings.TrimSpace(cfg.GistFilename),
 		"gist_report_rows":              len(summary.GistReportRows),
 	}
-	if len(summary.AutoAdd.WouldCreate) > 0 {
-		metadata["auto_add_would_create_handles"] = summary.AutoAdd.WouldCreate
-	}
-	if len(summary.AutoAdd.WouldLink) > 0 {
-		metadata["auto_add_would_link_handles"] = summary.AutoAdd.WouldLink
-	}
 	if len(summary.ErrorSummaries) > 0 {
 		metadata["errors"] = summary.ErrorSummaries
 	}
@@ -620,8 +617,36 @@ func buildAuditEvent(summary dotproject.SyncSummary, metrics *postSyncMetrics, m
 		summary.AutoAdd.LinkedMaintainers,
 	)
 	return model.AuditLog{
-		Action:   "DOT_PROJECT_SYNC_RUN",
+		Action:   "DOT_PROJECT_SYNC_RUN_FINISHED",
 		Message:  message,
+		Metadata: string(body),
+	}
+}
+
+func buildStartAuditEvent(cfg syncConfig) model.AuditLog {
+	metadata := map[string]any{
+		"check_foundation_csv":   cfg.CheckFoundationCSV,
+		"auto_add_maintainers":   cfg.AutoAddMaintainers,
+		"dot_project_sync_actor": strings.TrimSpace(cfg.Actor),
+		"foundation_csv_owner":   strings.TrimSpace(cfg.FoundationOwner),
+		"foundation_csv_repo":    strings.TrimSpace(cfg.FoundationRepo),
+		"foundation_csv_ref":     strings.TrimSpace(cfg.FoundationRef),
+		"foundation_csv_path":    strings.TrimSpace(cfg.FoundationPath),
+		"write_gist":             cfg.WriteGist,
+		"gist_id":                strings.TrimSpace(cfg.GistID),
+		"gist_filename":          strings.TrimSpace(cfg.GistFilename),
+	}
+	body, err := json.Marshal(metadata)
+	if err != nil {
+		body = []byte("{}")
+	}
+	actor := strings.TrimSpace(cfg.Actor)
+	if actor == "" {
+		actor = "dot-project-sync"
+	}
+	return model.AuditLog{
+		Action:   "DOT_PROJECT_SYNC_RUN_STARTED",
+		Message:  fmt.Sprintf("DOT_PROJECT_SYNC_RUN_STARTED: actor=%s auto_add_maintainers=%t check_foundation_csv=%t", actor, cfg.AutoAddMaintainers, cfg.CheckFoundationCSV),
 		Metadata: string(body),
 	}
 }

--- a/cmd/dot-project-sync/main_test.go
+++ b/cmd/dot-project-sync/main_test.go
@@ -108,10 +108,10 @@ func TestBuildAuditEvent(t *testing.T) {
 		FoundationRepo:     "foundation",
 		FoundationRef:      "main",
 		FoundationPath:     "project-maintainers.csv",
-		GistFilename:       "dot-project-repos.csv",
+		GistFilename:       "dot-project-repos.md",
 	})
 
-	assert.Equal(t, "DOT_PROJECT_SYNC_RUN", event.Action)
+	assert.Equal(t, "DOT_PROJECT_SYNC_RUN_FINISHED", event.Action)
 	assert.Contains(t, event.Message, "scanned=20")
 	assert.Contains(t, event.Message, "rate_limit_errors=1")
 
@@ -138,13 +138,41 @@ func TestBuildAuditEvent(t *testing.T) {
 	assert.Equal(t, false, metadata["auto_add_maintainers"])
 	assert.Equal(t, "staff-tester", metadata["dot_project_sync_actor"])
 	assert.Equal(t, "cncf", metadata["foundation_csv_owner"])
-	wouldCreate, ok := metadata["auto_add_would_create_handles"].([]any)
-	require.True(t, ok)
-	assert.Len(t, wouldCreate, 1)
+	assert.NotContains(t, metadata, "auto_add_would_create_handles")
+	assert.NotContains(t, metadata, "auto_add_would_link_handles")
 	errorsValue, ok := metadata["errors"].([]any)
 	require.True(t, ok)
 	assert.Len(t, errorsValue, 2)
 	warningsValue, ok := metadata["warnings"].([]any)
 	require.True(t, ok)
 	assert.Len(t, warningsValue, 1)
+}
+
+func TestBuildStartAuditEvent(t *testing.T) {
+	t.Parallel()
+
+	event := buildStartAuditEvent(syncConfig{
+		CheckFoundationCSV: true,
+		AutoAddMaintainers: true,
+		Actor:              "staff-tester",
+		FoundationOwner:    "cncf",
+		FoundationRepo:     "foundation",
+		FoundationRef:      "main",
+		FoundationPath:     "project-maintainers.csv",
+		WriteGist:          true,
+		GistID:             "abc123",
+		GistFilename:       "dot-project-repos.md",
+	})
+
+	assert.Equal(t, "DOT_PROJECT_SYNC_RUN_STARTED", event.Action)
+	assert.Contains(t, event.Message, "actor=staff-tester")
+	assert.Contains(t, event.Message, "auto_add_maintainers=true")
+
+	var metadata map[string]any
+	require.NoError(t, json.Unmarshal([]byte(event.Metadata), &metadata))
+	assert.Equal(t, true, metadata["check_foundation_csv"])
+	assert.Equal(t, true, metadata["auto_add_maintainers"])
+	assert.Equal(t, "staff-tester", metadata["dot_project_sync_actor"])
+	assert.Equal(t, true, metadata["write_gist"])
+	assert.Equal(t, "abc123", metadata["gist_id"])
 }

--- a/cmd/web-bff/main.go
+++ b/cmd/web-bff/main.go
@@ -4813,7 +4813,7 @@ func (s *server) publishLFXDotProjectGist(ctx context.Context, options lfxEnrich
 	if err != nil {
 		return nil, 0, err
 	}
-	content, err := dotproject.GistReportCSV(rows)
+	content, err := dotproject.GistReportMarkdown(rows)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -4935,7 +4935,7 @@ func (s *server) buildDotProjectGistRows() ([]dotproject.GistReportRow, error) {
 func lfxGistFilename(value string) string {
 	value = strings.TrimSpace(value)
 	if value == "" {
-		return "dot-project-repos.csv"
+		return "dot-project-repos.md"
 	}
 	return value
 }

--- a/deploy/secrets/maintainerd-web-bff-env.yaml
+++ b/deploy/secrets/maintainerd-web-bff-env.yaml
@@ -16,6 +16,7 @@ stringData:
     SESSION_COOKIE_SECURE: ENC[AES256_GCM,data:APiMWQ==,iv:i/sltfpOD4Vf4CoCQtA8xYnqYBfiHijMXjpWuvnxmx4=,tag:3sboHbIXMqordceTYIuP9Q==,type:str]
     FOSSA_API_TOKEN: ENC[AES256_GCM,data:dCJrgVHi/5ZWS6+PaQhJqZTJzFrUfJrFUQ1l4+PYCs0=,iv:dxqD07FeiSdubZdkIRWrMlbLgf9cn/Bfc7Hp8SBMLmc=,tag:DqfOf7ehY1U9v4ggf6OYzw==,type:str]
     BFF_ALLOW_LIVE_FOSSA: ENC[AES256_GCM,data:EPzxgw==,iv:pkVkHFhW0Rit6Ku5GjXRopwzPbMmXc9Jw/gyC7KaQCg=,tag:CPjuUqdNY3AQjwp36u74Jg==,type:str]
+    LFX_ENRICHMENT_ADMIN_GITHUB_LOGINS: ENC[AES256_GCM,data:+pjX/4+fHoEQZ7TT,iv:i7kpy8HHLxokb4vSHtrkZjZ63QcE9bsrT07Wa4tgSpg=,tag:XhhuIDcm1LhrVD+FfuveZw==,type:str]
 sops:
     age:
         - recipient: age13ky20ttewhjkjncjkj3xk4ngah6luurk7xu83p6w7f9z4r49js9qk2t3w0
@@ -27,7 +28,7 @@ sops:
             VEtlbWJuRHZIN1I0MjhsaXJYVTd5R0kKpz9Sah938Dz0tXT2MGDq6pk+FuEt72F1
             qxsjDq5LxoZL+Ub5B4M0bDqAw6VquQlV1Q7MIwQZgjh3ZJcgOLm+cQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-03-03T01:07:25Z"
-    mac: ENC[AES256_GCM,data:jHz+V/A9ItdCExFKRXQT4o8PoUWhpsup4X87T4wFWpeSCBlE7wjOqf1/WVfpdlJ2eN4YHyuU6JvqhqqVR7XlTurBgWR+eDZn8AeG6hTrvTQfmJfqmKrR7DYu63CHdCj+gCwzhZegeFpi88WrWSxgKWLi+VqCsxhi0phqWwQ5E90=,iv:WNFxTAB72AX25gCuRedgF+PBRJLJF1bTHHc3ty9eLq8=,tag:U79LgNoU7xC8tKAjJj4osQ==,type:str]
+    lastmodified: "2026-06-15T13:21:05Z"
+    mac: ENC[AES256_GCM,data:VdcUMBFnD/689l0jvjALbtFQ/2BL1h5SHYY9DhEpzHWprgQE62Szil2uT/Lvynecdp7FISv4W+qyPSxGe1IeNfTVfzVAdlfEHQQ6fxvGaa4WrtSq0/pYsNEj+ksysfJMUrLbR222Wwa42R0ldqXh0F90t5GSISfxjfUlzqHl/U4=,iv:HNm6yTMhwCAuiqGUufxmhCwQi74mioSevwlTc3+toNI=,tag:F3zEbIOcNIbJBytWuyJwhg==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.11.0

--- a/dotproject/auto_add.go
+++ b/dotproject/auto_add.go
@@ -203,9 +203,6 @@ func (a *AutoMaintainerAdder) ProcessProject(ctx context.Context, project model.
 			if !a.AutoAddMaintainers {
 				summary.WouldLinkMaintainers++
 				summary.WouldLink = append(summary.WouldLink, entry)
-				if err := a.logAutoAdd(project, &existing, record, result, nil, now, "would_link"); err != nil {
-					summary.AuditFailures++
-				}
 				continue
 			}
 			maintainer, _, didLink, err := a.Store.UpsertMaintainerWithIdentity(project.ID, existing.Name, existing.Email, existing.GitHubAccount, companyName(existing.Company.Name, record.Company), existing.LFXUserID)
@@ -242,9 +239,6 @@ func (a *AutoMaintainerAdder) ProcessProject(ctx context.Context, project model.
 		if !a.AutoAddMaintainers {
 			summary.WouldCreateMaintainers++
 			summary.WouldCreate = append(summary.WouldCreate, entry)
-			if err := a.logAutoAdd(project, nil, record, result, &identity, now, "would_create"); err != nil {
-				summary.AuditFailures++
-			}
 			continue
 		}
 

--- a/dotproject/gist_report.go
+++ b/dotproject/gist_report.go
@@ -2,9 +2,10 @@ package dotproject
 
 import (
 	"bytes"
-	"encoding/csv"
 	"fmt"
 	"io"
+	"net/url"
+	"path"
 	"strconv"
 	"strings"
 
@@ -38,18 +39,11 @@ func BuildGistReportRow(project model.Project, result *DiscoveryResult) (GistRep
 	}, true
 }
 
-func WriteGistReportCSV(w io.Writer, rows []GistReportRow) error {
-	writer := csv.NewWriter(w)
-	if err := writer.Write([]string{
-		"Project Name",
-		"project.yaml",
-		"maintainers.yaml",
-		"Maintainer Count",
-		"SECURITY.md",
-		"CONTRIBUTING.md",
-		"GOVERNANCE.md",
-		"Warning",
-	}); err != nil {
+func WriteGistReportMarkdown(w io.Writer, rows []GistReportRow) error {
+	if _, err := io.WriteString(w, "| Project Name | project.yaml | maintainers.yaml | Maintainer Count | SECURITY.md | CONTRIBUTING.md | GOVERNANCE.md | Warning |\n"); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, "| --- | --- | --- | ---: | --- | --- | --- | --- |\n"); err != nil {
 		return err
 	}
 	for _, row := range rows {
@@ -57,29 +51,68 @@ func WriteGistReportCSV(w io.Writer, rows []GistReportRow) error {
 		if row.MaintainerCount != nil {
 			count = strconv.FormatUint(uint64(*row.MaintainerCount), 10)
 		}
-		if err := writer.Write([]string{
-			row.ProjectName,
-			row.ProjectFileURL,
-			row.MaintainersFileURL,
+		if _, err := fmt.Fprintf(w, "| %s | %s | %s | %s | %s | %s | %s | %s |\n",
+			markdownTableCell(row.ProjectName),
+			markdownLinkForURL(row.ProjectFileURL),
+			markdownLinkForURL(row.MaintainersFileURL),
 			count,
-			row.SecurityFileURL,
-			row.ContributingFileURL,
-			row.GovernanceFileURL,
-			row.Warning,
-		}); err != nil {
+			markdownLinkForURL(row.SecurityFileURL),
+			markdownLinkForURL(row.ContributingFileURL),
+			markdownLinkForURL(row.GovernanceFileURL),
+			markdownTableCell(row.Warning),
+		); err != nil {
 			return err
 		}
 	}
-	writer.Flush()
-	return writer.Error()
+	return nil
 }
 
-func GistReportCSV(rows []GistReportRow) (string, error) {
+func GistReportMarkdown(rows []GistReportRow) (string, error) {
 	var buf bytes.Buffer
-	if err := WriteGistReportCSV(&buf, rows); err != nil {
-		return "", fmt.Errorf("write dot-project gist csv: %w", err)
+	if err := WriteGistReportMarkdown(&buf, rows); err != nil {
+		return "", fmt.Errorf("write dot-project gist markdown: %w", err)
 	}
 	return buf.String(), nil
+}
+
+func markdownLinkForURL(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	label := markdownLinkLabel(raw)
+	return fmt.Sprintf("[%s](%s)", markdownLinkText(label), markdownURL(raw))
+}
+
+func markdownLinkLabel(raw string) string {
+	if parsed, err := url.Parse(raw); err == nil {
+		if base := path.Base(strings.TrimRight(parsed.Path, "/")); base != "." && base != "/" && base != "" {
+			return base
+		}
+	}
+	trimmed := strings.TrimRight(raw, "/")
+	if idx := strings.LastIndex(trimmed, "/"); idx >= 0 && idx+1 < len(trimmed) {
+		return trimmed[idx+1:]
+	}
+	return raw
+}
+
+func markdownTableCell(value string) string {
+	value = strings.ReplaceAll(strings.TrimSpace(value), "\n", " ")
+	value = strings.ReplaceAll(value, "\r", " ")
+	value = strings.ReplaceAll(value, "|", "\\|")
+	return value
+}
+
+func markdownLinkText(value string) string {
+	value = markdownTableCell(value)
+	value = strings.ReplaceAll(value, "[", "\\[")
+	value = strings.ReplaceAll(value, "]", "\\]")
+	return value
+}
+
+func markdownURL(value string) string {
+	return strings.ReplaceAll(strings.TrimSpace(value), ")", "%29")
 }
 
 func fileURL(file FileDiscovery) string {

--- a/dotproject/gist_report_test.go
+++ b/dotproject/gist_report_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGistReportCSV(t *testing.T) {
+func TestGistReportMarkdown(t *testing.T) {
 	t.Parallel()
 
 	count := uint(3)
@@ -25,10 +25,10 @@ func TestGistReportCSV(t *testing.T) {
 	})
 	require.True(t, ok)
 
-	csv, err := GistReportCSV([]GistReportRow{row})
+	markdown, err := GistReportMarkdown([]GistReportRow{row})
 	require.NoError(t, err)
 
-	assert.Equal(t, "Project Name,project.yaml,maintainers.yaml,Maintainer Count,SECURITY.md,CONTRIBUTING.md,GOVERNANCE.md,Warning\nExample,https://github.com/example/.project/blob/main/project.yaml,https://github.com/example/.project/blob/main/maintainers.yaml,3,https://github.com/example/.project/blob/main/SECURITY.md,,https://raw.githubusercontent.com/example/.project/main/GOVERNANCE.md,\n", csv)
+	assert.Equal(t, "| Project Name | project.yaml | maintainers.yaml | Maintainer Count | SECURITY.md | CONTRIBUTING.md | GOVERNANCE.md | Warning |\n| --- | --- | --- | ---: | --- | --- | --- | --- |\n| Example | [project.yaml](https://github.com/example/.project/blob/main/project.yaml) | [maintainers.yaml](https://github.com/example/.project/blob/main/maintainers.yaml) | 3 | [SECURITY.md](https://github.com/example/.project/blob/main/SECURITY.md) |  | [GOVERNANCE.md](https://raw.githubusercontent.com/example/.project/main/GOVERNANCE.md) |  |\n", markdown)
 }
 
 func TestBuildGistReportRowIncludesMaintainersWarning(t *testing.T) {

--- a/web/src/app/lfx/page.tsx
+++ b/web/src/app/lfx/page.tsx
@@ -70,7 +70,7 @@ export default function LFXPage() {
   const [maxLookups, setMaxLookups] = useState("50");
   const [writeGist, setWriteGist] = useState(false);
   const [gistId, setGistId] = useState("");
-  const [gistFilename, setGistFilename] = useState("dot-project-repos.csv");
+  const [gistFilename, setGistFilename] = useState("dot-project-repos.md");
   const [gistDescription, setGistDescription] = useState("maintainer-d dot-project repository report");
   const [status, setStatus] = useState<"idle" | "loading" | "ready">("idle");
   const [submitting, setSubmitting] = useState(false);


### PR DESCRIPTION
-   records explicit dot-project sync start and finish audit events only
-   removes dry-run auto-add candidate rows, bulky would-create/would-link metadata from audit logs
-   dot-project-sync run report gist has been changed to Markdown so .project refs are navigable on GitHub
-   stages LFX_ENRICHMENT_ADMIN_GITHUB_LOGINS that contains the list of GitHub accounts that has LFX page access, for initial deployment I am restricting access to this feature to just my account