### PR TITLE
generates a draft MAINTAINERS.yaml for projects without a .project repo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,100 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+**maintainer-d** tracks maintainers for CNCF Projects using multiple data sources. It is a CNCF-internal project. The system consists of:
+
+- **maintainerd server** (`main.go`, `onboarding/`) — listens for GitHub webhooks to initiate project onboarding workflows (e.g., FOSSA license scanning)
+- **web-bff** (`cmd/web-bff/`) — Go REST API backend serving the Next.js web app
+- **web** (`web/`) — Next.js 16 / React 19 frontend with App Router
+- **PostgreSQL** database accessed via GORM (SQLite used locally/in tests)
+- **CRDs** (`apis/`, `config/`) — Kubernetes Custom Resource Definitions for projects, maintainers, companies
+
+## Running the Web App Locally
+
+```bash
+scripts/run-local-web.sh
+```
+
+Starts the web-bff API server (`:8001`) and the Next.js frontend (`:3000`) together against the local Postgres dev DB (`maintainerd_local` on `127.0.0.1:55432`). Set `RUN_LOCAL_WEB_PRESERVE_ENV=true` to keep existing env vars instead of forcing local-safe defaults.
+
+`BFF_TEST_MODE=true` (the default) enables `/auth/test-login?login=<github_username>` for local sign-in without real OAuth.
+
+## Go Testing
+
+```bash
+make test                        # run all Go tests
+make test-verbose                # verbose output
+make test-coverage               # generate coverage.out
+make test-race                   # with race detector
+make test-package PKG=onboarding # single package
+make lint                        # golangci-lint
+make fmt                         # go fmt
+make vet                         # go vet
+make ci-local                    # full CI check (run before pushing)
+```
+
+Single test by function name:
+```bash
+go test -v -run TestFossaChosen ./onboarding/...
+go test -v -run TestFossaChosen/successful_onboarding ./onboarding/...
+```
+
+`make ci-local` replicates what GitHub Actions runs: dependency verify, fmt, vet, staticcheck, race-detected tests, web lint/typecheck/BDD.
+
+## Web BDD Tests (Cucumber + Playwright)
+
+Feature files live in `features/web/*.feature`. Step definitions are in `web/tests/steps/`.
+
+```bash
+make test-web                                      # run all BDD tests
+WEB_BDD_USE_MICROCKS=true make test-web            # with mocked FOSSA API
+WEB_BDD_USE_MICROCKS=true BDD_FEATURE=../features/web/maintainer_profile.feature make test-web  # single feature
+make test-web-podman                               # run in Playwright container (non-Ubuntu hosts)
+```
+
+Microcks mocks the FOSSA API. The mock contract is at `microcks/fossa-api-mock.yaml`. Start/stop Microcks manually with `scripts/microcks-up.sh` / `scripts/microcks-down.sh` (UI at `http://localhost:8585`).
+
+## Architecture
+
+### Data flow
+```
+Web UI → web-bff (Go REST API, :8000) → PostgreSQL
+```
+
+### Key packages
+- `model/` — Core data models (Maintainer, Project, Company); shared across the codebase
+- `db/` — GORM store interface (`store.go`) and implementation (`store_impl.go`)
+- `onboarding/` — Webhook-triggered onboarding workflows; server + tasks
+- `plugins/fossa/` — FOSSA API client
+- `refparse/` — Parses maintainer references from project YAML files
+- `cmd/web-bff/` — REST API handlers, GitHub OAuth, session management
+- `cmd/web-bff-seed/` — Seeds test database
+- `cmd/sync/` — Syncs DB data to CRDs
+- `cmd/migrate/` — Database migrations
+- `apis/maintainers/v1alpha1/` — CRD type definitions (do not hand-edit generated files)
+
+### Web app (`web/src/app/`)
+Next.js App Router. Routes include `/projects/[id]`, `/maintainers/[id]`, `/companies/[id]`, `/search`. The `AppShell` component (`web/src/components/AppShell.tsx`) wraps all pages.
+
+## FOSSA Rule
+
+`remote_teams.remote_team_id` must always be sourced from the FOSSA API. Never derive it from `project.id` or any local identifier.
+
+## Commit Messages
+
+Use the "Friends episode nameing method": write commit messages as if prefixed with *"This is the change that…"*. For example: `"adds the repo being monitored to log output at loglevel INFO"`.
+
+## Deployment
+
+Kubernetes manifests are in `deploy/manifests/` (no Helm). See `OPS.MD` for operational commands.
+
+```bash
+make secrets           # build bootstrap.env and apply required Secrets
+make manifests-apply   # apply all manifests to cluster
+make manifests-delete  # delete manifests from cluster
+```
+
+Required secrets in namespace `maintainerd`: `maintainerd-bootstrap-env`, `workspace-credentials`, `ghcr-secret`.

--- a/cmd/web-bff-seed/main.go
+++ b/cmd/web-bff-seed/main.go
@@ -172,7 +172,7 @@ func main() {
 			DotProjectLastSyncedAt:    atlasSyncedAt,
 			DotProjectAdoptionStatus:  "adopted",
 		},
-		{Name: "Project Beacon", Maturity: model.Incubating},
+		{Name: "Project Beacon", Maturity: model.Incubating, DotProjectAdoptionStatus: "not_found"},
 		{Name: "Project Comet", Maturity: model.Sandbox},
 		{Name: "Project Fossa Full", Maturity: model.Sandbox},
 		{Name: "Project Fossa Partial", Maturity: model.Sandbox},

--- a/cmd/web-bff/main.go
+++ b/cmd/web-bff/main.go
@@ -679,42 +679,43 @@ type maintainerRefStatus struct {
 }
 
 type projectDetailResponse struct {
-	ID                        uint                           `json:"id"`
-	Name                      string                         `json:"name"`
-	Maturity                  string                         `json:"maturity"`
-	ParentProjectID           *uint                          `json:"parentProjectId,omitempty"`
-	LegacyMaintainerRef       string                         `json:"legacyMaintainerRef,omitempty"`
-	DotProjectRepoRef         string                         `json:"dotProjectRepoRef,omitempty"`
-	DotProjectProjectRef      string                         `json:"dotProjectProjectRef,omitempty"`
-	DotProjectMaintainerRef   string                         `json:"dotProjectMaintainerRef,omitempty"`
-	DotProjectSecurityRef     string                         `json:"dotProjectSecurityRef,omitempty"`
-	DotProjectContributingRef string                         `json:"dotProjectContributingRef,omitempty"`
-	DotProjectGovernanceRef   string                         `json:"dotProjectGovernanceRef,omitempty"`
-	DotProjectSchemaVersion   string                         `json:"dotProjectSchemaVersion,omitempty"`
-	DotProjectMaintainerCount *uint                          `json:"dotProjectMaintainerCount,omitempty"`
-	DotProjectLastSyncedAt    *time.Time                     `json:"dotProjectLastSyncedAt,omitempty"`
-	DotProjectAdoptionStatus  string                         `json:"dotProjectAdoptionStatus,omitempty"`
-	DotProjectSyncState       *dotProjectSyncStateResponse   `json:"dotProjectSyncState,omitempty"`
-	DotProjectMaintainerCache *dotProjectMaintainerCacheBody `json:"dotProjectMaintainerCache,omitempty"`
-	DotProjectMaintainerPR    *dotProjectMaintainerPRStatus  `json:"dotProjectMaintainerPullRequest,omitempty"`
-	RefStatus                 maintainerRefStatus            `json:"maintainerRefStatus"`
-	LegacyMaintainerRefBody   string                         `json:"legacyMaintainerRefBody,omitempty"`
-	RefOnlyGitHub             []string                       `json:"refOnlyGitHub"`
-	RefLines                  map[string]string              `json:"refLines,omitempty"`
-	OnboardingIssue           string                         `json:"onboardingIssue,omitempty"`
-	MailingList               string                         `json:"mailingList,omitempty"`
-	Maintainers               []projectMaintainerDetail      `json:"maintainers"`
-	Services                  []serviceSummary               `json:"services"`
-	FossaTeamID               *uint                          `json:"fossaTeamId,omitempty"`
-	FossaTeamName             string                         `json:"fossaTeamName,omitempty"`
-	FossaTeamMembers          []fossaTeamMemberSummary       `json:"fossaTeamMembers,omitempty"`
-	FossaInviteIneligible     []fossaInviteIneligibleSummary `json:"fossaInviteIneligible,omitempty"`
-	FossaInviteCandidates     []fossaInviteCandidateSummary  `json:"fossaInviteCandidates,omitempty"`
-	CreatedAt                 time.Time                      `json:"createdAt"`
-	UpdatedAt                 time.Time                      `json:"updatedAt"`
-	DeletedAt                 *time.Time                     `json:"deletedAt,omitempty"`
-	UpdatedBy                 string                         `json:"updatedBy,omitempty"`
-	UpdatedAuditID            *uint                          `json:"updatedAuditId,omitempty"`
+	ID                                 uint                           `json:"id"`
+	Name                               string                         `json:"name"`
+	Maturity                           string                         `json:"maturity"`
+	ParentProjectID                    *uint                          `json:"parentProjectId,omitempty"`
+	LegacyMaintainerRef                string                         `json:"legacyMaintainerRef,omitempty"`
+	DotProjectRepoRef                  string                         `json:"dotProjectRepoRef,omitempty"`
+	DotProjectProjectRef               string                         `json:"dotProjectProjectRef,omitempty"`
+	DotProjectMaintainerRef            string                         `json:"dotProjectMaintainerRef,omitempty"`
+	DotProjectSecurityRef              string                         `json:"dotProjectSecurityRef,omitempty"`
+	DotProjectContributingRef          string                         `json:"dotProjectContributingRef,omitempty"`
+	DotProjectGovernanceRef            string                         `json:"dotProjectGovernanceRef,omitempty"`
+	DotProjectSchemaVersion            string                         `json:"dotProjectSchemaVersion,omitempty"`
+	DotProjectMaintainerCount          *uint                          `json:"dotProjectMaintainerCount,omitempty"`
+	DotProjectLastSyncedAt             *time.Time                     `json:"dotProjectLastSyncedAt,omitempty"`
+	DotProjectAdoptionStatus           string                         `json:"dotProjectAdoptionStatus,omitempty"`
+	DotProjectSyncState                *dotProjectSyncStateResponse   `json:"dotProjectSyncState,omitempty"`
+	DotProjectMaintainerCache          *dotProjectMaintainerCacheBody `json:"dotProjectMaintainerCache,omitempty"`
+	DotProjectMaintainerPR             *dotProjectMaintainerPRStatus  `json:"dotProjectMaintainerPullRequest,omitempty"`
+	DotProjectGeneratedMaintainersYaml string                         `json:"dotProjectGeneratedMaintainersYaml,omitempty"`
+	RefStatus                          maintainerRefStatus            `json:"maintainerRefStatus"`
+	LegacyMaintainerRefBody            string                         `json:"legacyMaintainerRefBody,omitempty"`
+	RefOnlyGitHub                      []string                       `json:"refOnlyGitHub"`
+	RefLines                           map[string]string              `json:"refLines,omitempty"`
+	OnboardingIssue                    string                         `json:"onboardingIssue,omitempty"`
+	MailingList                        string                         `json:"mailingList,omitempty"`
+	Maintainers                        []projectMaintainerDetail      `json:"maintainers"`
+	Services                           []serviceSummary               `json:"services"`
+	FossaTeamID                        *uint                          `json:"fossaTeamId,omitempty"`
+	FossaTeamName                      string                         `json:"fossaTeamName,omitempty"`
+	FossaTeamMembers                   []fossaTeamMemberSummary       `json:"fossaTeamMembers,omitempty"`
+	FossaInviteIneligible              []fossaInviteIneligibleSummary `json:"fossaInviteIneligible,omitempty"`
+	FossaInviteCandidates              []fossaInviteCandidateSummary  `json:"fossaInviteCandidates,omitempty"`
+	CreatedAt                          time.Time                      `json:"createdAt"`
+	UpdatedAt                          time.Time                      `json:"updatedAt"`
+	DeletedAt                          *time.Time                     `json:"deletedAt,omitempty"`
+	UpdatedBy                          string                         `json:"updatedBy,omitempty"`
+	UpdatedAuditID                     *uint                          `json:"updatedAuditId,omitempty"`
 }
 
 type dotProjectSyncStateResponse struct {
@@ -1492,6 +1493,9 @@ func (s *server) handleProject(w http.ResponseWriter, r *http.Request) {
 		if status := s.dotProjectMaintainerPullRequestStatus(r.Context(), project.ID, owner, ".project", maintainerFilePath, session.AccessToken); status != nil {
 			response.DotProjectMaintainerPR = status
 		}
+	}
+	if response.DotProjectMaintainerCache == nil && response.DotProjectAdoptionStatus == "not_found" {
+		response.DotProjectGeneratedMaintainersYaml = dotproject.GenerateMaintainersRosterYAML(activeProjectMaintainerGitHubHandles(project.Maintainers))
 	}
 	if project.OnboardingIssue != nil {
 		onboardingIssue := strings.TrimSpace(*project.OnboardingIssue)

--- a/cmd/web-bff/main_test.go
+++ b/cmd/web-bff/main_test.go
@@ -381,6 +381,76 @@ func TestProjectDetailIncludesDotProjectMaintainerCache(t *testing.T) {
 	assert.True(t, response.DotProjectMaintainerCache.LastCheckedAt.Equal(now))
 }
 
+func TestProjectDetailGeneratesMaintainersYamlWhenNoDotProjectFile(t *testing.T) {
+	dbConn := setupPostgresTestDB(t)
+	store := db.NewSQLStore(dbConn)
+	now := time.Now().UTC().Truncate(time.Second)
+
+	staff := model.StaffMember{
+		Name:          "Staff Tester",
+		GitHubAccount: "staff-tester",
+		Email:         "staff@example.org",
+	}
+	require.NoError(t, dbConn.Create(&staff).Error)
+
+	project := model.Project{
+		Name:                     "Project Nofile",
+		Maturity:                 model.Sandbox,
+		GitHubOrg:                "project-nofile",
+		DotProjectAdoptionStatus: "not_found",
+	}
+	require.NoError(t, dbConn.Create(&project).Error)
+
+	alice := model.Maintainer{
+		Name:             "Alice Example",
+		Email:            "alice@example.org",
+		GitHubAccount:    "alice-example",
+		MaintainerStatus: model.ActiveMaintainer,
+	}
+	require.NoError(t, dbConn.Create(&alice).Error)
+
+	archived := model.Maintainer{
+		Name:             "Departed Maintainer",
+		Email:            "departed@example.org",
+		GitHubAccount:    "departed-example",
+		MaintainerStatus: model.ArchivedMaintainer,
+	}
+	require.NoError(t, dbConn.Create(&archived).Error)
+
+	require.NoError(t, dbConn.Model(&project).Association("Maintainers").Append(&alice, &archived))
+
+	s := &server{
+		store:      store,
+		sessions:   newSessionStore(log.New(io.Discard, "", 0)),
+		cookieName: defaultSessionCookieName,
+		logger:     log.New(io.Discard, "", 0),
+	}
+
+	staffSessionID := "staff-session"
+	s.sessions.Set(session{
+		ID:        staffSessionID,
+		Login:     staff.GitHubAccount,
+		Role:      roleStaff,
+		CreatedAt: now,
+		ExpiresAt: now.Add(time.Hour),
+	})
+
+	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/projects/%d", project.ID), nil)
+	req.AddCookie(&http.Cookie{Name: s.cookieName, Value: staffSessionID})
+	rec := httptest.NewRecorder()
+	handler := s.requireSession(http.HandlerFunc(s.handleProject))
+	handler.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	var response projectDetailResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&response))
+	require.Nil(t, response.DotProjectMaintainerCache)
+	require.NotEmpty(t, response.DotProjectGeneratedMaintainersYaml)
+	assert.Contains(t, response.DotProjectGeneratedMaintainersYaml, `name: "project-maintainers"`)
+	assert.Contains(t, response.DotProjectGeneratedMaintainersYaml, "- alice-example")
+	assert.NotContains(t, response.DotProjectGeneratedMaintainersYaml, "departed-example")
+}
+
 func TestProjectDetailIncludesOpenDotProjectMaintainerPullRequestFromGitHub(t *testing.T) {
 	dbConn := setupPostgresTestDB(t)
 	store := db.NewSQLStore(dbConn)

--- a/dotproject/maintainers_patch.go
+++ b/dotproject/maintainers_patch.go
@@ -123,6 +123,28 @@ func BuildMaintainerRosterPatch(source string, activeHandles []string) (*Maintai
 	}, nil
 }
 
+// GenerateMaintainersRosterYAML builds a scaffold MAINTAINERS.yaml for a project
+// that does not yet have a .project repo, populating the project-maintainers
+// team from the given active GitHub handles.
+func GenerateMaintainersRosterYAML(activeHandles []string) string {
+	handles := missingActiveHandles(activeHandles, map[string]struct{}{})
+
+	var builder strings.Builder
+	builder.WriteString("maintainers:\n")
+	builder.WriteString("  - teams:\n")
+	builder.WriteString("      - name: \"project-maintainers\"\n")
+	builder.WriteString("        members:\n")
+	if len(handles) == 0 {
+		builder.WriteString("          # TODO: Add maintainer GitHub handles\n")
+		builder.WriteString("          - github-handle\n")
+		return builder.String()
+	}
+	for _, handle := range handles {
+		builder.WriteString("          - " + handle + "\n")
+	}
+	return builder.String()
+}
+
 func NormalizeGitHubHandle(handle string) string {
 	return strings.ToLower(strings.Trim(strings.TrimSpace(handle), `@"'`))
 }

--- a/dotproject/maintainers_patch_test.go
+++ b/dotproject/maintainers_patch_test.go
@@ -56,3 +56,35 @@ func TestBuildMaintainerRosterPatchErrorsWhenProjectMaintainersTeamMissing(t *te
 	_, err := BuildMaintainerRosterPatch("maintainers: []\n", []string{"alice"})
 	require.Error(t, err)
 }
+
+func TestGenerateMaintainersRosterYAMLPopulatesActiveHandles(t *testing.T) {
+	yamlContent := GenerateMaintainersRosterYAML([]string{"Bob", "@alice", "alice"})
+
+	assert.Equal(t, `maintainers:
+  - teams:
+      - name: "project-maintainers"
+        members:
+          - bob
+          - alice
+`, yamlContent)
+}
+
+func TestGenerateMaintainersRosterYAMLAddsPlaceholderWhenNoActiveHandles(t *testing.T) {
+	yamlContent := GenerateMaintainersRosterYAML(nil)
+
+	assert.Equal(t, `maintainers:
+  - teams:
+      - name: "project-maintainers"
+        members:
+          # TODO: Add maintainer GitHub handles
+          - github-handle
+`, yamlContent)
+}
+
+func TestGenerateMaintainersRosterYAMLRoundTripsThroughDiscoveryParser(t *testing.T) {
+	yamlContent := GenerateMaintainersRosterYAML([]string{"alice", "bob"})
+
+	handles, status, parseErr := ParseProjectMaintainerHandles(yamlContent)
+	require.Equal(t, ParseStatusParsed, status, parseErr)
+	assert.ElementsMatch(t, []string{"alice", "bob"}, handles)
+}

--- a/features/web/project_dot_project_generate_maintainers.feature
+++ b/features/web/project_dot_project_generate_maintainers.feature
@@ -1,0 +1,26 @@
+Feature: Generate a MAINTAINERS.yaml for projects without a .project repo
+  As a staff member
+  I want to generate a draft MAINTAINERS.yaml from a project's active maintainer-d roster
+  So I can bootstrap the project's .project repo without maintainer-d writing to GitHub
+
+  Background:
+    Given the maintainer-d database contains staff, maintainers, and projects
+    And I am signed in as a staff member
+
+  Scenario: Staff sees a generated MAINTAINERS.yaml for a project with no .project repo
+    Given a project exists without a .project repo
+    When I open the DOT-PROJECT ROLL CALL route for that project
+    Then the dot-project roll call shows a generate MAINTAINERS.yaml panel
+    And the generated MAINTAINERS.yaml lists the project's active maintainers
+
+  Scenario: Staff can copy the generated MAINTAINERS.yaml to the clipboard
+    Given a project exists without a .project repo
+    When I open the DOT-PROJECT ROLL CALL route for that project
+    And I click "Copy to clipboard" on the generate MAINTAINERS.yaml panel
+    Then the system clipboard contains the generated MAINTAINERS.yaml
+    And a "Copied" confirmation is shown
+
+  Scenario: The generate panel does not appear once a .project repo is adopted
+    Given a project exists with reconciliation routes
+    When I open the DOT-PROJECT ROLL CALL route for that project
+    Then the dot-project roll call does not show a generate MAINTAINERS.yaml panel

--- a/web/src/app/projects/[id]/ProjectRouteClient.tsx
+++ b/web/src/app/projects/[id]/ProjectRouteClient.tsx
@@ -79,6 +79,7 @@ type ProjectDetail = {
   dotProjectSyncState?: DotProjectSyncState | null;
   dotProjectMaintainerCache?: DotProjectMaintainerCache | null;
   dotProjectMaintainerPullRequest?: DotProjectMaintainerPullRequest | null;
+  dotProjectGeneratedMaintainersYaml?: string;
   maintainerRefStatus: {
     url?: string;
     status: string;
@@ -188,6 +189,7 @@ const projectDataHasChanged = (current: ProjectDetail | null, next: ProjectDetai
     current.dotProjectMaintainerPullRequest?.number !== next.dotProjectMaintainerPullRequest?.number ||
     current.dotProjectMaintainerPullRequest?.updatedAt !== next.dotProjectMaintainerPullRequest?.updatedAt ||
     current.dotProjectMaintainerPullRequest?.warning !== next.dotProjectMaintainerPullRequest?.warning ||
+    current.dotProjectGeneratedMaintainersYaml !== next.dotProjectGeneratedMaintainersYaml ||
     current.maintainerRefStatus.status !== next.maintainerRefStatus.status ||
     current.maintainerRefStatus.url !== next.maintainerRefStatus.url ||
     current.maintainerRefStatus.checkedAt !== next.maintainerRefStatus.checkedAt ||
@@ -477,6 +479,7 @@ export default function ProjectRouteClient({ children }: ProjectRouteClientProps
                 dotProjectSyncState={project.dotProjectSyncState}
                 dotProjectMaintainerCache={project.dotProjectMaintainerCache}
                 dotProjectMaintainerPullRequest={project.dotProjectMaintainerPullRequest}
+                dotProjectGeneratedMaintainersYaml={project.dotProjectGeneratedMaintainersYaml}
                 maintainerRefStatus={project.maintainerRefStatus}
                 maintainerRefBody={project.legacyMaintainerRefBody}
                 refOnlyGitHub={project.refOnlyGitHub}

--- a/web/src/components/ProjectReconciliationCard.module.css
+++ b/web/src/components/ProjectReconciliationCard.module.css
@@ -871,6 +871,32 @@
   box-shadow: none;
 }
 
+.dotProjectGeneratedYamlActions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 8px 0;
+}
+
+.dotProjectGeneratedYamlBlock {
+  white-space: pre-wrap;
+  word-break: break-word;
+  padding: 12px;
+  border-radius: 8px;
+  background: var(--code-block-background, #1e1e1e);
+  color: var(--code-block-foreground, #d4d4d4);
+  font-family: "Fira Mono", "SFMono-Regular", Consolas, monospace;
+  font-size: 12px;
+  line-height: 1.5;
+  overflow-x: auto;
+}
+
+.copyToast {
+  font-size: 11px;
+  color: #d62293;
+  font-weight: 600;
+}
+
 .dotProjectTeamGrid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));

--- a/web/src/components/ProjectReconciliationCard.tsx
+++ b/web/src/components/ProjectReconciliationCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Card } from "clo-ui/components/Card";
 import ReactMarkdown from "react-markdown";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
@@ -152,6 +152,7 @@ type ProjectReconciliationCardProps = {
   dotProjectSyncState?: DotProjectSyncStateSummary | null;
   dotProjectMaintainerCache?: DotProjectMaintainerCacheSummary | null;
   dotProjectMaintainerPullRequest?: DotProjectMaintainerPullRequestSummary | null;
+  dotProjectGeneratedMaintainersYaml?: string | null;
   maintainerRefStatus: {
     url?: string;
     status: string;
@@ -294,6 +295,7 @@ export default function ProjectReconciliationCard({
   dotProjectSyncState,
   dotProjectMaintainerCache,
   dotProjectMaintainerPullRequest,
+  dotProjectGeneratedMaintainersYaml,
   maintainerRefStatus,
   maintainerRefBody,
   refLines,
@@ -338,6 +340,20 @@ export default function ProjectReconciliationCard({
     dotProjectMaintainerCache?.filename || dotProjectMaintainersFilename || "maintainers.yaml";
   const openDotProjectMaintainerPR =
     dotProjectMaintainerPullRequest?.status === "open" ? dotProjectMaintainerPullRequest : null;
+  const generatedMaintainersYaml = dotProjectGeneratedMaintainersYaml?.trim() ? dotProjectGeneratedMaintainersYaml : "";
+  const [generatedYamlCopyNotice, setGeneratedYamlCopyNotice] = useState(false);
+  const generatedYamlCopyTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const handleCopyGeneratedMaintainersYaml = async () => {
+    if (!generatedMaintainersYaml) return;
+    try {
+      await navigator.clipboard.writeText(generatedMaintainersYaml);
+      setGeneratedYamlCopyNotice(true);
+      if (generatedYamlCopyTimer.current) clearTimeout(generatedYamlCopyTimer.current);
+      generatedYamlCopyTimer.current = setTimeout(() => setGeneratedYamlCopyNotice(false), 1500);
+    } catch {
+      // clipboard unavailable
+    }
+  };
   const dotProjectFiles = [
     {
       label: ".project repo",
@@ -947,6 +963,30 @@ export default function ProjectReconciliationCard({
             }}
             source={dotProjectMaintainerCacheBody}
           />
+        </div>
+      ) : dotProjectMissing && generatedMaintainersYaml ? (
+        <div className={styles.tableSection}>
+          <div className={styles.tableHeader}>
+            <h3 className={styles.tableTitle}>Generate MAINTAINERS.yaml</h3>
+          </div>
+          <p className={styles.secondary}>
+            This project does not have a <code>.project</code> repo yet. The draft below is generated from the
+            project&apos;s active maintainer-d roster — review it, then copy it into a new <code>MAINTAINERS.yaml</code>
+            file in the project&apos;s <code>.project</code> repo.
+          </p>
+          <div className={styles.dotProjectGeneratedYamlActions}>
+            <button
+              type="button"
+              className={styles.dotProjectPreviewButton}
+              onClick={handleCopyGeneratedMaintainersYaml}
+            >
+              Copy to clipboard
+            </button>
+            {generatedYamlCopyNotice ? <span className={styles.copyToast}>Copied</span> : null}
+          </div>
+          <pre className={styles.dotProjectGeneratedYamlBlock}>
+            <code>{generatedMaintainersYaml}</code>
+          </pre>
         </div>
       ) : null}
       <div className={styles.tableSection}>

--- a/web/tests/steps/project_dot_project_generate_maintainers.steps.js
+++ b/web/tests/steps/project_dot_project_generate_maintainers.steps.js
@@ -1,0 +1,76 @@
+const { Given, When, Then } = require("@cucumber/cucumber");
+const { expect } = require("@playwright/test");
+
+const noDotProjectRepoName = "Project Beacon";
+
+const resolveProjectId = async (world, name) => {
+  const response = await world.page.request.get(
+    `${world.bffBaseUrl}/api/search?query=${encodeURIComponent(name)}`
+  );
+  if (!response.ok()) {
+    throw new Error(`Failed to search project: ${response.status()}`);
+  }
+  const data = await response.json();
+  const project = (data.projects || []).find((item) => item.name === name);
+  if (!project) {
+    throw new Error(`Project ${name} not found in search results.`);
+  }
+  return project.id;
+};
+
+Given("a project exists without a .project repo", function () {
+  this.projectName = noDotProjectRepoName;
+});
+
+When("I open the DOT-PROJECT ROLL CALL route for that project", async function () {
+  this.projectId = await resolveProjectId(this, this.projectName);
+  await this.context.grantPermissions(["clipboard-read", "clipboard-write"], {
+    origin: this.baseUrl,
+  });
+  await this.page.goto(`${this.baseUrl}/projects/${this.projectId}/dot-project`, {
+    waitUntil: "domcontentloaded",
+  });
+  await expect(this.page.getByRole("heading", { name: this.projectName })).toBeVisible({
+    timeout: 15000,
+  });
+});
+
+When("I click {string} on the generate MAINTAINERS.yaml panel", async function (buttonName) {
+  const contentColumn = this.page.locator('[class*="contentColumn"]');
+  await contentColumn.getByRole("button", { name: buttonName, exact: true }).click();
+});
+
+Then("the dot-project roll call shows a generate MAINTAINERS.yaml panel", async function () {
+  const contentColumn = this.page.locator('[class*="contentColumn"]');
+  await expect(contentColumn.getByText("Generate MAINTAINERS.yaml", { exact: true })).toBeVisible({
+    timeout: 15000,
+  });
+  await expect(
+    contentColumn.getByText("This project does not have a .project repo yet.", { exact: false })
+  ).toBeVisible({ timeout: 15000 });
+});
+
+Then("the dot-project roll call does not show a generate MAINTAINERS.yaml panel", async function () {
+  const contentColumn = this.page.locator('[class*="contentColumn"]');
+  await expect(contentColumn.getByText("Generate MAINTAINERS.yaml", { exact: true })).toHaveCount(0);
+});
+
+Then("the generated MAINTAINERS.yaml lists the project's active maintainers", async function () {
+  const contentColumn = this.page.locator('[class*="contentColumn"]');
+  const generatedBlock = contentColumn.locator('[class*="dotProjectGeneratedYamlBlock"]');
+  await expect(generatedBlock).toContainText('name: "project-maintainers"');
+  await expect(generatedBlock).toContainText("antonio-example");
+  await expect(generatedBlock).toContainText("diego-placeholder");
+});
+
+Then("the system clipboard contains the generated MAINTAINERS.yaml", async function () {
+  const clipboardText = await this.page.evaluate(() => navigator.clipboard.readText());
+  expect(clipboardText).toContain('name: "project-maintainers"');
+  expect(clipboardText).toContain("antonio-example");
+  expect(clipboardText).toContain("diego-placeholder");
+});
+
+Then("a {string} confirmation is shown", async function (message) {
+  const contentColumn = this.page.locator('[class*="contentColumn"]');
+  await expect(contentColumn.getByText(message, { exact: true })).toBeVisible({ timeout: 15000 });
+});


### PR DESCRIPTION
viewable and copyable from the DOT-PROJECT ROLL CALL route

Refs cncf/maintainer-d#129