### PR TITLE
updates the FOSSA API swagger baseline to 4.34.66

### DIFF
--- a/plugins/fossa/swagger.json
+++ b/plugins/fossa/swagger.json
@@ -8,7 +8,7 @@
       "url": "fossa.com",
       "email": "support@fossa.com"
     },
-    "version": "4.32.3"
+    "version": "4.34.66"
   },
   "servers": [
     {
@@ -137,6 +137,10 @@
       "description": "Manage GitHub App integration"
     },
     {
+      "name": "Fossabot",
+      "description": "Manage fossabot dependency-upgrade pull requests"
+    },
+    {
       "name": "Binary",
       "description": "APIs related to Binary Decomposition functionality"
     },
@@ -159,6 +163,10 @@
     {
       "name": "Report Options",
       "description": "APIs for managing saved report options"
+    },
+    {
+      "name": "Registry Search",
+      "description": "APIs for searching third-party package registries"
     }
   ],
   "paths": {
@@ -193,7 +201,7 @@
                           "scope": {
                             "type": "string",
                             "enum": [
-                              "PROJECT"
+                              "project"
                             ],
                             "description": "Project-scoped conclusion"
                           },
@@ -213,7 +221,7 @@
                           "scope": {
                             "type": "string",
                             "enum": [
-                              "REVISION"
+                              "revision"
                             ],
                             "description": "Revision-scoped conclusion"
                           },
@@ -238,7 +246,7 @@
                           "scope": {
                             "type": "string",
                             "enum": [
-                              "RELEASE_GROUP"
+                              "release_group"
                             ],
                             "description": "Release group-scoped conclusion"
                           },
@@ -258,7 +266,7 @@
                           "scope": {
                             "type": "string",
                             "enum": [
-                              "RELEASE"
+                              "release"
                             ],
                             "description": "Release-scoped conclusion"
                           },
@@ -275,6 +283,41 @@
                           "scope",
                           "releaseGroupId",
                           "releaseId"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "scope": {
+                            "type": "string",
+                            "enum": [
+                              "organization"
+                            ],
+                            "description": "Organization-scoped conclusion"
+                          },
+                          "organizationId": {
+                            "type": "integer",
+                            "description": "The ID of the organization"
+                          }
+                        },
+                        "required": [
+                          "scope",
+                          "organizationId"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "scope": {
+                            "type": "string",
+                            "enum": [
+                              "global"
+                            ],
+                            "description": "Global conclusion (FOSSA admins only)"
+                          }
+                        },
+                        "required": [
+                          "scope"
                         ]
                       }
                     ]
@@ -300,7 +343,7 @@
                   "value": {
                     "dependencyRevisionLocator": "npm+lodash$4.17.21",
                     "scope": {
-                      "scope": "PROJECT",
+                      "scope": "project",
                       "projectLocator": "git+github.com/fossas/fossa-cli$main"
                     },
                     "licenseId": "MIT",
@@ -312,7 +355,7 @@
                   "value": {
                     "dependencyRevisionLocator": "npm+lodash$4.17.21",
                     "scope": {
-                      "scope": "REVISION",
+                      "scope": "revision",
                       "projectLocator": "git+github.com/fossas/fossa-cli$main",
                       "revisionLocator": "git+github.com/fossas/fossa-cli$abc123"
                     },
@@ -324,11 +367,32 @@
                   "value": {
                     "dependencyRevisionLocator": "npm+lodash$4.17.21",
                     "scope": {
-                      "scope": "RELEASE_GROUP",
+                      "scope": "release_group",
                       "releaseGroupId": 123
                     },
                     "licenseId": "MIT",
                     "originId": "456"
+                  }
+                },
+                "organizationScope": {
+                  "summary": "Organization-scoped conclusion",
+                  "value": {
+                    "dependencyRevisionLocator": "npm+lodash$4.17.21",
+                    "scope": {
+                      "scope": "organization",
+                      "organizationId": 42
+                    },
+                    "licenseId": "MIT"
+                  }
+                },
+                "globalScope": {
+                  "summary": "Global-scoped conclusion (FOSSA admins only)",
+                  "value": {
+                    "dependencyRevisionLocator": "npm+lodash$4.17.21",
+                    "scope": {
+                      "scope": "global"
+                    },
+                    "licenseId": "MIT"
                   }
                 }
               }
@@ -350,18 +414,20 @@
                     "scope": {
                       "type": "string",
                       "enum": [
-                        "PROJECT",
-                        "REVISION",
-                        "RELEASE_GROUP",
-                        "RELEASE"
+                        "project",
+                        "revision",
+                        "release_group",
+                        "release",
+                        "organization",
+                        "global"
                       ],
-                      "nullable": false,
-                      "description": "The scope of the license conclusion"
+                      "nullable": true,
+                      "description": "The scope of the license conclusion. May be `null` for auto-generated conclusions."
                     },
                     "scopeId": {
                       "type": "string",
-                      "nullable": false,
-                      "description": "The ID of the scope (project locator, revision locator, release group ID, etc.)"
+                      "nullable": true,
+                      "description": "The ID of the scope (project locator, revision locator, release group ID, etc.). `null` for global conclusions."
                     },
                     "concludedLicenses": {
                       "type": "array",
@@ -394,7 +460,7 @@
                   "licenseConclusionResponse": {
                     "value": {
                       "dependencyRevisionLocator": "npm+lodash$4.17.21",
-                      "scope": "PROJECT",
+                      "scope": "project",
                       "scopeId": "git+github.com/fossas/fossa-cli$main",
                       "concludedLicenses": [
                         "MIT",
@@ -441,13 +507,19 @@
                   "invalidRequest": {
                     "summary": "Invalid request body",
                     "value": {
-                      "error": "Invalid request body: missing required field"
+                      "code": 2003,
+                      "message": "Invalid request body: missing required field",
+                      "name": "BadRequestError",
+                      "httpStatusCode": 400
                     }
                   },
                   "missingScopeId": {
                     "summary": "Missing scopeId for scoped conclusion",
                     "value": {
-                      "error": "scopeId is required for project/revision scopes"
+                      "code": 2003,
+                      "message": "scopeId is required for project/revision scopes",
+                      "name": "BadRequestError",
+                      "httpStatusCode": 400
                     }
                   }
                 }
@@ -487,7 +559,10 @@
                   "forbidden": {
                     "summary": "Insufficient permissions",
                     "value": {
-                      "error": "You do not have permission to edit license conclusions for this scope"
+                      "code": 2005,
+                      "message": "You do not have permission to edit license conclusions for this scope",
+                      "name": "ForbiddenError",
+                      "httpStatusCode": 403
                     }
                   }
                 }
@@ -527,13 +602,19 @@
                   "revisionNotFound": {
                     "summary": "Origin revision not found",
                     "value": {
-                      "error": "Origin revision with locator git+github.com/fossas/fossa-cli$abc123 not found or you don't have access"
+                      "code": 2004,
+                      "message": "Origin revision with locator git+github.com/fossas/fossa-cli$abc123 not found or you don't have access",
+                      "name": "NotFoundError",
+                      "httpStatusCode": 404
                     }
                   },
                   "releaseNotFound": {
                     "summary": "Origin release not found",
                     "value": {
-                      "error": "Origin release with locator 123 not found or you don't have access"
+                      "code": 2004,
+                      "message": "Origin release with locator 123 not found or you don't have access",
+                      "name": "NotFoundError",
+                      "httpStatusCode": 404
                     }
                   }
                 }
@@ -574,7 +655,7 @@
                           "scope": {
                             "type": "string",
                             "enum": [
-                              "PROJECT"
+                              "project"
                             ],
                             "description": "Project-scoped conclusion"
                           },
@@ -594,7 +675,7 @@
                           "scope": {
                             "type": "string",
                             "enum": [
-                              "REVISION"
+                              "revision"
                             ],
                             "description": "Revision-scoped conclusion"
                           },
@@ -619,7 +700,7 @@
                           "scope": {
                             "type": "string",
                             "enum": [
-                              "RELEASE_GROUP"
+                              "release_group"
                             ],
                             "description": "Release group-scoped conclusion"
                           },
@@ -639,7 +720,7 @@
                           "scope": {
                             "type": "string",
                             "enum": [
-                              "RELEASE"
+                              "release"
                             ],
                             "description": "Release-scoped conclusion"
                           },
@@ -656,6 +737,41 @@
                           "scope",
                           "releaseGroupId",
                           "releaseId"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "scope": {
+                            "type": "string",
+                            "enum": [
+                              "organization"
+                            ],
+                            "description": "Organization-scoped conclusion"
+                          },
+                          "organizationId": {
+                            "type": "integer",
+                            "description": "The ID of the organization"
+                          }
+                        },
+                        "required": [
+                          "scope",
+                          "organizationId"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "scope": {
+                            "type": "string",
+                            "enum": [
+                              "global"
+                            ],
+                            "description": "Global conclusion (FOSSA admins only)"
+                          }
+                        },
+                        "required": [
+                          "scope"
                         ]
                       }
                     ]
@@ -681,7 +797,7 @@
                   "value": {
                     "dependencyRevisionLocator": "npm+lodash$4.17.21",
                     "scope": {
-                      "scope": "PROJECT",
+                      "scope": "project",
                       "projectLocator": "git+github.com/fossas/fossa-cli$main"
                     },
                     "licenseId": "MIT",
@@ -693,7 +809,7 @@
                   "value": {
                     "dependencyRevisionLocator": "npm+lodash$4.17.21",
                     "scope": {
-                      "scope": "REVISION",
+                      "scope": "revision",
                       "projectLocator": "git+github.com/fossas/fossa-cli$main",
                       "revisionLocator": "git+github.com/fossas/fossa-cli$abc123"
                     },
@@ -705,7 +821,7 @@
                   "value": {
                     "dependencyRevisionLocator": "npm+lodash$4.17.21",
                     "scope": {
-                      "scope": "RELEASE_GROUP",
+                      "scope": "release_group",
                       "releaseGroupId": 123
                     },
                     "licenseId": "MIT",
@@ -713,11 +829,11 @@
                   }
                 },
                 "globalScope": {
-                  "summary": "Global-scoped conclusion",
+                  "summary": "Global-scoped conclusion (FOSSA admins only)",
                   "value": {
                     "dependencyRevisionLocator": "npm+lodash$4.17.21",
                     "scope": {
-                      "scope": "GLOBAL"
+                      "scope": "global"
                     },
                     "licenseId": "MIT"
                   }
@@ -741,18 +857,20 @@
                     "scope": {
                       "type": "string",
                       "enum": [
-                        "PROJECT",
-                        "REVISION",
-                        "RELEASE_GROUP",
-                        "RELEASE"
+                        "project",
+                        "revision",
+                        "release_group",
+                        "release",
+                        "organization",
+                        "global"
                       ],
-                      "nullable": false,
-                      "description": "The scope of the license conclusion"
+                      "nullable": true,
+                      "description": "The scope of the license conclusion. May be `null` for auto-generated conclusions."
                     },
                     "scopeId": {
                       "type": "string",
-                      "nullable": false,
-                      "description": "The ID of the scope (project locator, revision locator, release group ID, etc.)"
+                      "nullable": true,
+                      "description": "The ID of the scope (project locator, revision locator, release group ID, etc.). `null` for global conclusions."
                     },
                     "concludedLicenses": {
                       "type": "array",
@@ -786,7 +904,7 @@
                     "summary": "License removed from conclusions",
                     "value": {
                       "dependencyRevisionLocator": "npm+lodash$4.17.21",
-                      "scope": "PROJECT",
+                      "scope": "project",
                       "scopeId": "git+github.com/fossas/fossa-cli$main",
                       "concludedLicenses": [
                         "Apache-2.0"
@@ -952,7 +1070,7 @@
             "description": "Redirects to the GitHub App installation page."
           },
           "403": {
-            "description": "Forbidden",
+            "description": "The authenticated user is not associated with an organization.",
             "content": {
               "application/json": {
                 "schema": {
@@ -981,13 +1099,53 @@
                   }
                 },
                 "examples": {
-                  "No permission": {
+                  "noOrganization": {
+                    "summary": "User is not in an organization",
                     "value": {
-                      "uuid": "00000000-0000-0000-0000-000000000000",
-                      "code": 2005,
-                      "message": "User does not have permission to view this resource",
-                      "name": "ForbiddenError",
-                      "httpStatusCode": 403
+                      "message": "You must be in an organization to view this page."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The GitHub App is not configured for this FOSSA instance.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "notConfigured": {
+                    "summary": "GitHub App not configured",
+                    "value": {
+                      "code": 2004,
+                      "message": "GitHub App not configured",
+                      "name": "NotFoundError",
+                      "httpStatusCode": 404
                     }
                   }
                 }
@@ -1031,6 +1189,1832 @@
                       "message": "Sorry, we've encountered an unexpected error. We've recorded it. If you continue to see this, contact support at support@fossa.com and include the unique reference code: 00000000-0000-0000-0000-000000000000",
                       "name": "InternalServerError",
                       "httpStatusCode": 500
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/fossabot/status": {
+      "get": {
+        "operationId": "getFossabotStatus",
+        "x-internal": true,
+        "description": "fossabot connection and credit status for the calling organization, optionally scoped to one project's repository.\n",
+        "tags": [
+          "Fossabot"
+        ],
+        "security": [
+          {
+            "ApiToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "projectLocator",
+            "description": "Scope the connection check to this project's repository.",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "example": "git+github.com/fossas/example"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The fossabot connection status.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "connected",
+                    "appUrl",
+                    "creditLevel"
+                  ],
+                  "properties": {
+                    "connected": {
+                      "type": "boolean"
+                    },
+                    "appUrl": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "creditLevel": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "enum": [
+                        "available",
+                        "low",
+                        "exhausted",
+                        null
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Bad API Token": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2010,
+                      "message": "API token is invalid",
+                      "name": "UnauthorizedError",
+                      "httpStatusCode": 401
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The fossabot feature is not enabled or the caller lacks permission.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The project does not exist in the calling organization.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Server Error": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2009,
+                      "message": "Sorry, we've encountered an unexpected error. We've recorded it. If you continue to see this, contact support at support@fossa.com and include the unique reference code: 00000000-0000-0000-0000-000000000000",
+                      "name": "InternalServerError",
+                      "httpStatusCode": 500
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/fossabot/dependency-upgrade-prs": {
+      "get": {
+        "operationId": "listFossabotDependencyUpgradePRs",
+        "x-internal": true,
+        "description": "One cursor-paginated slice of fossabot dependency-upgrade PRs for a project's repository. Provide either first (with optional after) or last (with optional before). A project that is not a fossabot-connected GitHub repository reads as an empty connection.\n",
+        "tags": [
+          "Fossabot"
+        ],
+        "security": [
+          {
+            "ApiToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "projectLocator",
+            "description": "The project whose repository's PRs to list.",
+            "required": true,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "example": "git+github.com/fossas/example"
+          },
+          {
+            "name": "first",
+            "description": "Number of PRs to return while traversing forward. Cannot be combined with last or before.",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100
+            }
+          },
+          {
+            "name": "after",
+            "description": "Opaque end cursor from the preceding forward slice. Requires first.",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "last",
+            "description": "Number of PRs to return while traversing backward. Cannot be combined with first or after.",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100
+            }
+          },
+          {
+            "name": "before",
+            "description": "Opaque start cursor from the following backward slice. Requires last.",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "state",
+            "description": "Filter by VCS state.",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "open",
+                "draft",
+                "closed",
+                "merged"
+              ]
+            }
+          },
+          {
+            "name": "search",
+            "description": "Filter PRs by title.",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sort",
+            "description": "Sort order; newest first by default.",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "newest",
+                "oldest"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "One cursor-paginated slice of fossabot PRs.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "nodes",
+                    "pageInfo"
+                  ],
+                  "properties": {
+                    "nodes": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "description": "One fossabot dependency-upgrade PR row on the project PRs tab.",
+                        "required": [
+                          "title",
+                          "prNumber",
+                          "vcsUrl",
+                          "fossabotUrl",
+                          "state",
+                          "analysisBadge",
+                          "initiatedByUserId",
+                          "initiatedByName",
+                          "openedAt",
+                          "closedAt",
+                          "mergedAt"
+                        ],
+                        "properties": {
+                          "title": {
+                            "type": "string"
+                          },
+                          "prNumber": {
+                            "type": [
+                              "integer",
+                              "null"
+                            ]
+                          },
+                          "vcsUrl": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "fossabotUrl": {
+                            "description": "PR detail page in the fossabot app. Null when fossabot did not give one.",
+                            "type": [
+                              "string",
+                              "null"
+                            ],
+                            "example": "https://bot.fossa.com/pull-requests/9f2b1c04-6d3a-4d1e-9f88-2a7c5b0e41d7"
+                          },
+                          "state": {
+                            "type": "string",
+                            "enum": [
+                              "open",
+                              "draft",
+                              "closed",
+                              "merged"
+                            ]
+                          },
+                          "analysisBadge": {
+                            "type": [
+                              "string",
+                              "null"
+                            ],
+                            "enum": [
+                              "scanning",
+                              "analyzed",
+                              "needsReview",
+                              null
+                            ]
+                          },
+                          "initiatedByUserId": {
+                            "description": "FOSSA user id of the initiator; null for automated PRs.",
+                            "type": [
+                              "integer",
+                              "null"
+                            ]
+                          },
+                          "initiatedByName": {
+                            "description": "Display name of the initiator; null for automated PRs and for ids with no user in the calling organization.\n",
+                            "type": [
+                              "string",
+                              "null"
+                            ],
+                            "example": "Barbu Paul"
+                          },
+                          "openedAt": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "closedAt": {
+                            "type": [
+                              "string",
+                              "null"
+                            ],
+                            "format": "date-time"
+                          },
+                          "mergedAt": {
+                            "type": [
+                              "string",
+                              "null"
+                            ],
+                            "format": "date-time"
+                          }
+                        }
+                      }
+                    },
+                    "pageInfo": {
+                      "type": "object",
+                      "description": "Cursor metadata for the requested traversal direction. Clients should retain cursors from visited slices to navigate back to them.\n",
+                      "required": [
+                        "startCursor",
+                        "endCursor",
+                        "hasNextPage",
+                        "hasPreviousPage"
+                      ],
+                      "properties": {
+                        "startCursor": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "endCursor": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "hasNextPage": {
+                          "type": "boolean",
+                          "description": "For forward requests, whether another forward slice exists. Always false for backward requests.\n"
+                        },
+                        "hasPreviousPage": {
+                          "type": "boolean",
+                          "description": "For backward requests, whether another backward slice exists. Always false for forward requests.\n"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Bad Request Parameter/Body": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2003,
+                      "message": "Parse error at root.X: ...",
+                      "name": "BadRequestError",
+                      "httpStatusCode": 400
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The fossabot feature is not enabled or the caller lacks permission.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The project does not exist in the calling organization.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Server Error": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2009,
+                      "message": "Sorry, we've encountered an unexpected error. We've recorded it. If you continue to see this, contact support at support@fossa.com and include the unique reference code: 00000000-0000-0000-0000-000000000000",
+                      "name": "InternalServerError",
+                      "httpStatusCode": 500
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/fossabot/dependency-upgrade-prs/counts": {
+      "get": {
+        "operationId": "getFossabotDependencyUpgradePRCounts",
+        "x-internal": true,
+        "description": "Counts of fossabot dependency-upgrade PRs for a project's repository, by VCS state and analysis verdict. Drives the PRs-tab stat cards and filter chips.\n",
+        "tags": [
+          "Fossabot"
+        ],
+        "security": [
+          {
+            "ApiToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "projectLocator",
+            "description": "The project whose repository's PR counts to fetch.",
+            "required": true,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "example": "git+github.com/fossas/example"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The PR counts.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "total",
+                    "open",
+                    "draft",
+                    "analyzed",
+                    "needsReview",
+                    "closed",
+                    "merged"
+                  ],
+                  "properties": {
+                    "total": {
+                      "type": "integer"
+                    },
+                    "open": {
+                      "type": "integer"
+                    },
+                    "draft": {
+                      "type": "integer"
+                    },
+                    "analyzed": {
+                      "type": "integer"
+                    },
+                    "needsReview": {
+                      "type": "integer"
+                    },
+                    "closed": {
+                      "type": "integer"
+                    },
+                    "merged": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Bad Request Parameter/Body": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2003,
+                      "message": "Parse error at root.X: ...",
+                      "name": "BadRequestError",
+                      "httpStatusCode": 400
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The fossabot feature is not enabled or the caller lacks permission.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The project does not exist in the calling organization.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Server Error": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2009,
+                      "message": "Sorry, we've encountered an unexpected error. We've recorded it. If you continue to see this, contact support at support@fossa.com and include the unique reference code: 00000000-0000-0000-0000-000000000000",
+                      "name": "InternalServerError",
+                      "httpStatusCode": 500
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/fossabot/issues/{issueId}/dependency-upgrade-pr": {
+      "get": {
+        "operationId": "getFossabotDependencyUpgradePR",
+        "x-internal": true,
+        "description": "Current state of the fossabot dependency-upgrade PR for an issue: creation progress, analysis progress, and the PR link once it exists.\n",
+        "tags": [
+          "Fossabot"
+        ],
+        "security": [
+          {
+            "ApiToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "issueId",
+            "description": "The FOSSA issue id.",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "projectLocator",
+            "description": "Required only when the issue affects more than one project.",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "jobId",
+            "description": "Creation-job id returned by the create response. A failed creation job is only reportable through its id.\n",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The PR state for the issue.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "State of a fossabot dependency-upgrade PR for a FOSSA issue.",
+                  "required": [
+                    "status",
+                    "vcsUrl",
+                    "fossabotUrl",
+                    "isAnalysisDelayed",
+                    "jobId"
+                  ],
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "none",
+                        "creating",
+                        "queued",
+                        "analyzing",
+                        "analysisNotRun",
+                        "needsReview",
+                        "readyToMerge",
+                        "merged",
+                        "closed",
+                        "failed"
+                      ]
+                    },
+                    "vcsUrl": {
+                      "description": "PR URL on the VCS provider. Null until the PR exists.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "fossabotUrl": {
+                      "description": "PR URL in the fossabot UI. Null until the PR exists.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "isAnalysisDelayed": {
+                      "description": "True while analysis is taking longer than expected or should be retried.",
+                      "type": "boolean"
+                    },
+                    "jobId": {
+                      "description": "Creation-job id to pass back on the status endpoint.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Bad Request Parameter/Body": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2003,
+                      "message": "Parse error at root.X: ...",
+                      "name": "BadRequestError",
+                      "httpStatusCode": 400
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Bad API Token": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2010,
+                      "message": "API token is invalid",
+                      "name": "UnauthorizedError",
+                      "httpStatusCode": 401
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The fossabot feature is not enabled or the caller lacks permission.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The issue does not exist in the calling organization.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Server Error": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2009,
+                      "message": "Sorry, we've encountered an unexpected error. We've recorded it. If you continue to see this, contact support at support@fossa.com and include the unique reference code: 00000000-0000-0000-0000-000000000000",
+                      "name": "InternalServerError",
+                      "httpStatusCode": 500
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "createFossabotDependencyUpgradePR",
+        "x-internal": true,
+        "description": "Ask fossabot to open a dependency-upgrade pull request for the issue. Asynchronous: the response is usually 'creating'; poll the GET endpoint with the returned jobId to watch it progress. Re-invoking after a failure starts a fresh attempt; invoking while a PR is already in flight returns the existing state.\n",
+        "tags": [
+          "Fossabot"
+        ],
+        "security": [
+          {
+            "ApiToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "issueId",
+            "description": "The FOSSA issue id.",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "fix": {
+                    "description": "Which remediation target to use. Defaults to complete.",
+                    "type": "string",
+                    "enum": [
+                      "partial",
+                      "complete"
+                    ]
+                  },
+                  "projectLocator": {
+                    "description": "Required only when the issue affects more than one project.",
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The freshly created (or already existing) PR state.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "State of a fossabot dependency-upgrade PR for a FOSSA issue.",
+                  "required": [
+                    "status",
+                    "vcsUrl",
+                    "fossabotUrl",
+                    "isAnalysisDelayed",
+                    "jobId"
+                  ],
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "none",
+                        "creating",
+                        "queued",
+                        "analyzing",
+                        "analysisNotRun",
+                        "needsReview",
+                        "readyToMerge",
+                        "merged",
+                        "closed",
+                        "failed"
+                      ]
+                    },
+                    "vcsUrl": {
+                      "description": "PR URL on the VCS provider. Null until the PR exists.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "fossabotUrl": {
+                      "description": "PR URL in the fossabot UI. Null until the PR exists.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "isAnalysisDelayed": {
+                      "description": "True while analysis is taking longer than expected or should be retried.",
+                      "type": "boolean"
+                    },
+                    "jobId": {
+                      "description": "Creation-job id to pass back on the status endpoint.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Bad Request Parameter/Body": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2003,
+                      "message": "Parse error at root.X: ...",
+                      "name": "BadRequestError",
+                      "httpStatusCode": 400
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Bad API Token": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2010,
+                      "message": "API token is invalid",
+                      "name": "UnauthorizedError",
+                      "httpStatusCode": 401
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The fossabot feature is not enabled or the caller lacks permission.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The issue does not exist in the calling organization.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Server Error": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2009,
+                      "message": "Sorry, we've encountered an unexpected error. We've recorded it. If you continue to see this, contact support at support@fossa.com and include the unique reference code: 00000000-0000-0000-0000-000000000000",
+                      "name": "InternalServerError",
+                      "httpStatusCode": 500
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "The fossabot integration is not configured.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/fossabot/issues/{issueId}/dependency-upgrade-pr/retry": {
+      "post": {
+        "operationId": "retryFossabotDependencyUpgradePRAnalysis",
+        "x-internal": true,
+        "description": "Re-run fossabot's analysis on the issue's dependency-upgrade PR (the \"analysis delayed\" retry action). Analysis consumes fossabot credits.\n",
+        "tags": [
+          "Fossabot"
+        ],
+        "security": [
+          {
+            "ApiToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "issueId",
+            "description": "The FOSSA issue id.",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "projectLocator": {
+                    "description": "Required only when the issue affects more than one project.",
+                    "type": "string",
+                    "minLength": 1
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The refreshed PR state.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "State of a fossabot dependency-upgrade PR for a FOSSA issue.",
+                  "required": [
+                    "status",
+                    "vcsUrl",
+                    "fossabotUrl",
+                    "isAnalysisDelayed",
+                    "jobId"
+                  ],
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "none",
+                        "creating",
+                        "queued",
+                        "analyzing",
+                        "analysisNotRun",
+                        "needsReview",
+                        "readyToMerge",
+                        "merged",
+                        "closed",
+                        "failed"
+                      ]
+                    },
+                    "vcsUrl": {
+                      "description": "PR URL on the VCS provider. Null until the PR exists.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "fossabotUrl": {
+                      "description": "PR URL in the fossabot UI. Null until the PR exists.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "isAnalysisDelayed": {
+                      "description": "True while analysis is taking longer than expected or should be retried.",
+                      "type": "boolean"
+                    },
+                    "jobId": {
+                      "description": "Creation-job id to pass back on the status endpoint.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Bad Request Parameter/Body": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2003,
+                      "message": "Parse error at root.X: ...",
+                      "name": "BadRequestError",
+                      "httpStatusCode": 400
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "The organization is out of fossabot credits.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The fossabot feature is not enabled or the caller lacks permission.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The issue or its fossabot PR does not exist.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "The analysis is already running and cannot be retried yet.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Server Error": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2009,
+                      "message": "Sorry, we've encountered an unexpected error. We've recorded it. If you continue to see this, contact support at support@fossa.com and include the unique reference code: 00000000-0000-0000-0000-000000000000",
+                      "name": "InternalServerError",
+                      "httpStatusCode": 500
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "The fossabot integration is not configured.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
                     }
                   }
                 }
@@ -1101,6 +3085,30 @@
             "in": "query",
             "schema": {
               "type": "string"
+            }
+          },
+          {
+            "name": "teamId",
+            "description": "Filter issues by one or more team IDs. Accepts a single team ID, an array of team IDs, or the literal string `\"null\"` to scope to unassigned projects. Requires the `View` permission on each requested team; otherwise the request is rejected with a `403`. Ignored for organizations on the free tier.\n",
+            "in": "query",
+            "schema": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "null"
+                  ]
+                }
+              ]
             }
           }
         ],
@@ -1358,6 +3366,30 @@
             "in": "query",
             "schema": {
               "type": "string"
+            }
+          },
+          {
+            "name": "teamId",
+            "description": "Filter issues by one or more team IDs. Accepts a single team ID, an array of team IDs, or the literal string `\"null\"` to scope to unassigned projects. Requires the `View` permission on each requested team; otherwise the request is rejected with a `403`. Ignored for organizations on the free tier.\n",
+            "in": "query",
+            "schema": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "null"
+                  ]
+                }
+              ]
             }
           }
         ],
@@ -1950,6 +3982,30 @@
                 }
               ]
             }
+          },
+          {
+            "name": "teamId",
+            "description": "Filter issues by one or more team IDs. Accepts a single team ID, an array of team IDs, or the literal string `\"null\"` to scope to unassigned projects. Requires the `View` permission on each requested team; otherwise the request is rejected with a `403`. Ignored for organizations on the free tier.\n",
+            "in": "query",
+            "schema": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "null"
+                  ]
+                }
+              ]
+            }
           }
         ],
         "security": [
@@ -2034,7 +4090,7 @@
                         "active": 0,
                         "ignored": 0
                       },
-                      "revision": {
+                      "revisions": {
                         "active": 0,
                         "ignored": 0
                       }
@@ -2939,6 +4995,30 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "teamId",
+            "description": "Filter issues by one or more team IDs. Accepts a single team ID, an array of team IDs, or the literal string `\"null\"` to scope to unassigned projects. Requires the `View` permission on each requested team; otherwise the request is rejected with a `403`. Ignored for organizations on the free tier.\n",
+            "in": "query",
+            "schema": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "null"
+                  ]
+                }
+              ]
+            }
           }
         ],
         "security": [
@@ -3213,6 +5293,30 @@
             "in": "query",
             "schema": {
               "type": "string"
+            }
+          },
+          {
+            "name": "teamId",
+            "description": "Filter issues by one or more team IDs. Accepts a single team ID, an array of team IDs, or the literal string `\"null\"` to scope to unassigned projects. Requires the `View` permission on each requested team; otherwise the request is rejected with a `403`. Ignored for organizations on the free tier.\n",
+            "in": "query",
+            "schema": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "null"
+                  ]
+                }
+              ]
             }
           }
         ],
@@ -3500,24 +5604,25 @@
             }
           },
           {
-            "name": "teamId[]",
+            "name": "teamId",
+            "description": "Filter issues by one or more team IDs. Accepts a single team ID, an array of team IDs, or the literal string `\"null\"` to scope to unassigned projects. Requires the `View` permission on each requested team; otherwise the request is rejected with a `403`. Ignored for organizations on the free tier.\n",
             "in": "query",
-            "description": "Filter by one or more team IDs. Providing \"null\" will return all unassigned projects.",
             "schema": {
-              "nullable": true,
               "oneOf": [
+                {
+                  "type": "string"
+                },
                 {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "number"
-                      }
-                    ]
+                    "type": "string"
                   }
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "null"
+                  ]
                 }
               ]
             }
@@ -3557,7 +5662,7 @@
                     "message": {
                       "type": "string"
                     },
-                    "packageManagers": {
+                    "cwes": {
                       "type": "array",
                       "items": {
                         "type": "string"
@@ -3569,7 +5674,7 @@
                   "analyzing": {
                     "value": {
                       "message": "analysis in-progress",
-                      "packageManagers": []
+                      "cwes": []
                     }
                   }
                 }
@@ -4055,7 +6160,7 @@
                               }
                             },
                             "customRiskScore": {
-                              "description": "Optional custom risk score for the vulnerability, only present\nwhen the Custom Risk Scores feature is enabled for the organization.\nNot available for global scope queries.\n",
+                              "description": "Optional custom risk score for the vulnerability.\nNot available for global scope queries.\n",
                               "type": "object",
                               "properties": {
                                 "score": {
@@ -5011,7 +7116,7 @@
     "/v2/issues/{issueId}/disputes": {
       "post": {
         "operationId": "createIssueDispute",
-        "description": "Creates an issue dispute. For now it only supports licensing issues.",
+        "description": "Creates an issue dispute. Supports licensing and quality issue disputes. The dispute type is determined by the category of the specified issue.",
         "tags": [
           "Issues"
         ],
@@ -5032,15 +7137,21 @@
             "application/json": {
               "schema": {
                 "type": "object",
+                "required": [
+                  "reason"
+                ],
                 "properties": {
                   "reason": {
                     "type": "string",
-                    "required": true,
-                    "description": "The reason why this issue is being disputed.",
+                    "description": "The reason why this issue is being disputed. License dispute reasons: INCORRECT_DEPENDENCY_VERSION_REPORTED, LICENSE_DETECTION_FALSE_POSITIVE, MULTI_OR_DUAL_LICENSED, INCORRECT_LICENSE_CONCLUSION. Quality dispute reasons: INCORRECT_STALENESS_REPORTED, INCORRECTLY_FLAGGED_ABANDONWARE, INCORRECTLY_FLAGGED_EMPTY.",
                     "enum": [
                       "INCORRECT_DEPENDENCY_VERSION_REPORTED",
                       "LICENSE_DETECTION_FALSE_POSITIVE",
-                      "MULTI_OR_DUAL_LICENSED"
+                      "MULTI_OR_DUAL_LICENSED",
+                      "INCORRECT_LICENSE_CONCLUSION",
+                      "INCORRECT_STALENESS_REPORTED",
+                      "INCORRECTLY_FLAGGED_ABANDONWARE",
+                      "INCORRECTLY_FLAGGED_EMPTY"
                     ]
                   },
                   "comment": {
@@ -5063,44 +7174,112 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "number"
+                  "oneOf": [
+                    {
+                      "title": "LicenseDisputeResponse",
+                      "type": "object",
+                      "required": [
+                        "id",
+                        "createdBy",
+                        "createdAt",
+                        "licenseId",
+                        "disputedIssueId",
+                        "reason",
+                        "comment",
+                        "resolvedAt",
+                        "resolvedBy"
+                      ],
+                      "properties": {
+                        "id": {
+                          "type": "integer"
+                        },
+                        "createdBy": {
+                          "type": "integer"
+                        },
+                        "createdAt": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "licenseId": {
+                          "type": "string"
+                        },
+                        "disputedIssueId": {
+                          "type": "integer"
+                        },
+                        "reason": {
+                          "type": "string",
+                          "enum": [
+                            "INCORRECT_DEPENDENCY_VERSION_REPORTED",
+                            "LICENSE_DETECTION_FALSE_POSITIVE",
+                            "MULTI_OR_DUAL_LICENSED",
+                            "INCORRECT_LICENSE_CONCLUSION"
+                          ]
+                        },
+                        "comment": {
+                          "type": "string"
+                        },
+                        "resolvedAt": {
+                          "type": "string",
+                          "format": "date-time",
+                          "nullable": true
+                        },
+                        "resolvedBy": {
+                          "type": "integer",
+                          "nullable": true
+                        }
+                      }
                     },
-                    "createdBy": {
-                      "type": "number"
-                    },
-                    "createdAt": {
-                      "type": "string",
-                      "format": "date"
-                    },
-                    "licenseId": {
-                      "type": "string"
-                    },
-                    "disputedIssueId": {
-                      "type": "number"
-                    },
-                    "reason": {
-                      "type": "string",
-                      "description": "The reason why this issue is being disputed.",
-                      "enum": [
-                        "INCORRECT_DEPENDENCY_VERSION_REPORTED",
-                        "LICENSE_DETECTION_FALSE_POSITIVE",
-                        "MULTI_OR_DUAL_LICENSED"
-                      ]
-                    },
-                    "comment": {
-                      "type": "string"
-                    },
-                    "resolvedAt": {
-                      "type": "string",
-                      "format": "date"
-                    },
-                    "resolvedBy": {
-                      "type": "number"
+                    {
+                      "title": "QualityDisputeResponse",
+                      "type": "object",
+                      "required": [
+                        "id",
+                        "createdBy",
+                        "createdAt",
+                        "disputedIssueId",
+                        "reason",
+                        "comment",
+                        "resolvedAt",
+                        "resolvedBy"
+                      ],
+                      "properties": {
+                        "id": {
+                          "type": "integer"
+                        },
+                        "createdBy": {
+                          "type": "integer"
+                        },
+                        "createdAt": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "disputedIssueId": {
+                          "type": "integer"
+                        },
+                        "reason": {
+                          "type": "string",
+                          "enum": [
+                            "INCORRECT_STALENESS_REPORTED",
+                            "INCORRECTLY_FLAGGED_ABANDONWARE",
+                            "INCORRECTLY_FLAGGED_EMPTY"
+                          ]
+                        },
+                        "comment": {
+                          "type": "string",
+                          "nullable": true
+                        },
+                        "resolvedAt": {
+                          "type": "string",
+                          "format": "date-time",
+                          "nullable": true
+                        },
+                        "resolvedBy": {
+                          "type": "integer",
+                          "nullable": true
+                        }
+                      }
                     }
-                  }
+                  ]
                 }
               }
             }
@@ -5799,7 +7978,7 @@
           },
           {
             "name": "filter[severitySource][]",
-            "description": "Filter by severity source (when category is \"vulnerability\"). Use 'standard' to filter by CVSS score, 'custom' to filter by custom risk score. When both are provided, issues matching either source are returned. Defaults to 'standard' when not provided. Custom risk score filtering requires the Custom Risk Scores feature to be enabled and a non-global scope.\n",
+            "description": "Filter by severity source (when category is \"vulnerability\"). Use 'standard' to filter by CVSS score, 'custom' to filter by custom risk score. When both are provided, issues matching either source are returned. Defaults to 'standard' when not provided. Custom risk score filtering is not available for global scope.\n",
             "in": "query",
             "schema": {
               "type": "array",
@@ -5992,6 +8171,54 @@
             }
           },
           {
+            "name": "filter[cvssAttackVector][]",
+            "description": "Filter by CVSS attack vector (when category is \"vulnerability\")",
+            "in": "query",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "network",
+                  "adjacent",
+                  "local",
+                  "physical"
+                ]
+              }
+            }
+          },
+          {
+            "name": "filter[cvssAttackComplexity][]",
+            "description": "Filter by CVSS attack complexity (when category is \"vulnerability\"). For CVSS v4, this includes the Attack Requirements (AT) metric.",
+            "in": "query",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "low",
+                  "high"
+                ]
+              }
+            }
+          },
+          {
+            "name": "filter[cvssPrivilegesRequired][]",
+            "description": "Filter by CVSS privileges required (when category is \"vulnerability\")",
+            "in": "query",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "none",
+                  "low",
+                  "high"
+                ]
+              }
+            }
+          },
+          {
             "name": "sort",
             "description": "Sort by package name, when the issue was created, or severity (when category is \"vulnerability\")\n",
             "in": "query",
@@ -6029,6 +8256,38 @@
               "maximum": 1000,
               "default": 20
             }
+          },
+          {
+            "name": "teamId",
+            "description": "Filter issues by one or more team IDs. Accepts a single team ID, an array of team IDs, or the literal string `\"null\"` to scope to unassigned projects. Requires the `View` permission on each requested team; otherwise the request is rejected with a `403`. Ignored for organizations on the free tier.\n",
+            "in": "query",
+            "schema": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "null"
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "name": "email",
+            "description": "Only applies when `csv=true`. When provided, the CSV report is generated as a background task and emailed to the requesting user once ready; the response is then a `201` with the task metadata. When omitted, the CSV is streamed directly in the response.\n",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
           }
         ],
         "security": [
@@ -6038,7 +8297,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Vulnerability, licensing, or quality issues response",
+            "description": "Vulnerability, licensing, or quality issues response. When `csv=true` (without `email`), the CSV report is streamed as an attachment with content type `text/csv`.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -6294,7 +8553,7 @@
                                 }
                               },
                               "customRiskScore": {
-                                "description": "Optional custom risk score for the vulnerability, only present\nwhen the Custom Risk Scores feature is enabled for the organization.\nNot available for global scope queries.\n",
+                                "description": "Optional custom risk score for the vulnerability.\nNot available for global scope queries.\n",
                                 "type": "object",
                                 "properties": {
                                   "score": {
@@ -7022,6 +9281,105 @@
                     }
                   }
                 }
+              },
+              "text/csv": {
+                "schema": {
+                  "type": "string",
+                  "description": "CSV-formatted issues report, streamed as an attachment"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "Returned when `csv=true` and `email=true`. The CSV report is generated as a background task and emailed to the requesting user once ready; the response body is the queued task's metadata.\n",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Metadata describing a background task that has been queued for processing.",
+                  "properties": {
+                    "id": {
+                      "type": "integer",
+                      "description": "Unique identifier for the task"
+                    },
+                    "task": {
+                      "type": "string",
+                      "description": "Name of the task being run"
+                    },
+                    "jobToken": {
+                      "type": "string",
+                      "description": "Token used to poll for the task's status and result"
+                    },
+                    "status": {
+                      "type": "string",
+                      "description": "Current status of the task",
+                      "enum": [
+                        "CREATED",
+                        "ASSIGNED",
+                        "RUNNING",
+                        "SUCCEEDED",
+                        "FAILED"
+                      ]
+                    },
+                    "attempt_number": {
+                      "type": "integer",
+                      "description": "Number of times the task has been attempted"
+                    },
+                    "maxRetries": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ],
+                      "description": "Maximum number of retries permitted for the task"
+                    },
+                    "started": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "format": "date-time",
+                      "description": "When the task started running, or null if it has not started"
+                    },
+                    "finished": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "format": "date-time",
+                      "description": "When the task finished, or null if it has not finished"
+                    },
+                    "scheduledStartTime": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "format": "date-time",
+                      "description": "When the task is scheduled to start, or null"
+                    },
+                    "pod": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Identifier of the pod running the task, or null"
+                    },
+                    "context": {
+                      "type": "object",
+                      "description": "Task-specific context payload",
+                      "additionalProperties": true
+                    },
+                    "createdAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "description": "When the task record was created"
+                    },
+                    "updatedAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "description": "When the task record was last updated"
+                    }
+                  }
+                }
               }
             }
           },
@@ -7285,7 +9643,7 @@
                                 }
                               },
                               "customRiskScore": {
-                                "description": "Optional custom risk score for the vulnerability, only present\nwhen the Custom Risk Scores feature is enabled for the organization.\nNot available for global scope queries.\n",
+                                "description": "Optional custom risk score for the vulnerability.\nNot available for global scope queries.\n",
                                 "type": "object",
                                 "properties": {
                                   "score": {
@@ -8131,7 +10489,7 @@
           },
           {
             "name": "filter[severitySource][]",
-            "description": "Filter by severity source (when category is \"vulnerability\"). Use 'standard' to filter by CVSS score, 'custom' to filter by custom risk score. When both are provided, issues matching either source are returned. Defaults to 'standard' when not provided. Custom risk score filtering requires the Custom Risk Scores feature to be enabled and a non-global scope.\n",
+            "description": "Filter by severity source (when category is \"vulnerability\"). Use 'standard' to filter by CVSS score, 'custom' to filter by custom risk score. When both are provided, issues matching either source are returned. Defaults to 'standard' when not provided. Custom risk score filtering is not available for global scope.\n",
             "in": "query",
             "schema": {
               "type": "array",
@@ -8278,6 +10636,78 @@
                       "snippet"
                     ]
                   }
+                }
+              ]
+            }
+          },
+          {
+            "name": "filter[cvssAttackVector][]",
+            "description": "Filter by CVSS attack vector (when category is \"vulnerability\")",
+            "in": "query",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "network",
+                  "adjacent",
+                  "local",
+                  "physical"
+                ]
+              }
+            }
+          },
+          {
+            "name": "filter[cvssAttackComplexity][]",
+            "description": "Filter by CVSS attack complexity (when category is \"vulnerability\"). For CVSS v4, this includes the Attack Requirements (AT) metric.",
+            "in": "query",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "low",
+                  "high"
+                ]
+              }
+            }
+          },
+          {
+            "name": "filter[cvssPrivilegesRequired][]",
+            "description": "Filter by CVSS privileges required (when category is \"vulnerability\")",
+            "in": "query",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "none",
+                  "low",
+                  "high"
+                ]
+              }
+            }
+          },
+          {
+            "name": "teamId",
+            "description": "Filter issues by one or more team IDs. Accepts a single team ID, an array of team IDs, or the literal string `\"null\"` to scope to unassigned projects. Requires the `View` permission on each requested team; otherwise the request is rejected with a `403`. Ignored for organizations on the free tier.\n",
+            "in": "query",
+            "schema": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "null"
+                  ]
                 }
               ]
             }
@@ -9070,6 +11500,30 @@
               "maximum": 1000,
               "default": 20
             }
+          },
+          {
+            "name": "teamId",
+            "description": "Filter issues by one or more team IDs. Accepts a single team ID, an array of team IDs, or the literal string `\"null\"` to scope to unassigned projects. Requires the `View` permission on each requested team; otherwise the request is rejected with a `403`. Ignored for organizations on the free tier.\n",
+            "in": "query",
+            "schema": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "null"
+                  ]
+                }
+              ]
+            }
           }
         ],
         "security": [
@@ -9414,7 +11868,7 @@
     "/v2/issues/csv/global": {
       "get": {
         "operationId": "getGlobalIssuesCSV",
-        "description": "Download the global issues report (CSV) or submit for background processing",
+        "description": "Download the global issues report (CSV) or submit it for background processing.\n\nRequires the `Create` permission on either `OrganizationReport` or `TeamReport`; requests from users without one of these permissions are rejected with a `403`.\n",
         "tags": [
           "Issues"
         ],
@@ -9425,6 +11879,30 @@
             "in": "query",
             "schema": {
               "type": "boolean"
+            }
+          },
+          {
+            "name": "teamIds",
+            "description": "Scope the report to one or more team IDs. Accepts a single team ID, an array of team IDs, or the literal string `\"null\"`. Invalid (non-integer) team IDs are rejected with a `400`. Ignored for organizations on the free tier.\n",
+            "in": "query",
+            "schema": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "null"
+                  ]
+                }
+              ]
             }
           }
         ],
@@ -9446,14 +11924,174 @@
               },
               "application/json": {
                 "schema": {
-                  "description": "When an email is provided in the query parameter, we will queue the Report as a background task, and return information for the given job",
                   "type": "object",
+                  "description": "Metadata describing a background task that has been queued for processing.",
                   "properties": {
+                    "id": {
+                      "type": "integer",
+                      "description": "Unique identifier for the task"
+                    },
                     "task": {
-                      "type": "string"
+                      "type": "string",
+                      "description": "Name of the task being run"
                     },
                     "jobToken": {
-                      "type": "string"
+                      "type": "string",
+                      "description": "Token used to poll for the task's status and result"
+                    },
+                    "status": {
+                      "type": "string",
+                      "description": "Current status of the task",
+                      "enum": [
+                        "CREATED",
+                        "ASSIGNED",
+                        "RUNNING",
+                        "SUCCEEDED",
+                        "FAILED"
+                      ]
+                    },
+                    "attempt_number": {
+                      "type": "integer",
+                      "description": "Number of times the task has been attempted"
+                    },
+                    "maxRetries": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ],
+                      "description": "Maximum number of retries permitted for the task"
+                    },
+                    "started": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "format": "date-time",
+                      "description": "When the task started running, or null if it has not started"
+                    },
+                    "finished": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "format": "date-time",
+                      "description": "When the task finished, or null if it has not finished"
+                    },
+                    "scheduledStartTime": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "format": "date-time",
+                      "description": "When the task is scheduled to start, or null"
+                    },
+                    "pod": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Identifier of the pod running the task, or null"
+                    },
+                    "context": {
+                      "type": "object",
+                      "description": "Task-specific context payload",
+                      "additionalProperties": true
+                    },
+                    "createdAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "description": "When the task record was created"
+                    },
+                    "updatedAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "description": "When the task record was last updated"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Bad Request Parameter/Body": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2003,
+                      "message": "Parse error at root.X: ...",
+                      "name": "BadRequestError",
+                      "httpStatusCode": 400
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "No permission": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2005,
+                      "message": "User does not have permission to view this resource",
+                      "name": "ForbiddenError",
+                      "httpStatusCode": 403
                     }
                   }
                 }
@@ -10688,6 +13326,11 @@
         "tags": [
           "Issue Filters"
         ],
+        "security": [
+          {
+            "ApiToken": []
+          }
+        ],
         "parameters": [
           {
             "name": "category",
@@ -10764,17 +13407,65 @@
               }
             }
           },
+          "400": {
+            "description": "The `category` query parameter is missing or not one of `licensing`, `vulnerability`, or `quality`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Invalid Category": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2003,
+                      "message": "Invalid category: \"foo\"",
+                      "name": "BadRequestError",
+                      "httpStatusCode": 400
+                    }
+                  }
+                }
+              }
+            }
+          },
           "403": {
-            "description": "Authentication failed or not a premium account."
+            "description": "Forbidden: insufficient permissions to list filters."
           }
         }
       },
       "post": {
         "summary": "Create a saved filter for your organization",
-        "description": "This endpoint allows you to create a saved filter for your organization.\n",
+        "description": "This endpoint allows you to create a saved filter for your organization.\n\nThis endpoint requires a **Premium** subscription.\n",
         "operationId": "createSavedFilter",
         "tags": [
           "Issue Filters"
+        ],
+        "security": [
+          {
+            "ApiToken": []
+          }
         ],
         "requestBody": {
           "required": true,
@@ -10910,13 +13601,6 @@
                               "Inline_mitigations_already_exist",
                               "incorrect_data_found",
                               "other"
-                            ]
-                          },
-                          "reachability": {
-                            "type": "string",
-                            "enum": [
-                              "reachable",
-                              "unknown"
                             ]
                           },
                           "cwes": {
@@ -11118,7 +13802,7 @@
             }
           },
           "403": {
-            "description": "Authentication failed or not a premium account."
+            "description": "Returned when the request is forbidden. This can happen for two reasons:\n\n- The organization is not on a **Premium** subscription.\n- The user lacks permission to create issue filters for the relevant category.\n"
           }
         }
       }
@@ -11130,6 +13814,11 @@
         "operationId": "getSavedFilterById",
         "tags": [
           "Issue Filters"
+        ],
+        "security": [
+          {
+            "ApiToken": []
+          }
         ],
         "parameters": [
           {
@@ -11203,16 +13892,64 @@
             "description": "Invalid or missing ID."
           },
           "403": {
-            "description": "Authentication failed or not a premium account."
+            "description": "Forbidden: insufficient permissions to access this resource."
+          },
+          "404": {
+            "description": "No filter was found with the given ID for the user's organization.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Filter Not Found": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2004,
+                      "message": "Not found",
+                      "name": "NotFoundError",
+                      "httpStatusCode": 404
+                    }
+                  }
+                }
+              }
+            }
           }
         }
       },
       "put": {
         "summary": "Update a saved filter for your organization",
-        "description": "Update a saved filter for your organization. The filter must be owned by the user's organization.\n",
+        "description": "Update a saved filter for your organization. The filter must be owned by the user's organization.\n\nThis endpoint requires a **Premium** subscription.\n",
         "operationId": "updateSavedFilter",
         "tags": [
           "Issue Filters"
+        ],
+        "security": [
+          {
+            "ApiToken": []
+          }
         ],
         "parameters": [
           {
@@ -11351,13 +14088,6 @@
                               "Inline_mitigations_already_exist",
                               "incorrect_data_found",
                               "other"
-                            ]
-                          },
-                          "reachability": {
-                            "type": "string",
-                            "enum": [
-                              "reachable",
-                              "unknown"
                             ]
                           },
                           "cwes": {
@@ -11562,7 +14292,50 @@
             "description": "Invalid or missing ID."
           },
           "403": {
-            "description": "Authentication failed or not a premium account."
+            "description": "Returned when the request is forbidden. This can happen for two reasons:\n\n- The organization is not on a **Premium** subscription.\n- The user lacks permission to edit issue filters for the relevant category.\n"
+          },
+          "404": {
+            "description": "No filter was found with the given ID for the user's organization.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Filter Not Found": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2004,
+                      "message": "Not found",
+                      "name": "NotFoundError",
+                      "httpStatusCode": 404
+                    }
+                  }
+                }
+              }
+            }
           }
         }
       },
@@ -11572,6 +14345,11 @@
         "operationId": "deleteSavedFilter",
         "tags": [
           "Issue Filters"
+        ],
+        "security": [
+          {
+            "ApiToken": []
+          }
         ],
         "parameters": [
           {
@@ -11592,7 +14370,50 @@
             "description": "Invalid or missing ID."
           },
           "403": {
-            "description": "Authentication failed or not a premium account."
+            "description": "The user lacks permission to delete issue filters for the relevant category."
+          },
+          "404": {
+            "description": "No filter was found with the given ID for the user's organization.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Filter Not Found": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2004,
+                      "message": "Not found",
+                      "name": "NotFoundError",
+                      "httpStatusCode": 404
+                    }
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -11698,28 +14519,31 @@
                   ],
                   "properties": {
                     "counts": {
-                      "type": "object",
+                      "type": "array",
                       "description": "An array of daily issue count summaries.",
-                      "properties": {
-                        "date": {
-                          "type": "string",
-                          "format": "date-time",
-                          "example": "2023-12-19T20:09:12.583Z"
-                        },
-                        "active": {
-                          "type": "integer",
-                          "minimum": 0,
-                          "example": 10
-                        },
-                        "ignored": {
-                          "type": "integer",
-                          "minimum": 0,
-                          "example": 241
-                        },
-                        "remediated": {
-                          "type": "integer",
-                          "minimum": 0,
-                          "example": 51
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "date": {
+                            "type": "string",
+                            "format": "date-time",
+                            "example": "2023-12-19T20:09:12.583Z"
+                          },
+                          "active": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "example": 10
+                          },
+                          "ignored": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "example": 241
+                          },
+                          "remediated": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "example": 51
+                          }
                         }
                       }
                     },
@@ -11888,12 +14712,14 @@
                 "examples": {
                   "Success": {
                     "value": {
-                      "counts": {
-                        "date": "2023-12-19T20:09:12.583Z",
-                        "active": 10,
-                        "ignored": 241,
-                        "remediated": 51
-                      },
+                      "counts": [
+                        {
+                          "date": "2023-12-19T20:09:12.583Z",
+                          "active": 10,
+                          "ignored": 241,
+                          "remediated": 51
+                        }
+                      ],
                       "totalProjects": 9,
                       "licensing": {
                         "type": {
@@ -12018,7 +14844,7 @@
                     "value": {
                       "uuid": "e307c56c-1343-41c8-bd68-a2a1877f2632",
                       "code": 2005,
-                      "message": "User does not have permission to see every project and every issue category.",
+                      "message": "User is missing permission to view issues in this organization.",
                       "name": "ForbiddenError",
                       "httpStatusCode": 403
                     }
@@ -12125,6 +14951,10 @@
               "application/json": {
                 "schema": {
                   "type": "object",
+                  "required": [
+                    "task",
+                    "jobToken"
+                  ],
                   "properties": {
                     "jobToken": {
                       "type": "string",
@@ -12177,7 +15007,7 @@
                       "code": 2003,
                       "message": "User is not associated with an organization.",
                       "name": "BadRequestError",
-                      "httpStatusCode": 403
+                      "httpStatusCode": 400
                     }
                   }
                 }
@@ -12218,7 +15048,7 @@
                     "value": {
                       "uuid": "e307c56c-1343-41c8-bd68-a2a1877f2632",
                       "code": 2005,
-                      "message": "User does not have permission to see every project and every issue category.",
+                      "message": "User is missing permission to view issues in this organization.",
                       "name": "ForbiddenError",
                       "httpStatusCode": 403
                     }
@@ -12233,7 +15063,7 @@
     "/cli/organization": {
       "get": {
         "operationId": "getOrganizationCLI",
-        "description": "Retrieves organizations capability and preferences for CLI. This is used by CLI to infer default preference and capability of an organization.\nFor example, 'supportsIssueDiffs' of True indicates to the CLI, that this organization, and this endpoint can support issue diffing.\n",
+        "description": "Retrieves organizations capability and preferences for CLI. This is used by CLI to infer default preference and capability of an organization.\nFor example, 'supportsIssueDiffs' of True indicates to the CLI, that this organization, and this endpoint can support issue diffing.\n\nThis endpoint accepts push-only tokens in addition to full API tokens.\n",
         "tags": [
           "CLI"
         ],
@@ -12318,6 +15148,50 @@
                         }
                       },
                       "description": "Configuration for custom license scans"
+                    },
+                    "requirePolicyOnUpload": {
+                      "type": "boolean",
+                      "description": "True if the organization requires a policy to be assigned when uploading, otherwise False."
+                    },
+                    "archiveUploadAndCLILicenseScanEnabled": {
+                      "type": "boolean",
+                      "description": "True if the organization is permissioned for CLI license scanning and archive uploads, otherwise False."
+                    },
+                    "supportsPreflightChecks": {
+                      "type": "boolean",
+                      "description": "True if the organization supports CLI preflight checks, otherwise False."
+                    },
+                    "supportsGitBackedCargoLocators": {
+                      "type": "boolean",
+                      "description": "True if Core understands git-backed cargo locators in the format `cargo+<repoUrl>#<crateName>$<version>`. When False, the CLI should fall back to plain crate names for git-sourced cargo dependencies."
+                    },
+                    "supportsFasterRGAddProject": {
+                      "type": "boolean",
+                      "description": "True if Core exposes the `cli/project_group/release_lookup` endpoint, which resolves a release group title and release title to their numeric ids server-side. When False, the CLI falls back to listing all release groups and releases and filtering client-side."
+                    },
+                    "subscription": {
+                      "type": "string",
+                      "enum": [
+                        "Free",
+                        "Premium"
+                      ],
+                      "description": "The organization subscription access level."
+                    },
+                    "packageLabelScopes": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "enum": [
+                          "org",
+                          "project",
+                          "revision"
+                        ]
+                      },
+                      "description": "The package label scopes supported by the organization."
+                    },
+                    "snippetScanSourceCodeRetentionDays": {
+                      "type": "integer",
+                      "description": "Number of days source code from snippet scans is retained for the organization."
                     }
                   }
                 },
@@ -12341,7 +15215,19 @@
                           "name": "Proprietary License",
                           "matchCriteria": "[Pp]roprietary [Ll]icense"
                         }
-                      ]
+                      ],
+                      "requirePolicyOnUpload": false,
+                      "archiveUploadAndCLILicenseScanEnabled": true,
+                      "supportsPreflightChecks": true,
+                      "supportsGitBackedCargoLocators": true,
+                      "supportsFasterRGAddProject": true,
+                      "subscription": "Premium",
+                      "packageLabelScopes": [
+                        "org",
+                        "project",
+                        "revision"
+                      ],
+                      "snippetScanSourceCodeRetentionDays": 30
                     }
                   }
                 }
@@ -13719,10 +16605,10 @@
         }
       }
     },
-    "/organizations/{id}/limits/{resource}": {
+    "/organizations/{id}/limits/contributors": {
       "get": {
-        "operationId": "getOrganizationLimits",
-        "description": "Fetch the organization's limit for subscription limited resource and its current usage.",
+        "operationId": "getOrganizationContributorLimits",
+        "description": "Fetch the organization's contributor limit and its current usage.",
         "tags": [
           "Organization Limits"
         ],
@@ -13737,21 +16623,9 @@
             "name": "id",
             "required": true,
             "schema": {
-              "type": "number"
+              "type": "integer"
             },
             "description": "The organization ID."
-          },
-          {
-            "in": "path",
-            "name": "resource",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "enum": [
-                "contributors",
-                "release-groups"
-              ]
-            }
           }
         ],
         "responses": {
@@ -13792,7 +16666,7 @@
             }
           },
           "400": {
-            "description": "Bad Request error. Sent when an enterprise organization is missing an contract data.",
+            "description": "Bad Request error. Sent when an enterprise organization is missing contract data.",
             "content": {
               "application/json": {
                 "schema": {
@@ -13871,6 +16745,241 @@
                       "message": "User does not have access for this Organization resource",
                       "name": "ForbiddenError",
                       "httpStatusCode": 403
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error. Sent when an enterprise organization's contract has malformed contributor limits.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Organization contract limits are malformed": {
+                    "value": {
+                      "uuid": "12345678-1234-1234-1234-123456789012",
+                      "code": 500,
+                      "message": "Organization contract has malformed contributor limits.",
+                      "name": "InternalServerError",
+                      "httpStatusCode": 500
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/organizations/{id}/limits/release-groups": {
+      "get": {
+        "operationId": "getOrganizationReleaseGroupLimits",
+        "description": "Fetch the organization's release group limit and its current usage.",
+        "tags": [
+          "Organization Limits"
+        ],
+        "security": [
+          {
+            "ApiToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            },
+            "description": "The organization ID."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "usage": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "description": "The current usage of the resource."
+                    },
+                    "max": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "description": "The contractual limit of the resource."
+                    },
+                    "unlimited": {
+                      "type": "boolean",
+                      "description": "Whether or not the organization has an unlimited cap on the resource."
+                    }
+                  },
+                  "description": "An object that provides the current usage of a resource, the contractual limit of the resource, and whether or not the organization has an unlimited cap on the resource.\n"
+                },
+                "examples": {
+                  "Release group limit for an organization": {
+                    "value": {
+                      "usage": 1,
+                      "max": 5,
+                      "unlimited": false
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request error. Sent when an enterprise organization is missing contract data.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Organization contract data is missing": {
+                    "value": {
+                      "uuid": "12345678-1234-1234-1234-123456789012",
+                      "code": 400,
+                      "message": "Organization contract not found.",
+                      "name": "BadRequestError",
+                      "httpStatusCode": 400
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Requesting for another org": {
+                    "value": {
+                      "uuid": "12345678-1234-1234-1234-123456789012",
+                      "code": 403,
+                      "message": "User does not have access for this Organization resource",
+                      "name": "ForbiddenError",
+                      "httpStatusCode": 403
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error. Sent when an enterprise organization's contract has malformed release group limits.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Organization contract limits are malformed": {
+                    "value": {
+                      "uuid": "12345678-1234-1234-1234-123456789012",
+                      "code": 500,
+                      "message": "Organization contract has malformed release group limits.",
+                      "name": "InternalServerError",
+                      "httpStatusCode": 500
                     }
                   }
                 }
@@ -14096,10 +17205,265 @@
       }
     },
     "/projects/{locator}": {
+      "get": {
+        "operationId": "getProject",
+        "summary": "Get a single project.",
+        "description": "Retrieve a single project by its locator, including its policy, update hook, labels, and saved issue filters,\nplus computed metadata: the head/latest/last-analyzed revisions, notifications, references, and contributor count.\n\nThis endpoint implements its own access control via the project scope: a caller may read a project only if it is\npublic or belongs to the caller's organization.\n",
+        "tags": [
+          "Projects"
+        ],
+        "security": [
+          {
+            "ApiToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "locator",
+            "description": "The URL-encoded locator of the project (e.g., \"git+github.com/owner/repo\")",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "example": "git%2Bgithub.com%2Ffossas%2Ffossa-cli"
+          },
+          {
+            "name": "ref",
+            "description": "The branch or tag to use when computing the head/latest/last-analyzed revision metadata. Defaults to the project's default branch.",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "ref_type",
+            "description": "Whether `ref` refers to a branch or a tag. Defaults to `branch`.",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "branch",
+                "tag"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The requested Project object. Contains the stored project fields plus the included `policy`, `updateHook`,\n`labels`, and `filters` relations and computed metadata fields (`head`, `latest`, `last_analyzed`,\n`notifications`, `references`, and `contributorCount`).\n",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "The Project object, including related records and computed metadata.\n"
+                },
+                "examples": {
+                  "successResponse": {
+                    "value": {
+                      "locator": "git+github.com/fossas/fossa-cli",
+                      "title": "FOSSA CLI",
+                      "url": "https://github.com/fossas/fossa-cli",
+                      "description": "Open source CLI for analyzing dependencies",
+                      "public": false,
+                      "default_branch": "main",
+                      "organizationId": 1,
+                      "contributorCount": 42,
+                      "createdAt": "2023-01-15T10:30:00Z",
+                      "updatedAt": "2024-03-20T14:22:10Z",
+                      "labels": [],
+                      "filters": {
+                        "licensing": 101,
+                        "vulnerability": 102
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Bad API Token": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2010,
+                      "message": "API token is invalid",
+                      "name": "UnauthorizedError",
+                      "httpStatusCode": 401
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "nullPlaceholder": {
+                    "summary": "NULL placeholder locator",
+                    "value": {
+                      "uuid": "e307c56c-1343-41c8-bd68-a2a1877f2632",
+                      "code": 2005,
+                      "message": "Cannot access NULL placeholder.",
+                      "name": "ForbiddenError",
+                      "httpStatusCode": 403
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found - Project does not exist or you do not have access to it",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "projectNotFound": {
+                    "summary": "Project not found",
+                    "value": {
+                      "uuid": "e307c56c-1343-41c8-bd68-a2a1877f2632",
+                      "code": 1002,
+                      "message": "Could not find project git+github.com/example/repo",
+                      "name": "ProjectNotFoundError",
+                      "httpStatusCode": 404
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Server Error": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2009,
+                      "message": "Sorry, we've encountered an unexpected error. We've recorded it. If you continue to see this, contact support at support@fossa.com and include the unique reference code: 00000000-0000-0000-0000-000000000000",
+                      "name": "InternalServerError",
+                      "httpStatusCode": 500
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
       "put": {
         "operationId": "updateProject",
         "summary": "Update a project's settings and configuration.",
-        "description": "Update a project's settings and configuration. This endpoint allows updating a wide variety of project properties\nincluding metadata, policy assignments, scanning settings, integration configurations, and more.\n\n## Permission Requirements\n\nMost fields require Edit permission on the project. The following fields require special permissions:\n- `public`: Requires MakePublic permission\n- `policyId`, `securityPolicyId`, `qualityPolicyId`, `sbomPolicyId`, `sbomAnalysisEnabled`: Require SetPolicy permission for the respective policy type\n\n## Special Behaviors\n\n### Branch Management\n- `tracking_branches` and `hidden_branches` are mutually exclusive. Adding a branch to one will automatically remove it from the other.\n- Only branches can be added to these arrays; tags are filtered out automatically.\n\n### Policy Changes\n- When policies or scanning settings change, the project will be automatically rescanned if the last analyzed revision is in a steady state.\n\n### Feature Flags\n- `securityIssueScanningEnabled` and `qualityIssueScanningEnabled` can only be modified if the organization has the respective features enabled.\n\n### Issue Tracker Fields\n- When updating `issueTrackerCustomFields`, boolean values in the `isRequired` field may be stringified and will be automatically converted.\n- Custom field configurations are validated against Jira field requirements.\n\n### Notifications\n- Empty notification objects are automatically filtered out.\n- Notification changes are processed asynchronously.\n",
+        "description": "Update a project's settings and configuration. This endpoint allows updating a wide variety of project properties\nincluding metadata, policy assignments, scanning settings, integration configurations, and more.\n\n## Permission Requirements\n\nMost fields require Edit permission on the project. The following fields require special permissions:\n- `public`: Requires MakePublic permission\n- `policyId`, `securityPolicyId`, `qualityPolicyId`, `sbomPolicyId`, `sbomAnalysisEnabled`: Require SetPolicy permission for the respective policy type\n\n## Special Behaviors\n\n### Branch Management\n- `tracking_branches` and `hidden_branches` are mutually exclusive. Adding a branch to one will automatically remove it from the other.\n- Only branches can be added to these arrays; tags are filtered out automatically.\n\n### Policy Changes\n- When policies or scanning settings change, the project will be automatically rescanned if the last analyzed revision is in a steady state.\n\n### Feature Flags\n- `securityIssueScanningEnabled` and `qualityIssueScanningEnabled` can only be modified if the organization has the respective features enabled.\n- `quickImportVendoredDetectionEnabled` can only be modified if the organization has both quick import vendored detection and vendored dependency detection features enabled.\n- `quickImportSnippetDetectionEnabled` can only be modified if the organization has both quick import snippet detection and snippet detection features enabled.\n\n### Issue Tracker Fields\n- When updating `issueTrackerCustomFields`, boolean values in the `isRequired` field may be stringified and will be automatically converted.\n- Custom field configurations are validated against Jira field requirements.\n\n### Notifications\n- Empty notification objects are automatically filtered out.\n- Notification changes are processed asynchronously.\n",
         "tags": [
           "Projects"
         ],
@@ -14270,6 +17634,57 @@
                     "description": "Enable or disable snippet security issue scanning for this project",
                     "example": false
                   },
+                  "snippetAutoRejectMatchPercentageThreshold": {
+                    "type": "integer",
+                    "nullable": true,
+                    "description": "Match percentage at (or above) which snippet matches are automatically rejected.\nMust be an integer between 1 and 100, or `null` to disable auto-rejection.\n",
+                    "minimum": 1,
+                    "maximum": 100,
+                    "example": 80
+                  },
+                  "vendoredLicensingIssueScanningEnabled": {
+                    "type": "boolean",
+                    "description": "Enable or disable licensing issue scanning for vendored dependencies in this project",
+                    "example": false
+                  },
+                  "vendoredSecurityIssueScanningEnabled": {
+                    "type": "boolean",
+                    "description": "Enable or disable security issue scanning for vendored dependencies in this project",
+                    "example": false
+                  },
+                  "vendoredQualityIssueScanningEnabled": {
+                    "type": "boolean",
+                    "description": "Enable or disable quality issue scanning for vendored dependencies in this project",
+                    "example": false
+                  },
+                  "quickImportVendoredDetectionEnabled": {
+                    "type": "boolean",
+                    "description": "Enable or disable vendored dependency detection during quick imports for this project.\nCan only be modified if the organization has quick import vendored detection and vendored dependency detection features enabled.\n",
+                    "example": false
+                  },
+                  "quickImportSnippetDetectionEnabled": {
+                    "type": "boolean",
+                    "description": "Enable or disable snippet detection during quick imports for this project.\nCan only be modified if the organization has quick import snippet detection and snippet detection features enabled.\n",
+                    "example": false
+                  },
+                  "defaultSavedOptionLicensingReport": {
+                    "type": "integer",
+                    "nullable": true,
+                    "description": "ID of the saved report option to use as the default for licensing reports.\nMust reference a report option belonging to your organization, or `null` to clear it.\n",
+                    "example": 42
+                  },
+                  "defaultSavedOptionSbom": {
+                    "type": "integer",
+                    "nullable": true,
+                    "description": "ID of the saved report option to use as the default for SBOM reports.\nMust reference a report option belonging to your organization, or `null` to clear it.\n",
+                    "example": 43
+                  },
+                  "invalidCredential": {
+                    "type": "boolean",
+                    "nullable": true,
+                    "description": "Whether the credential associated with this project is currently invalid.",
+                    "example": false
+                  },
                   "licensingStatusCheckEnabled": {
                     "type": "boolean",
                     "description": "Enable or disable licensing issue CI/CD status checks",
@@ -14429,7 +17844,7 @@
                   "bom_column_settings": {
                     "type": "array",
                     "nullable": true,
-                    "description": "Columns to display in the Bill of Materials (BOM) report.\nAvailable options: All, Name, Version, Type, License, DirectLicense, DirectLicenseOrigin,\nDeepLicense, DeepLicenseOrigin, Description, Homepage, PrimaryLanguage, SourceLocation,\nReleasePublishDate, OriginId, Tags, ComponentComment, Reachability\n",
+                    "description": "Columns to display in the Bill of Materials (BOM) report.\nAvailable options: All, Name, Version, Type, License, DirectLicense, DirectLicenseOrigin,\nDeepLicense, DeepLicenseOrigin, Description, Homepage, PrimaryLanguage, SourceLocation,\nReleasePublishDate, OriginId, Tags, ComponentComment\n",
                     "items": {
                       "type": "string",
                       "enum": [
@@ -14449,8 +17864,7 @@
                         "ReleasePublishDate",
                         "OriginId",
                         "Tags",
-                        "ComponentComment",
-                        "Reachability"
+                        "ComponentComment"
                       ]
                     },
                     "example": [
@@ -14772,7 +18186,7 @@
                     "summary": "Empty project title",
                     "value": {
                       "uuid": "e307c56c-1343-41c8-bd68-a2a1877f2632",
-                      "code": 2003,
+                      "code": 2000,
                       "message": "Project title cannot be empty.",
                       "name": "MalformedPayloadError",
                       "httpStatusCode": 400
@@ -14923,9 +18337,223 @@
                     "summary": "Project not found",
                     "value": {
                       "uuid": "e307c56c-1343-41c8-bd68-a2a1877f2632",
-                      "code": 2004,
-                      "message": "Project not found for git+github.com/example/repo",
-                      "name": "NotFoundError",
+                      "code": 1002,
+                      "message": "Could not find project git+github.com/example/repo",
+                      "name": "ProjectNotFoundError",
+                      "httpStatusCode": 404
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Server Error": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2009,
+                      "message": "Sorry, we've encountered an unexpected error. We've recorded it. If you continue to see this, contact support at support@fossa.com and include the unique reference code: 00000000-0000-0000-0000-000000000000",
+                      "name": "InternalServerError",
+                      "httpStatusCode": 500
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteProject",
+        "summary": "Delete a project.",
+        "description": "Permanently delete a project and its associated data. The caller must have Delete permission on the project,\nand the project must belong to the caller's organization.\n",
+        "tags": [
+          "Projects"
+        ],
+        "security": [
+          {
+            "ApiToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "locator",
+            "description": "The URL-encoded locator of the project (e.g., \"git+github.com/owner/repo\")",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "example": "git%2Bgithub.com%2Ffossas%2Ffossa-cli"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Project deleted successfully."
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Bad API Token": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2010,
+                      "message": "API token is invalid",
+                      "name": "UnauthorizedError",
+                      "httpStatusCode": 401
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden - Insufficient permissions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "noDeletePermission": {
+                    "summary": "No delete permission",
+                    "value": {
+                      "uuid": "e307c56c-1343-41c8-bd68-a2a1877f2632",
+                      "code": 2005,
+                      "message": "Only project maintainers can delete projects.",
+                      "name": "ForbiddenError",
+                      "httpStatusCode": 403
+                    }
+                  },
+                  "wrongOrganization": {
+                    "summary": "Project belongs to a different organization",
+                    "value": {
+                      "uuid": "e307c56c-1343-41c8-bd68-a2a1877f2632",
+                      "code": 2005,
+                      "message": "You do not have permission to delete this project.",
+                      "name": "ForbiddenError",
+                      "httpStatusCode": 403
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found - Project does not exist or you do not have access to it",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "projectNotFound": {
+                    "summary": "Project not found",
+                    "value": {
+                      "uuid": "e307c56c-1343-41c8-bd68-a2a1877f2632",
+                      "code": 1002,
+                      "message": "Could not find project git+github.com/example/repo",
+                      "name": "ProjectNotFoundError",
                       "httpStatusCode": 404
                     }
                   }
@@ -15003,7 +18631,7 @@
           },
           {
             "name": "offset",
-            "description": "the number of revisions to skip for pagination (used with \"count\" query parameter)",
+            "description": "the number of revisions to skip per ref (branch or tag) for pagination.",
             "required": false,
             "in": "query",
             "schema": {
@@ -15012,7 +18640,7 @@
           },
           {
             "name": "count",
-            "description": "the number of revisions to return (maximum of 1000)",
+            "description": "the number of revisions to return per ref (branch or tag), max 1000.",
             "required": false,
             "in": "query",
             "schema": {
@@ -15068,8 +18696,27 @@
                 "cli",
                 "archive",
                 "container",
-                "sbom"
+                "sbom",
+                "binary"
               ]
+            }
+          },
+          {
+            "name": "isMinimal",
+            "description": "If `true`, each Revision in the response is reduced to only its `locator` and `message` fields. Useful for limiting response size.\n",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "locator",
+            "description": "Filter the revisions to those whose locator contains this value (case-insensitive substring match).",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
             }
           }
         ],
@@ -15126,6 +18773,20 @@
                               ],
                               "description": "FOSSA internal representation of the source language for the given repository/project"
                             },
+                            "source": {
+                              "type": [
+                                "string",
+                                "null"
+                              ],
+                              "description": "The source the Revision originated from (for example `github`, `cli`, `archive`, `container`, `sbom`, or `binary`)"
+                            },
+                            "unresolved_issue_count": {
+                              "type": [
+                                "number",
+                                "null"
+                              ],
+                              "description": "The number of unresolved issues found for this Revision"
+                            },
                             "error": {
                               "type": [
                                 "string",
@@ -15168,27 +18829,6 @@
                             "updatedAt": {
                               "type": "string",
                               "description": "when the Revision was last updated in the FOSSA Database"
-                            },
-                            "author": {
-                              "type": [
-                                "string",
-                                "null"
-                              ],
-                              "description": "The author of the Revision"
-                            },
-                            "link": {
-                              "type": [
-                                "string",
-                                "null"
-                              ],
-                              "description": "The link associated with the Revision"
-                            },
-                            "url": {
-                              "type": [
-                                "string",
-                                "null"
-                              ],
-                              "description": "The url associated with the Revision"
                             }
                           }
                         }
@@ -15239,6 +18879,20 @@
                               ],
                               "description": "FOSSA internal representation of the source language for the given repository/project"
                             },
+                            "source": {
+                              "type": [
+                                "string",
+                                "null"
+                              ],
+                              "description": "The source the Revision originated from (for example `github`, `cli`, `archive`, `container`, `sbom`, or `binary`)"
+                            },
+                            "unresolved_issue_count": {
+                              "type": [
+                                "number",
+                                "null"
+                              ],
+                              "description": "The number of unresolved issues found for this Revision"
+                            },
                             "error": {
                               "type": [
                                 "string",
@@ -15281,27 +18935,6 @@
                             "updatedAt": {
                               "type": "string",
                               "description": "when the Revision was last updated in the FOSSA Database"
-                            },
-                            "author": {
-                              "type": [
-                                "string",
-                                "null"
-                              ],
-                              "description": "The author of the Revision"
-                            },
-                            "link": {
-                              "type": [
-                                "string",
-                                "null"
-                              ],
-                              "description": "The link associated with the Revision"
-                            },
-                            "url": {
-                              "type": [
-                                "string",
-                                "null"
-                              ],
-                              "description": "The url associated with the Revision"
                             }
                           }
                         }
@@ -15556,7 +19189,7 @@
     "/projects/{locator}/generate_attribution_slug": {
       "put": {
         "operationId": "generateProjectGenerateAttributionSlug",
-        "description": "Generate (or regenerate) a slug used in the URL for the live attribution report for this project",
+        "description": "Generate (or regenerate) a slug used in the URL for the live attribution report for this project.\n\n**Requires a Premium subscription.** Organizations below the Premium access level receive a `403` response.\n",
         "tags": [
           "Projects"
         ],
@@ -15635,15 +19268,74 @@
             }
           },
           "401": {
-            "description": "Unauthenticated Request",
+            "description": "Unauthorized",
             "content": {
               "application/json": {
                 "schema": {
                   "type": "object",
                   "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
                     "message": {
                       "type": "string",
-                      "description": "Message describing the error"
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Bad API Token": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2010,
+                      "message": "API token is invalid",
+                      "name": "UnauthorizedError",
+                      "httpStatusCode": 401
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
                     }
                   }
                 },
@@ -15652,9 +19344,18 @@
                     "value": {
                       "uuid": "e307c56c-1343-41c8-bd68-a2a1877f2632",
                       "code": 2005,
-                      "message": "User does not have permission to edit this project.",
+                      "message": "You are not permitted to edit this project.",
                       "name": "ForbiddenError",
-                      "httpStatusCode": 401
+                      "httpStatusCode": 403
+                    }
+                  },
+                  "Premium Required": {
+                    "value": {
+                      "uuid": "e307c56c-1343-41c8-bd68-a2a1877f2632",
+                      "code": 2005,
+                      "message": "User not permissioned for feature. Feature requires \"premium\" subscription access level.",
+                      "name": "ForbiddenError",
+                      "httpStatusCode": 403
                     }
                   }
                 }
@@ -15776,7 +19477,50 @@
             }
           },
           "401": {
-            "description": "Unauthenticated Request",
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Bad API Token": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2010,
+                      "message": "API token is invalid",
+                      "name": "UnauthorizedError",
+                      "httpStatusCode": 401
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
             "content": {
               "application/json": {
                 "schema": {
@@ -15809,9 +19553,9 @@
                     "value": {
                       "uuid": "e307c56c-1343-41c8-bd68-a2a1877f2632",
                       "code": 2005,
-                      "message": "User does not have permission to edit this project.",
+                      "message": "You are not permitted to edit this project.",
                       "name": "ForbiddenError",
-                      "httpStatusCode": 401
+                      "httpStatusCode": 403
                     }
                   }
                 }
@@ -15949,7 +19693,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A report of all issues for the project. Either in JSON or CSV format.",
+            "description": "A report of all issues for the project. When `format=csv`, the report is served as a downloadable attachment with content type `application/octet-stream`; otherwise JSON is returned.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -16186,9 +19930,10 @@
                   }
                 }
               },
-              "text/csv": {
+              "application/octet-stream": {
                 "schema": {
-                  "type": "string"
+                  "type": "string",
+                  "format": "binary"
                 }
               }
             }
@@ -16266,12 +20011,12 @@
                   }
                 },
                 "examples": {
-                  "No Revisions found": {
+                  "Project not found": {
                     "value": {
                       "uuid": "00000000-0000-0000-0000-000000000000",
-                      "code": 2004,
+                      "code": 1002,
                       "message": "Could not find project abcd",
-                      "name": "NotFoundError",
+                      "name": "ProjectNotFoundError",
                       "httpStatusCode": 404
                     }
                   }
@@ -16280,7 +20025,7 @@
             }
           },
           "428": {
-            "description": "Not Found",
+            "description": "Precondition Required - the provided revision is invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -16314,7 +20059,7 @@
                       "uuid": "00000000-0000-0000-0000-000000000000",
                       "code": 1025,
                       "message": "Invalid revision specified",
-                      "name": "NotFoundError",
+                      "name": "InvalidRevisionError",
                       "httpStatusCode": 428
                     }
                   }
@@ -16769,12 +20514,12 @@
                   }
                 },
                 "examples": {
-                  "No Revisions found": {
+                  "Project not found": {
                     "value": {
                       "uuid": "00000000-0000-0000-0000-000000000000",
-                      "code": 2004,
+                      "code": 1002,
                       "message": "Could not find project abcd",
-                      "name": "NotFoundError",
+                      "name": "ProjectNotFoundError",
                       "httpStatusCode": 404
                     }
                   }
@@ -16783,7 +20528,7 @@
             }
           },
           "428": {
-            "description": "Not Found",
+            "description": "Precondition Required - the provided revision is invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -16817,7 +20562,7 @@
                       "uuid": "00000000-0000-0000-0000-000000000000",
                       "code": 1025,
                       "message": "Invalid revision specified",
-                      "name": "NotFoundError",
+                      "name": "InvalidRevisionError",
                       "httpStatusCode": 428
                     }
                   }
@@ -16942,11 +20687,12 @@
         ],
         "responses": {
           "200": {
-            "description": "A report of all issues for the project.",
+            "description": "A CSV report of all issues for the project, served as a downloadable attachment.",
             "content": {
-              "text/csv": {
+              "application/octet-stream": {
                 "schema": {
-                  "type": "string"
+                  "type": "string",
+                  "format": "binary"
                 }
               }
             }
@@ -17024,12 +20770,12 @@
                   }
                 },
                 "examples": {
-                  "No Revisions found": {
+                  "Project not found": {
                     "value": {
                       "uuid": "00000000-0000-0000-0000-000000000000",
-                      "code": 2004,
+                      "code": 1002,
                       "message": "Could not find project abcd",
-                      "name": "NotFoundError",
+                      "name": "ProjectNotFoundError",
                       "httpStatusCode": 404
                     }
                   }
@@ -17038,7 +20784,7 @@
             }
           },
           "428": {
-            "description": "Not Found",
+            "description": "Precondition Required - the provided revision is invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -17072,7 +20818,7 @@
                       "uuid": "00000000-0000-0000-0000-000000000000",
                       "code": 1025,
                       "message": "Invalid revision specified",
-                      "name": "NotFoundError",
+                      "name": "InvalidRevisionError",
                       "httpStatusCode": 428
                     }
                   }
@@ -17375,17 +21121,17 @@
                       "properties": {
                         "resourceType": {
                           "type": "string",
-                          "description": "Resource type for the permission",
+                          "description": "Resource type for the permission. Must be a valid `resourceType` returned\nby `GET /api/roles/all-permissions`, and the `resourceType`/`action`\ncombination must be valid for the role's `scope`.\n",
                           "example": "project_any"
                         },
                         "action": {
                           "type": "string",
-                          "description": "Action for the permission",
+                          "description": "Action for the permission. Must be a valid `action` returned by\n`GET /api/roles/all-permissions`, and the `resourceType`/`action`\ncombination must be valid for the role's `scope`.\n",
                           "example": "view"
                         }
                       }
                     },
-                    "description": "List of permissions for this role",
+                    "description": "List of permissions for this role. Each entry must be a permission that exists\nin the system (see `GET /api/roles/all-permissions`) and is valid for the role's\n`scope`; otherwise the request is rejected with a `400`.\n",
                     "example": [
                       {
                         "resourceType": "project_any",
@@ -17579,9 +21325,15 @@
                       "code": 2003
                     }
                   },
-                  "RoleNameExists": {
+                  "InvalidPermission": {
                     "value": {
-                      "message": "A role with the name \"Admin\" already exists in your organization.",
+                      "message": "Invalid permission \"made_up_resource.view\" in request.",
+                      "code": 2003
+                    }
+                  },
+                  "PermissionNotValidForScope": {
+                    "value": {
+                      "message": "The permission \"project.edit\" cannot be used for organization-scoped roles.",
                       "code": 2003
                     }
                   }
@@ -17623,6 +21375,46 @@
                     "value": {
                       "message": "You do not have permission to manage roles.",
                       "code": 2001
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "RoleNameExists": {
+                    "value": {
+                      "message": "A role with the name \"Admin\" already exists in your organization.",
+                      "code": 2011
                     }
                   }
                 }
@@ -17726,17 +21518,17 @@
                       "properties": {
                         "resourceType": {
                           "type": "string",
-                          "description": "Resource type for the permission",
+                          "description": "Resource type for the permission. Must be a valid `resourceType` returned\nby `GET /api/roles/all-permissions`, and the `resourceType`/`action`\ncombination must be valid for the role's `scope`.\n",
                           "example": "project_any"
                         },
                         "action": {
                           "type": "string",
-                          "description": "Action for the permission",
+                          "description": "Action for the permission. Must be a valid `action` returned by\n`GET /api/roles/all-permissions`, and the `resourceType`/`action`\ncombination must be valid for the role's `scope`.\n",
                           "example": "view"
                         }
                       }
                     },
-                    "description": "Updated list of permissions for this role",
+                    "description": "Updated list of permissions for this role. Each entry must be a permission that\nexists in the system (see `GET /api/roles/all-permissions`) and is valid for the\nrole's `scope`; otherwise the request is rejected with a `400`.\n",
                     "example": [
                       {
                         "resourceType": "project_any",
@@ -17922,9 +21714,15 @@
                       "code": 2003
                     }
                   },
-                  "RoleNameExists": {
+                  "InvalidPermission": {
                     "value": {
-                      "message": "A role with the name \"Admin\" already exists in your organization.",
+                      "message": "Invalid permission \"made_up_resource.view\" in request.",
+                      "code": 2003
+                    }
+                  },
+                  "PermissionNotValidForScope": {
+                    "value": {
+                      "message": "The permission \"project.edit\" cannot be used for organization-scoped roles.",
                       "code": 2003
                     }
                   }
@@ -18006,6 +21804,46 @@
                     "value": {
                       "message": "Role not found.",
                       "code": 2004
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "RoleNameExists": {
+                    "value": {
+                      "message": "A role with the name \"Admin\" already exists in your organization.",
+                      "code": 2011
                     }
                   }
                 }
@@ -18327,51 +22165,22 @@
                   "permissions": {
                     "value": [
                       {
-                        "resourceType": "organization",
+                        "resourceType": "organization_general_settings",
                         "action": "view",
                         "scopes": [
                           "organization"
                         ],
                         "group": "Organization",
-                        "description": "View organization settings"
+                        "description": "View general settings"
                       },
                       {
-                        "resourceType": "project_any",
-                        "action": "view",
-                        "scopes": [
-                          "organization",
-                          "team"
-                        ],
-                        "group": "Project",
-                        "description": "View any project in the organization"
-                      },
-                      {
-                        "resourceType": "project_any",
+                        "resourceType": "organization_general_settings",
                         "action": "edit",
                         "scopes": [
-                          "organization",
-                          "team"
+                          "organization"
                         ],
-                        "group": "Project",
-                        "description": "Edit any project in the organization"
-                      },
-                      {
-                        "resourceType": "project",
-                        "action": "view",
-                        "scopes": [
-                          "team"
-                        ],
-                        "group": "Project",
-                        "description": "View specific projects"
-                      },
-                      {
-                        "resourceType": "project",
-                        "action": "edit",
-                        "scopes": [
-                          "team"
-                        ],
-                        "group": "Project",
-                        "description": "Edit specific projects"
+                        "group": "Organization",
+                        "description": "Edit general settings"
                       },
                       {
                         "resourceType": "role",
@@ -18380,16 +22189,70 @@
                           "organization"
                         ],
                         "group": "Role",
-                        "description": "Manage roles and permissions"
+                        "description": "Manage roles"
                       },
                       {
                         "resourceType": "user",
-                        "action": "manage",
+                        "action": "invite",
                         "scopes": [
                           "organization"
                         ],
                         "group": "User",
-                        "description": "Manage users in the organization"
+                        "description": "Invite users to organization"
+                      },
+                      {
+                        "resourceType": "user_any",
+                        "action": "view",
+                        "scopes": [
+                          "organization"
+                        ],
+                        "group": "User",
+                        "description": "View users"
+                      },
+                      {
+                        "resourceType": "project_any",
+                        "action": "view",
+                        "scopes": [
+                          "organization"
+                        ],
+                        "group": "Project",
+                        "description": "View projects"
+                      },
+                      {
+                        "resourceType": "project_any",
+                        "action": "edit",
+                        "scopes": [
+                          "organization"
+                        ],
+                        "group": "Project",
+                        "description": "Edit projects"
+                      },
+                      {
+                        "resourceType": "project",
+                        "action": "view",
+                        "scopes": [
+                          "team"
+                        ],
+                        "group": "Project",
+                        "description": "View projects"
+                      },
+                      {
+                        "resourceType": "project",
+                        "action": "edit",
+                        "scopes": [
+                          "team"
+                        ],
+                        "group": "Project",
+                        "description": "Edit projects"
+                      },
+                      {
+                        "resourceType": "release_group_any",
+                        "action": "view",
+                        "scopes": [
+                          "organization"
+                        ],
+                        "group": "Release Group",
+                        "description": "View release groups"
                       },
                       {
                         "resourceType": "team",
@@ -18398,26 +22261,25 @@
                           "organization"
                         ],
                         "group": "Team",
-                        "description": "Create new teams"
+                        "description": "Create teams"
                       },
                       {
                         "resourceType": "team",
                         "action": "edit",
                         "scopes": [
-                          "organization",
                           "team"
                         ],
                         "group": "Team",
                         "description": "Edit team settings"
                       },
                       {
-                        "resourceType": "policy",
-                        "action": "manage",
+                        "resourceType": "security_policy",
+                        "action": "create",
                         "scopes": [
                           "organization"
                         ],
                         "group": "Policy",
-                        "description": "Manage organization policies"
+                        "description": "Create security policies"
                       }
                     ]
                   }
@@ -19124,7 +22986,7 @@
                   "InsufficientPermissions": {
                     "value": {
                       "message": "You are not permitted to add teams to these team groups.",
-                      "code": 2001
+                      "code": 2005
                     }
                   }
                 }
@@ -19442,7 +23304,7 @@
                   "InsufficientPermissions": {
                     "value": {
                       "message": "You do not have permission to update this team.",
-                      "code": 2001
+                      "code": 2005
                     }
                   }
                 }
@@ -19633,7 +23495,7 @@
                   "InsufficientPermissions": {
                     "value": {
                       "message": "You are not permitted to delete this team.",
-                      "code": 2001
+                      "code": 2005
                     }
                   }
                 }
@@ -20268,13 +24130,19 @@
                             "description": "ID of the role assigned to the user in the team"
                           },
                           "username": {
-                            "type": "string",
-                            "description": "Username of the user"
+                            "type": [
+                              "string",
+                              "null"
+                            ],
+                            "description": "Username of the user. Can be null when the underlying user record has no username."
                           },
                           "email": {
-                            "type": "string",
+                            "type": [
+                              "string",
+                              "null"
+                            ],
                             "format": "email",
-                            "description": "Email of the user"
+                            "description": "Email of the user. Can be null when the underlying user record has no email."
                           },
                           "isServiceAccount": {
                             "type": "boolean",
@@ -20729,12 +24597,6 @@
                   }
                 },
                 "examples": {
-                  "ForbiddenTeam": {
-                    "value": {
-                      "message": "You do not have permission to view this team.",
-                      "code": 2005
-                    }
-                  },
                   "ForbiddenEdit": {
                     "value": {
                       "message": "You do not have permission to edit this team.",
@@ -20889,7 +24751,7 @@
                         },
                         "roleId": {
                           "type": "integer",
-                          "description": "Role ID for the user (required for add and update actions)",
+                          "description": "Role ID for the user (required for add and replace actions)",
                           "example": 2
                         }
                       }
@@ -20929,7 +24791,7 @@
                 "replaceUsers": {
                   "summary": "Replace all users on the team with the provided users",
                   "value": {
-                    "action": "update",
+                    "action": "replace",
                     "users": [
                       {
                         "id": 123,
@@ -21071,13 +24933,13 @@
                   "TeamRolesManagedByIDP": {
                     "value": {
                       "message": "Team roles must be managed via the identity provider.",
-                      "code": 2001
+                      "code": 2005
                     }
                   },
                   "InsufficientPermissions": {
                     "value": {
                       "message": "You do not have permission to edit this team.",
-                      "code": 2001
+                      "code": 2005
                     }
                   }
                 }
@@ -21758,25 +25620,25 @@
                   "InsufficientAddPermissions": {
                     "value": {
                       "message": "You are not permitted to add projects to this team.",
-                      "code": 2001
+                      "code": 2005
                     }
                   },
                   "InsufficientRemovePermissions": {
                     "value": {
                       "message": "You are not permitted to remove projects from this team.",
-                      "code": 2001
+                      "code": 2005
                     }
                   },
                   "InsufficientReplacePermissions": {
                     "value": {
                       "message": "You are not permitted to set the projects in this team.",
-                      "code": 2001
+                      "code": 2005
                     }
                   },
                   "InsufficientProjectPermissions": {
                     "value": {
                       "message": "You are not permitted to add all selected projects to team \"Engineering\".",
-                      "code": 2001
+                      "code": 2005
                     }
                   }
                 }
@@ -22363,13 +26225,13 @@
                   "InsufficientPermissions": {
                     "value": {
                       "message": "You are not permitted to add release groups to this team.",
-                      "code": 2001
+                      "code": 2005
                     }
                   },
                   "InsufficientReleaseGroupPermissions": {
                     "value": {
                       "message": "You are not permitted to add all selected release groups to this team.",
-                      "code": 2001
+                      "code": 2005
                     }
                   }
                 }
@@ -22629,7 +26491,7 @@
                   "InsufficientPermissions": {
                     "value": {
                       "message": "You are not permitted to remove release groups from this team.",
-                      "code": 2001
+                      "code": 2005
                     }
                   }
                 }
@@ -23085,24 +26947,23 @@
                   "properties": {
                     "results": {
                       "type": "array",
-                      "description": "Array of projects and Release Groups that can be added to the team",
+                      "description": "Projects in the Release Group that can be added to the team",
                       "items": {
                         "type": "object",
                         "properties": {
                           "id": {
                             "type": "string",
-                            "description": "Locator of the project or stringified Release Group ID"
+                            "description": "Locator of the project"
                           },
                           "title": {
                             "type": "string",
-                            "description": "Title of the project or Release Group"
+                            "description": "Title of the project"
                           },
                           "type": {
                             "type": "string",
-                            "description": "Type of the project or Release Group",
+                            "description": "Type of the item, always `project` for this endpoint",
                             "enum": [
-                              "project",
-                              "release_group"
+                              "project"
                             ]
                           }
                         },
@@ -23112,29 +26973,14 @@
                           "type"
                         ]
                       }
-                    },
-                    "pageSize": {
-                      "type": "integer",
-                      "description": "Number of items per page"
-                    },
-                    "page": {
-                      "type": "integer",
-                      "description": "Current page number (1-indexed)"
-                    },
-                    "totalCount": {
-                      "type": "integer",
-                      "description": "Total number of projects and Release Groups that can be added to the team"
                     }
                   },
                   "required": [
-                    "results",
-                    "pageSize",
-                    "page",
-                    "totalCount"
+                    "results"
                   ]
                 },
                 "examples": {
-                  "addableProjectsAndReleaseGroups": {
+                  "addableProjectsFromReleaseGroup": {
                     "value": {
                       "results": [
                         {
@@ -23144,13 +26990,10 @@
                         },
                         {
                           "id": "2",
-                          "title": "Release Group 1",
-                          "type": "release_group"
+                          "title": "Project 2",
+                          "type": "project"
                         }
-                      ],
-                      "pageSize": 10,
-                      "page": 1,
-                      "totalCount": 2
+                      ]
                     }
                   }
                 }
@@ -23498,8 +27341,8 @@
                 "examples": {
                   "FeatureNotEnabled": {
                     "value": {
-                      "message": "Team groups feature is not enabled for this organization.",
-                      "code": 2001
+                      "message": "teamGroups is not enabled in this organization.",
+                      "code": 1006
                     }
                   }
                 }
@@ -23706,13 +27549,13 @@
                   "InsufficientPermissions": {
                     "value": {
                       "message": "You do not have permission to create team groups.",
-                      "code": 2001
+                      "code": 2005
                     }
                   },
                   "FeatureNotEnabled": {
                     "value": {
-                      "message": "Team groups feature is not enabled for this organization.",
-                      "code": 2001
+                      "message": "teamGroups is not enabled in this organization.",
+                      "code": 1006
                     }
                   }
                 }
@@ -23976,8 +27819,8 @@
                 "examples": {
                   "FeatureNotEnabled": {
                     "value": {
-                      "message": "Team groups feature is not enabled for this organization.",
-                      "code": 2001
+                      "message": "teamGroups is not enabled in this organization.",
+                      "code": 1006
                     }
                   }
                 }
@@ -24267,13 +28110,13 @@
                   "InsufficientPermissions": {
                     "value": {
                       "message": "You do not have permission to update this team group.",
-                      "code": 2001
+                      "code": 2005
                     }
                   },
                   "FeatureNotEnabled": {
                     "value": {
-                      "message": "Team groups feature is not enabled for this organization.",
-                      "code": 2001
+                      "message": "teamGroups is not enabled in this organization.",
+                      "code": 1006
                     }
                   }
                 }
@@ -24464,13 +28307,13 @@
                   "InsufficientPermissions": {
                     "value": {
                       "message": "You are not permitted to delete this team group.",
-                      "code": 2001
+                      "code": 2005
                     }
                   },
                   "FeatureNotEnabled": {
                     "value": {
-                      "message": "Team groups feature is not enabled for this organization.",
-                      "code": 2001
+                      "message": "teamGroups is not enabled in this organization.",
+                      "code": 1006
                     }
                   }
                 }
@@ -24810,19 +28653,19 @@
                   "InsufficientPermissions": {
                     "value": {
                       "message": "You are not permitted to add teams to this team group.",
-                      "code": 2001
+                      "code": 2005
                     }
                   },
                   "InsufficientTeamPermissions": {
                     "value": {
                       "message": "You are not permitted to edit all of the selected teams.",
-                      "code": 2001
+                      "code": 2005
                     }
                   },
                   "FeatureNotEnabled": {
                     "value": {
-                      "message": "Team groups feature is not enabled for this organization.",
-                      "code": 2001
+                      "message": "teamGroups is not enabled in this organization.",
+                      "code": 1006
                     }
                   }
                 }
@@ -25030,13 +28873,13 @@
                   "InsufficientPermissions": {
                     "value": {
                       "message": "You are not permitted to delete this team group.",
-                      "code": 2001
+                      "code": 2005
                     }
                   },
                   "FeatureNotEnabled": {
                     "value": {
-                      "message": "Team groups feature is not enabled for this organization.",
-                      "code": 2001
+                      "message": "teamGroups is not enabled in this organization.",
+                      "code": 1006
                     }
                   }
                 }
@@ -25388,19 +29231,19 @@
                   "TeamRolesManagedByIDP": {
                     "value": {
                       "message": "Team roles must be managed via the identity provider.",
-                      "code": 2001
+                      "code": 2005
                     }
                   },
                   "InsufficientPermissions": {
                     "value": {
                       "message": "You do not have permission to edit this team group.",
-                      "code": 2001
+                      "code": 2005
                     }
                   },
                   "FeatureNotEnabled": {
                     "value": {
-                      "message": "Team groups feature is not enabled for this organization.",
-                      "code": 2001
+                      "message": "teamGroups is not enabled in this organization.",
+                      "code": 1006
                     }
                   }
                 }
@@ -25560,18 +29403,22 @@
             }
           },
           {
-            "name": "type",
+            "name": "type[]",
             "in": "query",
             "description": "Filter by project type.",
             "schema": {
-              "type": "string",
-              "enum": [
-                "container",
-                "archive",
-                "provided",
-                "autobuild",
-                "sbom"
-              ]
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "container",
+                  "archive",
+                  "provided",
+                  "autobuild",
+                  "sbom",
+                  "binary"
+                ]
+              }
             }
           },
           {
@@ -25598,22 +29445,20 @@
             "in": "query",
             "description": "Filter by one or more team IDs. Providing \"null\" will return all unassigned projects.",
             "schema": {
-              "nullable": true,
-              "oneOf": [
-                {
-                  "type": "array",
-                  "items": {
-                    "oneOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "number"
-                      }
-                    ]
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "number"
                   }
-                }
-              ]
+                ]
+              }
             }
           },
           {
@@ -25666,6 +29511,21 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "inventory[]",
+            "in": "query",
+            "description": "Filter by additional inventory types.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "snippet",
+                  "vendored"
+                ]
+              }
+            }
           }
         ],
         "responses": {
@@ -25681,154 +29541,160 @@
                     },
                     "projects": {
                       "type": "array",
-                      "items": [
-                        [
-                          [
-                            {
-                              "type": "object",
-                              "required": [
-                                "id",
-                                "title",
-                                "branch",
-                                "type",
-                                "public",
-                                "teams"
-                              ],
-                              "properties": {
-                                "id": {
-                                  "type": "string"
-                                },
-                                "title": {
-                                  "type": "string"
-                                },
-                                "branch": {
-                                  "type": "string"
-                                },
-                                "version": {
-                                  "type": "string"
-                                },
-                                "type": {
-                                  "type": "string",
-                                  "enum": [
-                                    "container",
-                                    "archive",
-                                    "provided",
-                                    "autobuild",
-                                    "sbom"
-                                  ]
-                                },
-                                "public": {
-                                  "type": "boolean"
-                                },
-                                "url": {
-                                  "type": "string"
-                                },
-                                "scanned": {
-                                  "type": "string",
-                                  "format": "date-time"
-                                },
-                                "lastAnalyzed": {
-                                  "type": "string",
-                                  "format": "date-time"
-                                },
-                                "teams": {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "object",
-                                    "properties": {
-                                      "id": {
-                                        "type": "integer"
-                                      },
-                                      "name": {
-                                        "type": "string"
-                                      },
-                                      "uniqueId": {
-                                        "type": [
-                                          "string",
-                                          "null"
-                                        ]
-                                      },
-                                      "teamType": {
-                                        "type": "string",
-                                        "enum": [
-                                          "team",
-                                          "team_group"
-                                        ]
+                      "items": {
+                        "allOf": [
+                          {
+                            "allOf": [
+                              {
+                                "type": "object",
+                                "required": [
+                                  "id",
+                                  "title",
+                                  "branch",
+                                  "type",
+                                  "public",
+                                  "teams"
+                                ],
+                                "properties": {
+                                  "id": {
+                                    "type": "string"
+                                  },
+                                  "title": {
+                                    "type": "string"
+                                  },
+                                  "branch": {
+                                    "type": "string"
+                                  },
+                                  "version": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "type": {
+                                    "type": "string",
+                                    "enum": [
+                                      "container",
+                                      "archive",
+                                      "provided",
+                                      "autobuild",
+                                      "sbom",
+                                      "binary"
+                                    ]
+                                  },
+                                  "public": {
+                                    "type": "boolean"
+                                  },
+                                  "originOrganizationName": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "url": {
+                                    "type": "string"
+                                  },
+                                  "scanned": {
+                                    "type": "string",
+                                    "format": "date-time"
+                                  },
+                                  "lastAnalyzed": {
+                                    "type": "string",
+                                    "format": "date-time"
+                                  },
+                                  "teams": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "id": {
+                                          "type": "integer"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "uniqueId": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "teamType": {
+                                          "type": "string",
+                                          "enum": [
+                                            "team",
+                                            "team_group"
+                                          ]
+                                        }
                                       }
                                     }
-                                  }
-                                },
-                                "latestRevision": {
-                                  "type": "object",
-                                  "required": [
-                                    "locator"
-                                  ],
-                                  "properties": {
-                                    "locator": {
-                                      "type": "string"
-                                    },
-                                    "message": {
-                                      "type": "string"
+                                  },
+                                  "latestRevision": {
+                                    "type": "object",
+                                    "required": [
+                                      "locator"
+                                    ],
+                                    "properties": {
+                                      "locator": {
+                                        "type": "string"
+                                      },
+                                      "message": {
+                                        "type": "string"
+                                      }
                                     }
+                                  },
+                                  "latestBuildStatus": {
+                                    "type": "string",
+                                    "enum": [
+                                      "running",
+                                      "succeeded",
+                                      "failed"
+                                    ]
                                   }
-                                },
-                                "latestBuildStatus": {
-                                  "type": "string",
-                                  "enum": [
-                                    "running",
-                                    "succeeded",
-                                    "failed"
-                                  ]
                                 }
-                              }
-                            },
-                            {
-                              "type": "object",
-                              "required": [
-                                "id",
-                                "title",
-                                "branch",
-                                "type",
-                                "public",
-                                "labels",
-                                "teams",
-                                "issues"
-                              ],
-                              "properties": {
-                                "issues": {
-                                  "type": "array",
-                                  "items": {
+                              },
+                              {
+                                "type": "object",
+                                "required": [
+                                  "issues"
+                                ],
+                                "properties": {
+                                  "issues": {
                                     "type": "object",
                                     "properties": {
                                       "total": {
-                                        "type": "integer"
+                                        "type": [
+                                          "integer",
+                                          "null"
+                                        ]
                                       },
                                       "licensing": {
-                                        "type": "integer"
+                                        "type": [
+                                          "integer",
+                                          "null"
+                                        ]
                                       },
                                       "security": {
-                                        "type": "integer"
+                                        "type": [
+                                          "integer",
+                                          "null"
+                                        ]
                                       },
                                       "quality": {
-                                        "type": "integer"
+                                        "type": [
+                                          "integer",
+                                          "null"
+                                        ]
                                       }
                                     }
                                   }
                                 }
                               }
-                            }
-                          ],
+                            ]
+                          },
                           {
                             "type": "object",
                             "required": [
-                              "id",
-                              "title",
-                              "branch",
-                              "type",
-                              "public",
-                              "labels",
-                              "teams",
-                              "issues",
                               "labels"
                             ],
                             "properties": {
@@ -25841,7 +29707,403 @@
                             }
                           }
                         ]
+                      }
+                    }
+                  }
+                },
+                "examples": {
+                  "success": {
+                    "value": {
+                      "projects": [
+                        {
+                          "id": "custom+123/test-project-2025",
+                          "url": "https://test.com/test-project-2025",
+                          "title": "test-project-2025",
+                          "branch": "develop",
+                          "version": "test-version-01",
+                          "type": "provided",
+                          "public": false,
+                          "scanned": "2025-05-22T17:41:36.644Z",
+                          "lastAnalyzed": "2025-05-22T17:41:05.213Z",
+                          "issues": {
+                            "total": 10,
+                            "licensing": 5,
+                            "security": 3,
+                            "quality": 2
+                          },
+                          "labels": [],
+                          "teams": [],
+                          "originOrganizationName": null,
+                          "latestRevision": {
+                            "locator": "custom+123/test-project-2025$test-version-01",
+                            "message": "May 20th 2025, 5:16 pm +00:00"
+                          },
+                          "latestBuildStatus": "succeeded"
+                        }
                       ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "getProjectsByPost",
+        "description": "Fetch the list of projects based on provided filters. This endpoint is functionally identical to `GET /api/v2/projects`, but it reads the filter, sort, and pagination options from the request body instead of the query string. Use it when filtering by a large number of `locators` that would exceed query-string length limits.\n",
+        "tags": [
+          "Projects"
+        ],
+        "security": [
+          {
+            "ApiToken": []
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "sort": {
+                    "type": "string",
+                    "enum": [
+                      "title_asc",
+                      "title_desc",
+                      "issues-total_asc",
+                      "issues-total_desc",
+                      "latest-scan_asc",
+                      "latest-scan_desc",
+                      "last-analyzed_asc",
+                      "last-analyzed_desc",
+                      "issues-licensing_asc",
+                      "issues-licensing_desc",
+                      "issues-security_asc",
+                      "issues-security_desc",
+                      "issues-quality_asc",
+                      "issues-quality_desc"
+                    ],
+                    "description": "The category to order the results by and sort direction."
+                  },
+                  "page": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "default": 1,
+                    "description": "The specific page of data to return."
+                  },
+                  "count": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 1000,
+                    "default": 20,
+                    "description": "The number of items to return in each page of results."
+                  },
+                  "title": {
+                    "type": "string",
+                    "description": "Filter by project name."
+                  },
+                  "type": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "enum": [
+                        "container",
+                        "archive",
+                        "provided",
+                        "autobuild",
+                        "sbom",
+                        "binary"
+                      ]
+                    },
+                    "description": "Filter by project type."
+                  },
+                  "isPublic": {
+                    "type": "boolean",
+                    "description": "Filter by project being public or private."
+                  },
+                  "labels": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Filter by project labels."
+                  },
+                  "teamId": {
+                    "nullable": true,
+                    "oneOf": [
+                      {
+                        "type": "array",
+                        "items": {
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            }
+                          ]
+                        }
+                      }
+                    ],
+                    "description": "Filter by one or more team IDs. Providing \"null\" will return all unassigned projects."
+                  },
+                  "latestScan": {
+                    "type": "integer",
+                    "description": "Filter by last policy scan within N days."
+                  },
+                  "lastRevisionWithin": {
+                    "type": "integer",
+                    "description": "Filter by last revision analyzed within N days."
+                  },
+                  "locators": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Filter by project locators (exact match)."
+                  },
+                  "url": {
+                    "type": "string",
+                    "description": "Filter by a project's URL."
+                  },
+                  "includeSharedProjects": {
+                    "type": "boolean",
+                    "description": "Include shared projects."
+                  },
+                  "onlyIncludeSharedProjects": {
+                    "type": "boolean",
+                    "description": "Only show projects that have been shared with other organizations."
+                  },
+                  "inventory": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "enum": [
+                        "snippet",
+                        "vendored"
+                      ]
+                    },
+                    "description": "Filter by by additional inventory types."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "total": {
+                      "type": "integer"
+                    },
+                    "projects": {
+                      "type": "array",
+                      "items": {
+                        "allOf": [
+                          {
+                            "allOf": [
+                              {
+                                "type": "object",
+                                "required": [
+                                  "id",
+                                  "title",
+                                  "branch",
+                                  "type",
+                                  "public",
+                                  "teams"
+                                ],
+                                "properties": {
+                                  "id": {
+                                    "type": "string"
+                                  },
+                                  "title": {
+                                    "type": "string"
+                                  },
+                                  "branch": {
+                                    "type": "string"
+                                  },
+                                  "version": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "type": {
+                                    "type": "string",
+                                    "enum": [
+                                      "container",
+                                      "archive",
+                                      "provided",
+                                      "autobuild",
+                                      "sbom",
+                                      "binary"
+                                    ]
+                                  },
+                                  "public": {
+                                    "type": "boolean"
+                                  },
+                                  "originOrganizationName": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "url": {
+                                    "type": "string"
+                                  },
+                                  "scanned": {
+                                    "type": "string",
+                                    "format": "date-time"
+                                  },
+                                  "lastAnalyzed": {
+                                    "type": "string",
+                                    "format": "date-time"
+                                  },
+                                  "teams": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "id": {
+                                          "type": "integer"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "uniqueId": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "teamType": {
+                                          "type": "string",
+                                          "enum": [
+                                            "team",
+                                            "team_group"
+                                          ]
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "latestRevision": {
+                                    "type": "object",
+                                    "required": [
+                                      "locator"
+                                    ],
+                                    "properties": {
+                                      "locator": {
+                                        "type": "string"
+                                      },
+                                      "message": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "latestBuildStatus": {
+                                    "type": "string",
+                                    "enum": [
+                                      "running",
+                                      "succeeded",
+                                      "failed"
+                                    ]
+                                  }
+                                }
+                              },
+                              {
+                                "type": "object",
+                                "required": [
+                                  "issues"
+                                ],
+                                "properties": {
+                                  "issues": {
+                                    "type": "object",
+                                    "properties": {
+                                      "total": {
+                                        "type": [
+                                          "integer",
+                                          "null"
+                                        ]
+                                      },
+                                      "licensing": {
+                                        "type": [
+                                          "integer",
+                                          "null"
+                                        ]
+                                      },
+                                      "security": {
+                                        "type": [
+                                          "integer",
+                                          "null"
+                                        ]
+                                      },
+                                      "quality": {
+                                        "type": [
+                                          "integer",
+                                          "null"
+                                        ]
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "type": "object",
+                            "required": [
+                              "labels"
+                            ],
+                            "properties": {
+                              "labels": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          }
+                        ]
+                      }
                     }
                   }
                 },
@@ -25936,18 +30198,22 @@
             }
           },
           {
-            "name": "type",
+            "name": "type[]",
             "in": "query",
             "description": "Filter by project type.",
             "schema": {
-              "type": "string",
-              "enum": [
-                "container",
-                "archive",
-                "provided",
-                "autobuild",
-                "sbom"
-              ]
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "container",
+                  "archive",
+                  "provided",
+                  "autobuild",
+                  "sbom",
+                  "binary"
+                ]
+              }
             }
           },
           {
@@ -25974,22 +30240,20 @@
             "in": "query",
             "description": "Filter by one or more team IDs. Providing \"null\" will return all unassigned projects.",
             "schema": {
-              "nullable": true,
-              "oneOf": [
-                {
-                  "type": "array",
-                  "items": {
-                    "oneOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "number"
-                      }
-                    ]
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "number"
                   }
-                }
-              ]
+                ]
+              }
             }
           },
           {
@@ -26027,6 +30291,30 @@
                   }
                 }
               ]
+            }
+          },
+          {
+            "name": "url",
+            "in": "query",
+            "description": "Filter by a project's URL.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "includeSharedProjects",
+            "in": "query",
+            "description": "Include shared projects.",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "onlyIncludeSharedProjects",
+            "in": "query",
+            "description": "Only show projects that have been shared with other organizations.",
+            "schema": {
+              "type": "boolean"
             }
           }
         ],
@@ -26096,6 +30384,9 @@
                           "type": "integer"
                         },
                         "releaseGroups": {
+                          "type": "integer"
+                        },
+                        "sharedProjects": {
                           "type": "integer"
                         }
                       }
@@ -26193,18 +30484,22 @@
             }
           },
           {
-            "name": "type",
+            "name": "type[]",
             "in": "query",
             "description": "Filter by project type.",
             "schema": {
-              "type": "string",
-              "enum": [
-                "container",
-                "archive",
-                "provided",
-                "autobuild",
-                "sbom"
-              ]
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "container",
+                  "archive",
+                  "provided",
+                  "autobuild",
+                  "sbom",
+                  "binary"
+                ]
+              }
             }
           },
           {
@@ -26231,22 +30526,20 @@
             "in": "query",
             "description": "Filter by one or more team IDs. Providing \"null\" will return all unassigned projects.",
             "schema": {
-              "nullable": true,
-              "oneOf": [
-                {
-                  "type": "array",
-                  "items": {
-                    "oneOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "number"
-                      }
-                    ]
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "number"
                   }
-                }
-              ]
+                ]
+              }
             }
           },
           {
@@ -26263,6 +30556,30 @@
             "description": "Filter by last revision analyzed within N days.",
             "schema": {
               "type": "integer"
+            }
+          },
+          {
+            "name": "url",
+            "in": "query",
+            "description": "Filter by a project's URL.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "includeSharedProjects",
+            "in": "query",
+            "description": "Include shared projects.",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "onlyIncludeSharedProjects",
+            "in": "query",
+            "description": "Only show projects that have been shared with other organizations.",
+            "schema": {
+              "type": "boolean"
             }
           }
         ],
@@ -26367,18 +30684,22 @@
             }
           },
           {
-            "name": "type",
+            "name": "type[]",
             "in": "query",
             "description": "Filter by project type.",
             "schema": {
-              "type": "string",
-              "enum": [
-                "container",
-                "archive",
-                "provided",
-                "autobuild",
-                "sbom"
-              ]
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "container",
+                  "archive",
+                  "provided",
+                  "autobuild",
+                  "sbom",
+                  "binary"
+                ]
+              }
             }
           },
           {
@@ -26405,22 +30726,20 @@
             "in": "query",
             "description": "Filter by one or more team IDs. Providing \"null\" will return all unassigned projects.",
             "schema": {
-              "nullable": true,
-              "oneOf": [
-                {
-                  "type": "array",
-                  "items": {
-                    "oneOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "number"
-                      }
-                    ]
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "number"
                   }
-                }
-              ]
+                ]
+              }
             }
           },
           {
@@ -26437,6 +30756,30 @@
             "description": "Filter by last revision analyzed within N days.",
             "schema": {
               "type": "integer"
+            }
+          },
+          {
+            "name": "url",
+            "in": "query",
+            "description": "Filter by a project's URL.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "includeSharedProjects",
+            "in": "query",
+            "description": "Include shared projects.",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "onlyIncludeSharedProjects",
+            "in": "query",
+            "description": "Only show projects that have been shared with other organizations.",
+            "schema": {
+              "type": "boolean"
             }
           }
         ],
@@ -26517,39 +30860,44 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "releaseGroupId": {
-                        "type": "number"
-                      },
-                      "releaseGroupTitle": {
-                        "type": "string"
-                      },
-                      "createdAt": {
-                        "type": "string",
-                        "format": "date-time",
-                        "description": "The timestamp when the release group was created"
-                      },
-                      "revisions": {
-                        "type": "array",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "revisionId": {
-                              "type": "string"
-                            },
-                            "releases": {
-                              "type": "array",
-                              "items": {
-                                "type": "object",
-                                "properties": {
-                                  "releaseId": {
-                                    "type": "number"
-                                  },
-                                  "releaseTitle": {
-                                    "type": "string"
+                  "type": "object",
+                  "properties": {
+                    "releaseGroups": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "releaseGroupId": {
+                            "type": "number"
+                          },
+                          "releaseGroupTitle": {
+                            "type": "string"
+                          },
+                          "createdAt": {
+                            "type": "string",
+                            "format": "date-time",
+                            "description": "The timestamp when the release group was created"
+                          },
+                          "revisions": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "revisionId": {
+                                  "type": "string"
+                                },
+                                "releases": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "releaseId": {
+                                        "type": "number"
+                                      },
+                                      "releaseTitle": {
+                                        "type": "string"
+                                      }
+                                    }
                                   }
                                 }
                               }
@@ -26683,14 +31031,6 @@
             "name": "latestScan",
             "in": "query",
             "description": "Filter by last policy scan within N days.",
-            "schema": {
-              "type": "integer"
-            }
-          },
-          {
-            "name": "lastRevisionWithin",
-            "in": "query",
-            "description": "Filter by last revision analyzed within N days.",
             "schema": {
               "type": "integer"
             }
@@ -26918,8 +31258,8 @@
           {
             "name": "ids",
             "in": "query",
-            "required": true,
-            "description": "The list of IDs for the release groups to update. If \"all\" is provided, then all release groups that meet the provided filters will have the label applied.\n",
+            "required": false,
+            "description": "The list of IDs for the release groups to update. If \"all\" is provided, then all release groups that meet the provided filters will have the policy applied. If omitted, the release groups are selected by the supplied filter params (`title`, `latestScan`, `teamId`); at least one filter must then be provided.\n",
             "schema": {
               "oneOf": [
                 {
@@ -27102,11 +31442,12 @@
           {
             "name": "count",
             "in": "query",
-            "description": "The number of results to return.",
+            "description": "The number of results to return. Values above the maximum of 50 are silently clamped to 50.",
             "required": false,
             "schema": {
               "type": "integer",
-              "minimum": 1
+              "minimum": 1,
+              "maximum": 50
             }
           }
         ],
@@ -27369,17 +31710,21 @@
             }
           },
           {
-            "name": "blockType",
+            "name": "blockTypes",
             "in": "query",
             "description": "Filter packages to include only packages that do or do not have packages as dependencies which are blocked by your organization",
             "required": false,
             "schema": {
-              "type": "string",
-              "enum": [
-                "has_blocked_packages",
-                "no_blocked_packages"
-              ]
-            }
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "has_blocked_packages",
+                  "no_blocked_packages"
+                ]
+              }
+            },
+            "example": "blockTypes[0]=has_blocked_packages"
           },
           {
             "name": "cve",
@@ -27678,17 +32023,21 @@
             }
           },
           {
-            "name": "blockType",
+            "name": "blockTypes",
             "in": "query",
             "description": "Filter packages to include only packages that do or do not have packages as dependencies which are blocked by your organization",
             "required": false,
             "schema": {
-              "type": "string",
-              "enum": [
-                "has_blocked_packages",
-                "no_blocked_packages"
-              ]
-            }
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "has_blocked_packages",
+                  "no_blocked_packages"
+                ]
+              }
+            },
+            "example": "blockTypes[0]=has_blocked_packages"
           },
           {
             "name": "cve",
@@ -27786,10 +32135,12 @@
           {
             "name": "count",
             "in": "query",
-            "description": "The number of results to return per page",
+            "description": "The number of results to return per page. Values above the maximum of 50 are silently clamped to 50.",
             "required": false,
             "schema": {
-              "type": "integer"
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 50
             }
           },
           {
@@ -27809,28 +32160,52 @@
         ],
         "responses": {
           "200": {
-            "description": "The list of package dependency locators",
+            "description": "A paginated list of packages used by your organization.",
             "content": {
               "application/json": {
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "task": {
-                      "type": "object",
-                      "properties": {
-                        "task": {
-                          "type": "string"
+                    "data": {
+                      "type": "array",
+                      "description": "The page of packages matching the supplied filters.",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "locator": {
+                            "type": "string",
+                            "description": "The package locator (without revision / version data)."
+                          },
+                          "title": {
+                            "type": "string",
+                            "description": "The human-readable package title."
+                          },
+                          "numberOfProjects": {
+                            "type": "integer",
+                            "description": "The number of your projects that depend on this package."
+                          },
+                          "blockedVersionCount": {
+                            "type": "integer",
+                            "description": "The number of versions of this package that are blocked by your organization."
+                          }
                         },
-                        "jobToken": {
-                          "type": "string"
-                        }
+                        "required": [
+                          "locator",
+                          "title",
+                          "numberOfProjects",
+                          "blockedVersionCount"
+                        ]
                       }
                     },
-                    "target": {
-                      "type": "string",
-                      "description": "Email address where the report link will be sent"
+                    "count": {
+                      "type": "integer",
+                      "description": "The total number of packages matching the supplied filters across all pages."
                     }
-                  }
+                  },
+                  "required": [
+                    "data",
+                    "count"
+                  ]
                 }
               }
             }
@@ -28282,7 +32657,7 @@
           "Package Labels"
         ],
         "operationId": "getPackageLabelAssignments",
-        "description": "Get all Package Labels assigned to a single package.",
+        "description": "Get Package Label assignments for the organization, optionally filtered.\n\nAll filters are optional. When no filters are supplied, every Package Label\nassignment in the organization is returned (subject to the caller's project\nview permissions).\n\nNote - This endpoint is not available for organizations on the Free plan.\n",
         "parameters": [
           {
             "in": "query",
@@ -28328,6 +32703,26 @@
               "description": "The ID of the scope to get labels for."
             },
             "example": "custom+1/my-cli-project or custom+1/my-cli-project/$revision1"
+          },
+          {
+            "in": "query",
+            "name": "filters[shouldIncludePackageWideLabels]",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "When filtering by `packageVersion`, also include labels assigned to all versions of the package (those with a null `packageVersion`)."
+            },
+            "example": true
+          },
+          {
+            "in": "query",
+            "name": "filters[shouldIncludeRevisionScopedLabels]",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "When filtering by a `project` scope and `scopeId`, also include revision-scoped labels whose `scopeId` falls under that project."
+            },
+            "example": true
           }
         ],
         "responses": {
@@ -28337,86 +32732,148 @@
               "application/json": {
                 "schema": {
                   "type": "object",
+                  "description": "The list of Package Label assignments matching the supplied filters.",
                   "properties": {
-                    "packageLabelAssignmentResponse": {
-                      "type": "object",
-                      "properties": {
-                        "id": {
-                          "type": "integer",
-                          "description": "The ID of the package label assignment."
-                        },
-                        "createdAt": {
-                          "type": "string",
-                          "format": "date-time",
-                          "description": "The date and time the package label assignment was created."
-                        },
-                        "updatedAt": {
-                          "type": "string",
-                          "format": "date-time",
-                          "description": "The date and time the package label assignment was last updated."
-                        },
-                        "organizationId": {
-                          "type": "integer",
-                          "description": "The ID of the organization that owns the package label assignment."
-                        },
-                        "labelId": {
-                          "type": "integer",
-                          "description": "The ID of the label that was assigned to the package."
-                        },
-                        "packageId": {
-                          "type": "string",
-                          "description": "The ID of the package that the label was assigned to."
-                        },
-                        "packageVersion": {
-                          "type": "string",
-                          "nullable": true,
-                          "description": "The version of the package that the label was assigned to or null if the label was assigned to all versions."
-                        },
-                        "scope": {
-                          "type": "string",
-                          "description": "The scope of the package label assignment.",
-                          "enum": [
-                            "org",
-                            "project",
-                            "revision"
-                          ]
-                        },
-                        "scopeId": {
-                          "type": "string",
-                          "nullable": true,
-                          "description": "The ID of the scope that the label was assigned to or null if the label was assigned to all scopes."
-                        }
-                      },
-                      "required": [
-                        "id",
-                        "createdAt",
-                        "updatedAt",
-                        "organizationId",
-                        "labelId",
-                        "packageId",
-                        "scope",
-                        "scopeId"
-                      ]
+                    "packageLabelAssignments": {
+                      "type": "array",
+                      "description": "The matching package label assignments, each including the nested label that was assigned.",
+                      "items": {
+                        "allOf": [
+                          {
+                            "type": "object",
+                            "description": "A single Package Label assignment.",
+                            "properties": {
+                              "id": {
+                                "type": "integer",
+                                "description": "The ID of the package label assignment."
+                              },
+                              "createdAt": {
+                                "type": "string",
+                                "format": "date-time",
+                                "description": "The date and time the package label assignment was created."
+                              },
+                              "updatedAt": {
+                                "type": "string",
+                                "format": "date-time",
+                                "description": "The date and time the package label assignment was last updated."
+                              },
+                              "organizationId": {
+                                "type": "integer",
+                                "description": "The ID of the organization that owns the package label assignment."
+                              },
+                              "labelId": {
+                                "type": "integer",
+                                "description": "The ID of the label that was assigned to the package."
+                              },
+                              "packageId": {
+                                "type": "string",
+                                "description": "The ID of the package that the label was assigned to."
+                              },
+                              "packageVersion": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "The version of the package that the label was assigned to or null if the label was assigned to all versions."
+                              },
+                              "scope": {
+                                "type": "string",
+                                "description": "The scope of the package label assignment.",
+                                "enum": [
+                                  "org",
+                                  "project",
+                                  "revision"
+                                ]
+                              },
+                              "scopeId": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "The ID of the scope that the label was assigned to or null if the label was assigned to all scopes."
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "createdAt",
+                              "updatedAt",
+                              "organizationId",
+                              "labelId",
+                              "packageId",
+                              "scope",
+                              "scopeId"
+                            ]
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "packageLabel": {
+                                "type": "object",
+                                "description": "The label that was assigned to the package.",
+                                "properties": {
+                                  "id": {
+                                    "type": "integer",
+                                    "description": "The ID of the label."
+                                  },
+                                  "organizationId": {
+                                    "type": "integer",
+                                    "description": "The ID of the organization that owns the label."
+                                  },
+                                  "name": {
+                                    "type": "string",
+                                    "description": "The name of the label."
+                                  },
+                                  "createdAt": {
+                                    "type": "string",
+                                    "format": "date-time",
+                                    "description": "The date and time the label was created."
+                                  },
+                                  "updatedAt": {
+                                    "type": "string",
+                                    "format": "date-time",
+                                    "description": "The date and time the label was last updated."
+                                  }
+                                },
+                                "required": [
+                                  "id",
+                                  "organizationId",
+                                  "name",
+                                  "createdAt",
+                                  "updatedAt"
+                                ]
+                              }
+                            },
+                            "required": [
+                              "packageLabel"
+                            ]
+                          }
+                        ]
+                      }
                     }
-                  }
+                  },
+                  "required": [
+                    "packageLabelAssignments"
+                  ]
                 },
                 "examples": {
                   "packageLabelAssignments": {
                     "value": {
-                      "packageLabelAssignments": {
-                        "id": 1,
-                        "createdAt": "2024-12-02T21:31:12.515Z",
-                        "updatedAt": "2024-12-02T21:31:12.515Z",
-                        "organizationId": 1,
-                        "labelId": 5,
-                        "packageId": "npm+lodash",
-                        "packageVersion": "4.15.0",
-                        "scope": {
+                      "packageLabelAssignments": [
+                        {
                           "id": 1,
-                          "name": "project"
-                        },
-                        "scopeId": "custom+1/my-cli-project"
-                      }
+                          "createdAt": "2024-12-02T21:31:12.515Z",
+                          "updatedAt": "2024-12-02T21:31:12.515Z",
+                          "organizationId": 1,
+                          "labelId": 5,
+                          "packageId": "npm+lodash",
+                          "packageVersion": "4.15.0",
+                          "scope": "project",
+                          "scopeId": "custom+1/my-cli-project",
+                          "packageLabel": {
+                            "id": 5,
+                            "organizationId": 1,
+                            "name": "Approved",
+                            "createdAt": "2024-12-01T18:00:00.000Z",
+                            "updatedAt": "2024-12-01T18:00:00.000Z"
+                          }
+                        }
+                      ]
                     }
                   }
                 }
@@ -28565,7 +33022,8 @@
                 },
                 "required": [
                   "packageId",
-                  "labels"
+                  "scope",
+                  "labelIds"
                 ]
               },
               "examples": {
@@ -28592,86 +33050,383 @@
               "application/json": {
                 "schema": {
                   "type": "object",
+                  "description": "The package label assignments that were created or updated by the request.",
                   "properties": {
-                    "packageLabelAssignmentResponse": {
-                      "type": "object",
-                      "properties": {
-                        "id": {
-                          "type": "integer",
-                          "description": "The ID of the package label assignment."
+                    "packageLabelAssignments": {
+                      "type": "array",
+                      "description": "The package label assignments that were written. Newly created assignments only -- existing (duplicate) assignments are not returned.",
+                      "items": {
+                        "type": "object",
+                        "description": "A single Package Label assignment.",
+                        "properties": {
+                          "id": {
+                            "type": "integer",
+                            "description": "The ID of the package label assignment."
+                          },
+                          "createdAt": {
+                            "type": "string",
+                            "format": "date-time",
+                            "description": "The date and time the package label assignment was created."
+                          },
+                          "updatedAt": {
+                            "type": "string",
+                            "format": "date-time",
+                            "description": "The date and time the package label assignment was last updated."
+                          },
+                          "organizationId": {
+                            "type": "integer",
+                            "description": "The ID of the organization that owns the package label assignment."
+                          },
+                          "labelId": {
+                            "type": "integer",
+                            "description": "The ID of the label that was assigned to the package."
+                          },
+                          "packageId": {
+                            "type": "string",
+                            "description": "The ID of the package that the label was assigned to."
+                          },
+                          "packageVersion": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "The version of the package that the label was assigned to or null if the label was assigned to all versions."
+                          },
+                          "scope": {
+                            "type": "string",
+                            "description": "The scope of the package label assignment.",
+                            "enum": [
+                              "org",
+                              "project",
+                              "revision"
+                            ]
+                          },
+                          "scopeId": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "The ID of the scope that the label was assigned to or null if the label was assigned to all scopes."
+                          }
                         },
-                        "createdAt": {
-                          "type": "string",
-                          "format": "date-time",
-                          "description": "The date and time the package label assignment was created."
-                        },
-                        "updatedAt": {
-                          "type": "string",
-                          "format": "date-time",
-                          "description": "The date and time the package label assignment was last updated."
-                        },
-                        "organizationId": {
-                          "type": "integer",
-                          "description": "The ID of the organization that owns the package label assignment."
-                        },
-                        "labelId": {
-                          "type": "integer",
-                          "description": "The ID of the label that was assigned to the package."
-                        },
-                        "packageId": {
-                          "type": "string",
-                          "description": "The ID of the package that the label was assigned to."
-                        },
-                        "packageVersion": {
-                          "type": "string",
-                          "nullable": true,
-                          "description": "The version of the package that the label was assigned to or null if the label was assigned to all versions."
-                        },
-                        "scope": {
-                          "type": "string",
-                          "description": "The scope of the package label assignment.",
-                          "enum": [
-                            "org",
-                            "project",
-                            "revision"
-                          ]
-                        },
-                        "scopeId": {
-                          "type": "string",
-                          "nullable": true,
-                          "description": "The ID of the scope that the label was assigned to or null if the label was assigned to all scopes."
-                        }
-                      },
-                      "required": [
-                        "id",
-                        "createdAt",
-                        "updatedAt",
-                        "organizationId",
-                        "labelId",
-                        "packageId",
-                        "scope",
-                        "scopeId"
-                      ]
+                        "required": [
+                          "id",
+                          "createdAt",
+                          "updatedAt",
+                          "organizationId",
+                          "labelId",
+                          "packageId",
+                          "scope",
+                          "scopeId"
+                        ]
+                      }
                     }
-                  }
+                  },
+                  "required": [
+                    "packageLabelAssignments"
+                  ]
                 },
                 "examples": {
                   "packageLabelAssignments": {
                     "value": {
-                      "packageLabelAssignments": {
-                        "id": 1,
-                        "createdAt": "2024-12-02T21:31:12.515Z",
-                        "updatedAt": "2024-12-02T21:31:12.515Z",
-                        "organizationId": 1,
-                        "labelId": 5,
-                        "packageId": "npm+lodash",
-                        "packageVersion": "4.15.0",
-                        "scope": {
+                      "packageLabelAssignments": [
+                        {
                           "id": 1,
-                          "name": "project"
+                          "createdAt": "2024-12-02T21:31:12.515Z",
+                          "updatedAt": "2024-12-02T21:31:12.515Z",
+                          "organizationId": 1,
+                          "labelId": 1,
+                          "packageId": "npm+lodash",
+                          "packageVersion": "4.15.0",
+                          "scope": "project",
+                          "scopeId": "custom+1/my-cli-project"
                         },
-                        "scopeId": "custom+1/my-cli-project"
+                        {
+                          "id": 2,
+                          "createdAt": "2024-12-02T21:31:12.515Z",
+                          "updatedAt": "2024-12-02T21:31:12.515Z",
+                          "organizationId": 1,
+                          "labelId": 2,
+                          "packageId": "npm+lodash",
+                          "packageVersion": "4.15.0",
+                          "scope": "project",
+                          "scopeId": "custom+1/my-cli-project"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Package Labels"
+        ],
+        "operationId": "updatePackageLabelAssignments",
+        "description": "Reconcile the Package Label assignments for a single package at a given scope.\n\nThe desired end state is supplied as `newLabelIds`, a map keyed by package\nversion (use the version string, or `all` for assignments that apply to every\nversion) whose value is the list of label IDs that should be assigned for that\nversion. Existing assignments not present in the map are removed and any new\nlabel IDs are added.\n\nNote - This endpoint is not available for organizations on the Free plan.\n",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "packageId": {
+                    "type": "string",
+                    "description": "The ID of the package whose label assignments are being reconciled."
+                  },
+                  "scope": {
+                    "type": "string",
+                    "description": "The scope of the package label assignment.",
+                    "enum": [
+                      "org",
+                      "project",
+                      "revision"
+                    ]
+                  },
+                  "scopeId": {
+                    "type": "string",
+                    "description": "The ID of the scope to reconcile assignments for."
+                  },
+                  "newLabelIds": {
+                    "type": "object",
+                    "description": "The desired label assignments, keyed by package version (or `all` for\nassignments that apply to every version). Each value is the list of\nlabel IDs that should be assigned for that version.\n",
+                    "additionalProperties": {
+                      "type": "array",
+                      "items": {
+                        "type": "integer"
                       }
+                    }
+                  }
+                },
+                "required": [
+                  "packageId",
+                  "scope",
+                  "newLabelIds"
+                ]
+              },
+              "examples": {
+                "example": {
+                  "value": {
+                    "packageId": "npm+lodash",
+                    "scope": "project",
+                    "scopeId": "custom+1/my-cli-project",
+                    "newLabelIds": {
+                      "4.15.0": [
+                        1,
+                        2
+                      ],
+                      "all": [
+                        3
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "The package label assignments that were created or updated by the request.",
+                  "properties": {
+                    "packageLabelAssignments": {
+                      "type": "array",
+                      "description": "The package label assignments that were written. Newly created assignments only -- existing (duplicate) assignments are not returned.",
+                      "items": {
+                        "type": "object",
+                        "description": "A single Package Label assignment.",
+                        "properties": {
+                          "id": {
+                            "type": "integer",
+                            "description": "The ID of the package label assignment."
+                          },
+                          "createdAt": {
+                            "type": "string",
+                            "format": "date-time",
+                            "description": "The date and time the package label assignment was created."
+                          },
+                          "updatedAt": {
+                            "type": "string",
+                            "format": "date-time",
+                            "description": "The date and time the package label assignment was last updated."
+                          },
+                          "organizationId": {
+                            "type": "integer",
+                            "description": "The ID of the organization that owns the package label assignment."
+                          },
+                          "labelId": {
+                            "type": "integer",
+                            "description": "The ID of the label that was assigned to the package."
+                          },
+                          "packageId": {
+                            "type": "string",
+                            "description": "The ID of the package that the label was assigned to."
+                          },
+                          "packageVersion": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "The version of the package that the label was assigned to or null if the label was assigned to all versions."
+                          },
+                          "scope": {
+                            "type": "string",
+                            "description": "The scope of the package label assignment.",
+                            "enum": [
+                              "org",
+                              "project",
+                              "revision"
+                            ]
+                          },
+                          "scopeId": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "The ID of the scope that the label was assigned to or null if the label was assigned to all scopes."
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "createdAt",
+                          "updatedAt",
+                          "organizationId",
+                          "labelId",
+                          "packageId",
+                          "scope",
+                          "scopeId"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "packageLabelAssignments"
+                  ]
+                },
+                "examples": {
+                  "packageLabelAssignments": {
+                    "value": {
+                      "packageLabelAssignments": [
+                        {
+                          "id": 1,
+                          "createdAt": "2024-12-02T21:31:12.515Z",
+                          "updatedAt": "2024-12-02T21:31:12.515Z",
+                          "organizationId": 1,
+                          "labelId": 1,
+                          "packageId": "npm+lodash",
+                          "packageVersion": "4.15.0",
+                          "scope": "project",
+                          "scopeId": "custom+1/my-cli-project"
+                        },
+                        {
+                          "id": 2,
+                          "createdAt": "2024-12-02T21:31:12.515Z",
+                          "updatedAt": "2024-12-02T21:31:12.515Z",
+                          "organizationId": 1,
+                          "labelId": 2,
+                          "packageId": "npm+lodash",
+                          "packageVersion": "4.15.0",
+                          "scope": "project",
+                          "scopeId": "custom+1/my-cli-project"
+                        }
+                      ]
                     }
                   }
                 }
@@ -28789,19 +33544,23 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "assignmentLabelIds": {
+                  "assignmentIds": {
                     "type": "array",
                     "description": "The IDs of the package label assignments to delete.",
+                    "minItems": 1,
                     "items": {
                       "type": "integer"
                     }
                   }
-                }
+                },
+                "required": [
+                  "assignmentIds"
+                ]
               },
               "examples": {
                 "example": {
                   "value": {
-                    "assignmentLabelIds": [
+                    "assignmentIds": [
                       1,
                       2
                     ]
@@ -29015,86 +33774,105 @@
               "application/json": {
                 "schema": {
                   "type": "object",
+                  "description": "The package label assignments that were created or updated by the request.",
                   "properties": {
-                    "packageLabelAssignmentResponse": {
-                      "type": "object",
-                      "properties": {
-                        "id": {
-                          "type": "integer",
-                          "description": "The ID of the package label assignment."
+                    "packageLabelAssignments": {
+                      "type": "array",
+                      "description": "The package label assignments that were written. Newly created assignments only -- existing (duplicate) assignments are not returned.",
+                      "items": {
+                        "type": "object",
+                        "description": "A single Package Label assignment.",
+                        "properties": {
+                          "id": {
+                            "type": "integer",
+                            "description": "The ID of the package label assignment."
+                          },
+                          "createdAt": {
+                            "type": "string",
+                            "format": "date-time",
+                            "description": "The date and time the package label assignment was created."
+                          },
+                          "updatedAt": {
+                            "type": "string",
+                            "format": "date-time",
+                            "description": "The date and time the package label assignment was last updated."
+                          },
+                          "organizationId": {
+                            "type": "integer",
+                            "description": "The ID of the organization that owns the package label assignment."
+                          },
+                          "labelId": {
+                            "type": "integer",
+                            "description": "The ID of the label that was assigned to the package."
+                          },
+                          "packageId": {
+                            "type": "string",
+                            "description": "The ID of the package that the label was assigned to."
+                          },
+                          "packageVersion": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "The version of the package that the label was assigned to or null if the label was assigned to all versions."
+                          },
+                          "scope": {
+                            "type": "string",
+                            "description": "The scope of the package label assignment.",
+                            "enum": [
+                              "org",
+                              "project",
+                              "revision"
+                            ]
+                          },
+                          "scopeId": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "The ID of the scope that the label was assigned to or null if the label was assigned to all scopes."
+                          }
                         },
-                        "createdAt": {
-                          "type": "string",
-                          "format": "date-time",
-                          "description": "The date and time the package label assignment was created."
-                        },
-                        "updatedAt": {
-                          "type": "string",
-                          "format": "date-time",
-                          "description": "The date and time the package label assignment was last updated."
-                        },
-                        "organizationId": {
-                          "type": "integer",
-                          "description": "The ID of the organization that owns the package label assignment."
-                        },
-                        "labelId": {
-                          "type": "integer",
-                          "description": "The ID of the label that was assigned to the package."
-                        },
-                        "packageId": {
-                          "type": "string",
-                          "description": "The ID of the package that the label was assigned to."
-                        },
-                        "packageVersion": {
-                          "type": "string",
-                          "nullable": true,
-                          "description": "The version of the package that the label was assigned to or null if the label was assigned to all versions."
-                        },
-                        "scope": {
-                          "type": "string",
-                          "description": "The scope of the package label assignment.",
-                          "enum": [
-                            "org",
-                            "project",
-                            "revision"
-                          ]
-                        },
-                        "scopeId": {
-                          "type": "string",
-                          "nullable": true,
-                          "description": "The ID of the scope that the label was assigned to or null if the label was assigned to all scopes."
-                        }
-                      },
-                      "required": [
-                        "id",
-                        "createdAt",
-                        "updatedAt",
-                        "organizationId",
-                        "labelId",
-                        "packageId",
-                        "scope",
-                        "scopeId"
-                      ]
+                        "required": [
+                          "id",
+                          "createdAt",
+                          "updatedAt",
+                          "organizationId",
+                          "labelId",
+                          "packageId",
+                          "scope",
+                          "scopeId"
+                        ]
+                      }
                     }
-                  }
+                  },
+                  "required": [
+                    "packageLabelAssignments"
+                  ]
                 },
                 "examples": {
                   "packageLabelAssignments": {
                     "value": {
-                      "packageLabelAssignments": {
-                        "id": 1,
-                        "createdAt": "2024-12-02T21:31:12.515Z",
-                        "updatedAt": "2024-12-02T21:31:12.515Z",
-                        "organizationId": 1,
-                        "labelId": 5,
-                        "packageId": "npm+lodash",
-                        "packageVersion": "4.15.0",
-                        "scope": {
+                      "packageLabelAssignments": [
+                        {
                           "id": 1,
-                          "name": "project"
+                          "createdAt": "2024-12-02T21:31:12.515Z",
+                          "updatedAt": "2024-12-02T21:31:12.515Z",
+                          "organizationId": 1,
+                          "labelId": 1,
+                          "packageId": "npm+lodash",
+                          "packageVersion": "4.15.0",
+                          "scope": "project",
+                          "scopeId": "custom+1/my-cli-project"
                         },
-                        "scopeId": "custom+1/my-cli-project"
-                      }
+                        {
+                          "id": 2,
+                          "createdAt": "2024-12-02T21:31:12.515Z",
+                          "updatedAt": "2024-12-02T21:31:12.515Z",
+                          "organizationId": 1,
+                          "labelId": 2,
+                          "packageId": "npm+lodash",
+                          "packageVersion": "4.15.0",
+                          "scope": "project",
+                          "scopeId": "custom+1/my-cli-project"
+                        }
+                      ]
                     }
                   }
                 }
@@ -29274,13 +34052,6 @@
                     "type": "boolean",
                     "nullable": true
                   },
-                  "issueTrackerType": {
-                    "type": "string",
-                    "enum": [
-                      "github",
-                      "jira"
-                    ]
-                  },
                   "teams": {
                     "type": "array",
                     "items": {
@@ -29321,7 +34092,6 @@
                   "securityPolicyId": 2,
                   "qualityPolicyId": null,
                   "publicOnPortal": true,
-                  "issueTrackerType": "github",
                   "teams": [
                     101,
                     102
@@ -29407,7 +34177,7 @@
                     "securityPolicyId": 1002,
                     "qualityPolicyId": null,
                     "publicOnPortal": true,
-                    "customReportText": null,
+                    "reportCustomText": null,
                     "createdAt": "2024-07-09T21:51:20.671Z",
                     "updatedAt": "2024-07-09T21:51:20.671Z"
                   }
@@ -29420,7 +34190,7 @@
                   "securityPolicyId": 1,
                   "qualityPolicyId": null,
                   "publicOnPortal": true,
-                  "customReportText": null,
+                  "reportCustomText": null,
                   "createdAt": "2024-07-09T21:51:20.671Z",
                   "updatedAt": "2024-07-09T21:51:20.671Z"
                 }
@@ -29608,7 +34378,7 @@
                         "securityPolicyId": 1002,
                         "qualityPolicyId": null,
                         "publicOnPortal": true,
-                        "customReportText": null,
+                        "reportCustomText": null,
                         "createdAt": "2024-07-09T21:51:20.671Z",
                         "updatedAt": "2024-07-09T21:51:20.671Z"
                       }
@@ -29802,7 +34572,7 @@
                   "securityPolicyId": 1002,
                   "qualityPolicyId": null,
                   "publicOnPortal": true,
-                  "customReportText": null,
+                  "reportCustomText": null,
                   "createdAt": "2024-07-09T21:51:20.671Z",
                   "updatedAt": "2024-07-09T21:51:20.671Z",
                   "releases": [
@@ -30014,7 +34784,7 @@
                     "securityPolicyId": 1002,
                     "qualityPolicyId": null,
                     "publicOnPortal": true,
-                    "customReportText": null,
+                    "reportCustomText": null,
                     "createdAt": "2024-07-09T21:51:20.671Z",
                     "updatedAt": "2024-07-09T21:51:20.671Z"
                   }
@@ -30027,7 +34797,7 @@
                   "securityPolicyId": 1002,
                   "qualityPolicyId": 1003,
                   "publicOnPortal": true,
-                  "customReportText": null,
+                  "reportCustomText": null,
                   "createdAt": "2024-07-09T21:51:20.671Z",
                   "updatedAt": "2024-07-09T21:51:20.671Z"
                 }
@@ -30722,7 +35492,7 @@
                           "securityPolicyId": 1002,
                           "qualityPolicyId": null,
                           "publicOnPortal": true,
-                          "customReportText": null,
+                          "reportCustomText": null,
                           "createdAt": "2024-07-09T21:51:20.671Z",
                           "updatedAt": "2024-07-09T21:51:20.671Z"
                         }
@@ -30779,7 +35549,7 @@
                       "securityPolicyId": 1002,
                       "qualityPolicyId": 1003,
                       "publicOnPortal": true,
-                      "customReportText": null,
+                      "reportCustomText": null,
                       "createdAt": "2024-07-09T21:51:20.671Z",
                       "updatedAt": "2024-07-09T21:51:20.671Z",
                       "projects": []
@@ -30906,81 +35676,167 @@
         },
         "responses": {
           "200": {
-            "description": "OK",
+            "description": "The created release, including its projects",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "integer"
+                  "allOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "description": "Release ID"
+                        },
+                        "title": {
+                          "type": "string",
+                          "description": "Release title/version"
+                        },
+                        "projectGroupId": {
+                          "type": "integer",
+                          "description": "The release group which this belongs to"
+                        },
+                        "dependency_count": {
+                          "type": "integer",
+                          "description": "The count of dependencies in this release",
+                          "nullable": true
+                        },
+                        "license_count": {
+                          "type": "integer",
+                          "description": "The count of licenses in this release",
+                          "nullable": true
+                        },
+                        "unresolved_licensing_issue_count": {
+                          "type": "integer",
+                          "description": "The number of licensing issues in this release",
+                          "nullable": true
+                        },
+                        "unresolved_security_issue_count": {
+                          "type": "integer",
+                          "description": "The number of security issues in this release",
+                          "nullable": true
+                        },
+                        "unresolved_quality_issue_count": {
+                          "type": "integer",
+                          "description": "The number of quality issues in this release",
+                          "nullable": true
+                        },
+                        "publishedOnPortal": {
+                          "description": "If this release has been published on an SBOM portal",
+                          "type": "string",
+                          "enum": [
+                            "attribution_txt",
+                            "spdx_tagged",
+                            "cyclonedx_json",
+                            "spdx_json",
+                            "cyclonedx_xml",
+                            "pending"
+                          ],
+                          "nullable": true
+                        },
+                        "publishedAt": {
+                          "type": "string",
+                          "format": "date-time",
+                          "description": "When the release was published to the portal"
+                        },
+                        "reportPath": {
+                          "type": "string",
+                          "description": "Path to the SBOM report for this release",
+                          "nullable": true
+                        },
+                        "publishedLicenses": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "description": "List of published license IDs",
+                          "nullable": true
+                        }
+                      },
+                      "example": {
+                        "id": 1,
+                        "title": "1.0.0",
+                        "projectGroupId": 1,
+                        "dependency_count": 50,
+                        "license_count": 10,
+                        "unresolved_licensing_issue_count": 2,
+                        "unresolved_security_issue_count": 3,
+                        "unresolved_quality_issue_count": 1,
+                        "publishedOnPortal": "cyclonedx_json",
+                        "publishedAt": "2024-07-09T19:14:26Z",
+                        "reportPath": "/reports/1.0.0/sbom.cyclonedx.json",
+                        "publishedLicenses": [
+                          "MIT",
+                          "Apache-2.0"
+                        ]
+                      }
                     },
-                    "title": {
-                      "type": "string"
-                    },
-                    "organizationId": {
-                      "type": "integer"
-                    },
-                    "policyId": {
-                      "type": [
-                        "null",
-                        "integer"
-                      ]
-                    },
-                    "securityPolicyId": {
-                      "type": [
-                        "null",
-                        "integer"
-                      ]
-                    },
-                    "qualityPolicyId": {
-                      "type": [
-                        "null",
-                        "integer"
-                      ]
-                    },
-                    "publicOnPortal": {
-                      "type": "boolean"
-                    },
-                    "reportCustomText": {
-                      "type": [
-                        "null",
-                        "string"
-                      ]
-                    },
-                    "createdAt": {
-                      "type": "string",
-                      "format": "date-time"
-                    },
-                    "updatedAt": {
-                      "type": "string",
-                      "format": "date-time"
+                    {
+                      "type": "object",
+                      "properties": {
+                        "projects": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "projectId": {
+                                "type": "string"
+                              },
+                              "projectGroupReleaseId": {
+                                "type": "integer"
+                              },
+                              "branch": {
+                                "type": "string"
+                              },
+                              "revisionId": {
+                                "type": "string"
+                              },
+                              "createdAt": {
+                                "type": "string",
+                                "format": "date-time"
+                              },
+                              "updatedAt": {
+                                "type": "string",
+                                "format": "date-time"
+                              }
+                            },
+                            "example": {
+                              "projectId": "custom+1/github.com/myrepo",
+                              "projectGroupReleaseId": 1,
+                              "branch": "main",
+                              "revisionId": "rev001",
+                              "createdAt": "2024-07-09T19:14:26Z",
+                              "updatedAt": "2024-07-09T19:14:26Z"
+                            }
+                          }
+                        }
+                      }
                     }
-                  },
-                  "example": {
-                    "id": 1,
-                    "title": "My Release Group",
-                    "organizationId": 1000,
-                    "policyId": 1001,
-                    "securityPolicyId": 1002,
-                    "qualityPolicyId": null,
-                    "publicOnPortal": true,
-                    "customReportText": null,
-                    "createdAt": "2024-07-09T21:51:20.671Z",
-                    "updatedAt": "2024-07-09T21:51:20.671Z"
-                  }
+                  ]
                 },
                 "example": {
                   "id": 1,
-                  "title": "New Release Group",
-                  "organizationId": 1000,
-                  "policyId": 1001,
-                  "securityPolicyId": 1002,
-                  "qualityPolicyId": 1003,
-                  "publicOnPortal": true,
-                  "customReportText": null,
-                  "createdAt": "2024-07-09T21:51:20.671Z",
-                  "updatedAt": "2024-07-09T21:51:20.671Z"
+                  "title": "1.2.3",
+                  "projectGroupId": 1,
+                  "dependency_count": null,
+                  "license_count": null,
+                  "unresolved_licensing_issue_count": null,
+                  "unresolved_security_issue_count": null,
+                  "unresolved_quality_issue_count": null,
+                  "publishedOnPortal": null,
+                  "publishedAt": null,
+                  "reportPath": null,
+                  "publishedLicenses": null,
+                  "projects": [
+                    {
+                      "projectId": "git+github.com/myorg/myrepo",
+                      "projectGroupReleaseId": 1,
+                      "branch": "main",
+                      "revisionId": "a0b1c3",
+                      "createdAt": "2024-07-09T19:14:26Z",
+                      "updatedAt": "2024-07-09T19:14:26Z"
+                    }
+                  ]
                 }
               }
             }
@@ -31123,413 +35979,433 @@
         ],
         "responses": {
           "200": {
-            "description": "OK",
+            "description": "The release, including its projects",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "allOf": [
-                      {
-                        "type": "object",
-                        "properties": {
-                          "id": {
-                            "type": "integer"
-                          },
-                          "title": {
+                  "allOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "description": "Release ID"
+                        },
+                        "title": {
+                          "type": "string",
+                          "description": "Release title/version"
+                        },
+                        "projectGroupId": {
+                          "type": "integer",
+                          "description": "The release group which this belongs to"
+                        },
+                        "dependency_count": {
+                          "type": "integer",
+                          "description": "The count of dependencies in this release",
+                          "nullable": true
+                        },
+                        "license_count": {
+                          "type": "integer",
+                          "description": "The count of licenses in this release",
+                          "nullable": true
+                        },
+                        "unresolved_licensing_issue_count": {
+                          "type": "integer",
+                          "description": "The number of licensing issues in this release",
+                          "nullable": true
+                        },
+                        "unresolved_security_issue_count": {
+                          "type": "integer",
+                          "description": "The number of security issues in this release",
+                          "nullable": true
+                        },
+                        "unresolved_quality_issue_count": {
+                          "type": "integer",
+                          "description": "The number of quality issues in this release",
+                          "nullable": true
+                        },
+                        "publishedOnPortal": {
+                          "description": "If this release has been published on an SBOM portal",
+                          "type": "string",
+                          "enum": [
+                            "attribution_txt",
+                            "spdx_tagged",
+                            "cyclonedx_json",
+                            "spdx_json",
+                            "cyclonedx_xml",
+                            "pending"
+                          ],
+                          "nullable": true
+                        },
+                        "publishedAt": {
+                          "type": "string",
+                          "format": "date-time",
+                          "description": "When the release was published to the portal"
+                        },
+                        "reportPath": {
+                          "type": "string",
+                          "description": "Path to the SBOM report for this release",
+                          "nullable": true
+                        },
+                        "publishedLicenses": {
+                          "type": "array",
+                          "items": {
                             "type": "string"
                           },
-                          "organizationId": {
-                            "type": "integer"
-                          },
-                          "policyId": {
-                            "type": [
-                              "null",
-                              "integer"
-                            ]
-                          },
-                          "securityPolicyId": {
-                            "type": [
-                              "null",
-                              "integer"
-                            ]
-                          },
-                          "qualityPolicyId": {
-                            "type": [
-                              "null",
-                              "integer"
-                            ]
-                          },
-                          "publicOnPortal": {
-                            "type": "boolean"
-                          },
-                          "reportCustomText": {
-                            "type": [
-                              "null",
-                              "string"
-                            ]
-                          },
-                          "createdAt": {
-                            "type": "string",
-                            "format": "date-time"
-                          },
-                          "updatedAt": {
-                            "type": "string",
-                            "format": "date-time"
-                          }
-                        },
-                        "example": {
-                          "id": 1,
-                          "title": "My Release Group",
-                          "organizationId": 1000,
-                          "policyId": 1001,
-                          "securityPolicyId": 1002,
-                          "qualityPolicyId": null,
-                          "publicOnPortal": true,
-                          "customReportText": null,
-                          "createdAt": "2024-07-09T21:51:20.671Z",
-                          "updatedAt": "2024-07-09T21:51:20.671Z"
+                          "description": "List of published license IDs",
+                          "nullable": true
                         }
                       },
-                      {
-                        "type": "object",
-                        "properties": {
-                          "projects": {
-                            "type": "array",
-                            "items": {
-                              "allOf": [
-                                {
-                                  "type": "object",
-                                  "properties": {
-                                    "projectId": {
-                                      "type": "string"
-                                    },
-                                    "projectGroupReleaseId": {
-                                      "type": "integer"
-                                    },
-                                    "branch": {
-                                      "type": "string"
-                                    },
-                                    "revisionId": {
-                                      "type": "string"
-                                    },
-                                    "createdAt": {
-                                      "type": "string",
-                                      "format": "date-time"
-                                    },
-                                    "updatedAt": {
-                                      "type": "string",
-                                      "format": "date-time"
-                                    }
+                      "example": {
+                        "id": 1,
+                        "title": "1.0.0",
+                        "projectGroupId": 1,
+                        "dependency_count": 50,
+                        "license_count": 10,
+                        "unresolved_licensing_issue_count": 2,
+                        "unresolved_security_issue_count": 3,
+                        "unresolved_quality_issue_count": 1,
+                        "publishedOnPortal": "cyclonedx_json",
+                        "publishedAt": "2024-07-09T19:14:26Z",
+                        "reportPath": "/reports/1.0.0/sbom.cyclonedx.json",
+                        "publishedLicenses": [
+                          "MIT",
+                          "Apache-2.0"
+                        ]
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "projects": {
+                          "type": "array",
+                          "items": {
+                            "allOf": [
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "projectId": {
+                                    "type": "string"
                                   },
-                                  "example": {
-                                    "projectId": "custom+1/github.com/myrepo",
-                                    "projectGroupReleaseId": 1,
-                                    "branch": "main",
-                                    "revisionId": "rev001",
-                                    "createdAt": "2024-07-09T19:14:26Z",
-                                    "updatedAt": "2024-07-09T19:14:26Z"
+                                  "projectGroupReleaseId": {
+                                    "type": "integer"
+                                  },
+                                  "branch": {
+                                    "type": "string"
+                                  },
+                                  "revisionId": {
+                                    "type": "string"
+                                  },
+                                  "createdAt": {
+                                    "type": "string",
+                                    "format": "date-time"
+                                  },
+                                  "updatedAt": {
+                                    "type": "string",
+                                    "format": "date-time"
                                   }
                                 },
-                                {
-                                  "type": "object",
-                                  "properties": {
-                                    "project": {
-                                      "type": "array",
-                                      "items": {
-                                        "allOf": [
-                                          {
-                                            "type": "object",
-                                            "required": [
-                                              "id",
-                                              "title",
-                                              "branch",
-                                              "type",
-                                              "public",
-                                              "teams"
-                                            ],
-                                            "properties": {
-                                              "id": {
-                                                "type": "string"
-                                              },
-                                              "title": {
-                                                "type": "string"
-                                              },
-                                              "branch": {
-                                                "type": "string"
-                                              },
-                                              "version": {
-                                                "type": "string"
-                                              },
-                                              "type": {
-                                                "type": "string",
-                                                "enum": [
-                                                  "container",
-                                                  "archive",
-                                                  "provided",
-                                                  "autobuild",
-                                                  "sbom"
-                                                ]
-                                              },
-                                              "public": {
-                                                "type": "boolean"
-                                              },
-                                              "url": {
-                                                "type": "string"
-                                              },
-                                              "scanned": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                              },
-                                              "lastAnalyzed": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                              },
-                                              "teams": {
-                                                "type": "array",
-                                                "items": {
-                                                  "type": "object",
-                                                  "properties": {
-                                                    "id": {
-                                                      "type": "integer"
-                                                    },
-                                                    "name": {
-                                                      "type": "string"
-                                                    },
-                                                    "uniqueId": {
-                                                      "type": [
-                                                        "string",
-                                                        "null"
-                                                      ]
-                                                    },
-                                                    "teamType": {
-                                                      "type": "string",
-                                                      "enum": [
-                                                        "team",
-                                                        "team_group"
-                                                      ]
-                                                    }
-                                                  }
+                                "example": {
+                                  "projectId": "custom+1/github.com/myrepo",
+                                  "projectGroupReleaseId": 1,
+                                  "branch": "main",
+                                  "revisionId": "rev001",
+                                  "createdAt": "2024-07-09T19:14:26Z",
+                                  "updatedAt": "2024-07-09T19:14:26Z"
+                                }
+                              },
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "project": {
+                                    "allOf": [
+                                      {
+                                        "type": "object",
+                                        "required": [
+                                          "id",
+                                          "title",
+                                          "branch",
+                                          "type",
+                                          "public",
+                                          "teams"
+                                        ],
+                                        "properties": {
+                                          "id": {
+                                            "type": "string"
+                                          },
+                                          "title": {
+                                            "type": "string"
+                                          },
+                                          "branch": {
+                                            "type": "string"
+                                          },
+                                          "version": {
+                                            "type": [
+                                              "string",
+                                              "null"
+                                            ]
+                                          },
+                                          "type": {
+                                            "type": "string",
+                                            "enum": [
+                                              "container",
+                                              "archive",
+                                              "provided",
+                                              "autobuild",
+                                              "sbom",
+                                              "binary"
+                                            ]
+                                          },
+                                          "public": {
+                                            "type": "boolean"
+                                          },
+                                          "originOrganizationName": {
+                                            "type": [
+                                              "string",
+                                              "null"
+                                            ]
+                                          },
+                                          "url": {
+                                            "type": "string"
+                                          },
+                                          "scanned": {
+                                            "type": "string",
+                                            "format": "date-time"
+                                          },
+                                          "lastAnalyzed": {
+                                            "type": "string",
+                                            "format": "date-time"
+                                          },
+                                          "teams": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "object",
+                                              "properties": {
+                                                "id": {
+                                                  "type": "integer"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "uniqueId": {
+                                                  "type": [
+                                                    "string",
+                                                    "null"
+                                                  ]
+                                                },
+                                                "teamType": {
+                                                  "type": "string",
+                                                  "enum": [
+                                                    "team",
+                                                    "team_group"
+                                                  ]
                                                 }
-                                              },
-                                              "latestRevision": {
-                                                "type": "object",
-                                                "required": [
-                                                  "locator"
-                                                ],
-                                                "properties": {
-                                                  "locator": {
-                                                    "type": "string"
-                                                  },
-                                                  "message": {
-                                                    "type": "string"
-                                                  }
-                                                }
-                                              },
-                                              "latestBuildStatus": {
-                                                "type": "string",
-                                                "enum": [
-                                                  "running",
-                                                  "succeeded",
-                                                  "failed"
-                                                ]
                                               }
                                             }
                                           },
-                                          {
-                                            "latestRevision": [
-                                              {
-                                                "type": "object",
-                                                "properties": {
-                                                  "loc": {
-                                                    "type": "object",
-                                                    "description": "Normalized representation of the Locator",
-                                                    "properties": {
-                                                      "fetcher": {
-                                                        "type": "string",
-                                                        "description": "the external package manager or internal representation of one"
-                                                      },
-                                                      "package": {
-                                                        "type": "string",
-                                                        "description": "the package name"
-                                                      },
-                                                      "revision": {
-                                                        "type": "string",
-                                                        "description": "the version/revision of the package"
-                                                      }
-                                                    }
-                                                  },
-                                                  "locator": {
-                                                    "type": "string",
-                                                    "description": "Text ID that uniquely identifies a project"
-                                                  },
-                                                  "resolved": {
-                                                    "type": "boolean",
-                                                    "description": "Has the Revision been fully analyzed by FOSSA"
-                                                  },
-                                                  "projectId": {
-                                                    "type": "string",
-                                                    "description": "The Project locator that the Revision belongs to"
-                                                  },
-                                                  "source_type": {
-                                                    "type": [
-                                                      "string",
-                                                      "null"
-                                                    ],
-                                                    "description": "FOSSA internal representation of the source language for the given repository/project"
-                                                  },
-                                                  "error": {
-                                                    "type": [
-                                                      "string",
-                                                      "null"
-                                                    ],
-                                                    "description": "Error message during analysis (if any)"
-                                                  },
-                                                  "message": {
-                                                    "type": [
-                                                      "string",
-                                                      "null"
-                                                    ],
-                                                    "description": "Message of the revision or commit"
-                                                  },
-                                                  "revision_timestamp": {
-                                                    "type": [
-                                                      "string",
-                                                      "null"
-                                                    ],
-                                                    "description": "timestamp of when the Revision was published"
-                                                  },
-                                                  "latestRevisionScanId": {
-                                                    "type": [
-                                                      "number",
-                                                      "null"
-                                                    ],
-                                                    "description": "The Revision Scan ID of the latest policy scan"
-                                                  },
-                                                  "latestHubbleAnalysisId": {
-                                                    "type": [
-                                                      "number",
-                                                      "null"
-                                                    ],
-                                                    "description": "The Hubble Analysis ID of the latest analysis"
-                                                  },
-                                                  "createdAt": {
-                                                    "type": "string",
-                                                    "description": "when the Revision was added to the FOSSA Database"
-                                                  },
-                                                  "updatedAt": {
-                                                    "type": "string",
-                                                    "description": "when the Revision was last updated in the FOSSA Database"
-                                                  },
-                                                  "author": {
-                                                    "type": [
-                                                      "string",
-                                                      "null"
-                                                    ],
-                                                    "description": "The author of the Revision"
-                                                  },
-                                                  "link": {
-                                                    "type": [
-                                                      "string",
-                                                      "null"
-                                                    ],
-                                                    "description": "The link associated with the Revision"
-                                                  },
-                                                  "url": {
-                                                    "type": [
-                                                      "string",
-                                                      "null"
-                                                    ],
-                                                    "description": "The url associated with the Revision"
-                                                  }
-                                                }
+                                          "latestRevision": {
+                                            "type": "object",
+                                            "required": [
+                                              "locator"
+                                            ],
+                                            "properties": {
+                                              "locator": {
+                                                "type": "string"
+                                              },
+                                              "message": {
+                                                "type": "string"
                                               }
+                                            }
+                                          },
+                                          "latestBuildStatus": {
+                                            "type": "string",
+                                            "enum": [
+                                              "running",
+                                              "succeeded",
+                                              "failed"
                                             ]
                                           }
-                                        ]
+                                        }
+                                      },
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "latestRevision": {
+                                            "type": "object",
+                                            "properties": {
+                                              "loc": {
+                                                "type": "object",
+                                                "description": "Normalized representation of the Locator",
+                                                "properties": {
+                                                  "fetcher": {
+                                                    "type": "string",
+                                                    "description": "the external package manager or internal representation of one"
+                                                  },
+                                                  "package": {
+                                                    "type": "string",
+                                                    "description": "the package name"
+                                                  },
+                                                  "revision": {
+                                                    "type": "string",
+                                                    "description": "the version/revision of the package"
+                                                  }
+                                                }
+                                              },
+                                              "locator": {
+                                                "type": "string",
+                                                "description": "Text ID that uniquely identifies a project"
+                                              },
+                                              "resolved": {
+                                                "type": "boolean",
+                                                "description": "Has the Revision been fully analyzed by FOSSA"
+                                              },
+                                              "projectId": {
+                                                "type": "string",
+                                                "description": "The Project locator that the Revision belongs to"
+                                              },
+                                              "source_type": {
+                                                "type": [
+                                                  "string",
+                                                  "null"
+                                                ],
+                                                "description": "FOSSA internal representation of the source language for the given repository/project"
+                                              },
+                                              "source": {
+                                                "type": [
+                                                  "string",
+                                                  "null"
+                                                ],
+                                                "description": "The source the Revision originated from (for example `github`, `cli`, `archive`, `container`, `sbom`, or `binary`)"
+                                              },
+                                              "unresolved_issue_count": {
+                                                "type": [
+                                                  "number",
+                                                  "null"
+                                                ],
+                                                "description": "The number of unresolved issues found for this Revision"
+                                              },
+                                              "error": {
+                                                "type": [
+                                                  "string",
+                                                  "null"
+                                                ],
+                                                "description": "Error message during analysis (if any)"
+                                              },
+                                              "message": {
+                                                "type": [
+                                                  "string",
+                                                  "null"
+                                                ],
+                                                "description": "Message of the revision or commit"
+                                              },
+                                              "revision_timestamp": {
+                                                "type": [
+                                                  "string",
+                                                  "null"
+                                                ],
+                                                "description": "timestamp of when the Revision was published"
+                                              },
+                                              "latestRevisionScanId": {
+                                                "type": [
+                                                  "number",
+                                                  "null"
+                                                ],
+                                                "description": "The Revision Scan ID of the latest policy scan"
+                                              },
+                                              "latestHubbleAnalysisId": {
+                                                "type": [
+                                                  "number",
+                                                  "null"
+                                                ],
+                                                "description": "The Hubble Analysis ID of the latest analysis"
+                                              },
+                                              "createdAt": {
+                                                "type": "string",
+                                                "description": "when the Revision was added to the FOSSA Database"
+                                              },
+                                              "updatedAt": {
+                                                "type": "string",
+                                                "description": "when the Revision was last updated in the FOSSA Database"
+                                              }
+                                            }
+                                          }
+                                        }
                                       }
-                                    }
+                                    ]
                                   }
                                 }
-                              ]
-                            }
+                              }
+                            ]
                           }
                         }
                       }
-                    ]
-                  },
-                  "example": [
+                    }
+                  ]
+                },
+                "example": {
+                  "id": 1,
+                  "title": "1.0.0",
+                  "projectGroupId": 1,
+                  "dependency_count": 50,
+                  "license_count": 10,
+                  "unresolved_licensing_issue_count": 2,
+                  "unresolved_security_issue_count": 3,
+                  "unresolved_quality_issue_count": 1,
+                  "publishedOnPortal": "cyclonedx_json",
+                  "publishedAt": "2024-07-09T19:14:26Z",
+                  "reportPath": "/reports/1.0.0/sbom.cyclonedx.json",
+                  "publishedLicenses": [
+                    "MIT",
+                    "Apache-2.0"
+                  ],
+                  "projects": [
                     {
-                      "id": 1,
-                      "title": "My Release Group",
-                      "organizationId": 1000,
-                      "policyId": 1001,
-                      "securityPolicyId": 1002,
-                      "qualityPolicyId": 1003,
-                      "publicOnPortal": true,
-                      "customReportText": null,
-                      "createdAt": "2024-07-09T21:51:20.671Z",
-                      "updatedAt": "2024-07-09T21:51:20.671Z",
-                      "projects": [
-                        {
+                      "projectId": "custom+1/github.com/myorg/myrepo",
+                      "projectGroupReleaseId": 1,
+                      "branch": "main",
+                      "revisionId": "rev001",
+                      "createdAt": "2024-07-09T19:14:26Z",
+                      "updatedAt": "2024-07-09T19:14:26Z",
+                      "project": {
+                        "id": "123",
+                        "title": "Some Project",
+                        "description": "This is a project in my organization",
+                        "branch": "main",
+                        "type": "provided",
+                        "public": true,
+                        "scanned": "2024-07-09T19:14:26Z",
+                        "lastAnalyzed": "2024-07-09T19:14:26Z",
+                        "latestRevision": {
+                          "locator": "custom+1/github.com/myorg/myrepo$rev001",
+                          "resolve": true,
                           "projectId": "custom+1/github.com/myorg/myrepo",
-                          "projectGroupReleaseId": 1,
-                          "branch": "main",
-                          "revisionId": "rev001",
+                          "source_type": null,
+                          "error": null,
+                          "message": "fix(bug): Fixes some bug",
+                          "latestRevisionScanId": 123,
+                          "latestHubbleAnalysisId": null,
+                          "revision_timestamp": "2024-07-09T19:14:26Z",
                           "createdAt": "2024-07-09T19:14:26Z",
                           "updatedAt": "2024-07-09T19:14:26Z",
-                          "project": [
-                            {
-                              "id": "123",
-                              "title": "Some Project",
-                              "description": "This is a project in my organization",
-                              "branch": "main",
-                              "type": "provided",
-                              "public": true,
-                              "scanned": "2024-07-09T19:14:26Z",
-                              "lastAnalyzed": "2024-07-09T19:14:26Z",
-                              "latestRevision": {
-                                "locator": "custom+1/github.com/myorg/myrepo$rev001",
-                                "resolve": true,
-                                "projectId": "custom+1/github.com/myorg/myrepo",
-                                "source_type": null,
-                                "error": null,
-                                "message": "fix(bug): Fixes some bug",
-                                "latestRevisionScanId": 123,
-                                "latestHubbleAnalysisId": null,
-                                "revision_timestamp": "2024-07-09T19:14:26Z",
-                                "createdAt": "2024-07-09T19:14:26Z",
-                                "updatedAt": "2024-07-09T19:14:26Z",
-                                "author": "fossas",
-                                "link": null,
-                                "url": "https://github.com/myorg/myrepo"
-                              },
-                              "teams": [
-                                {
-                                  "id": 1,
-                                  "organizationId": 1,
-                                  "name": "Front-end Team",
-                                  "defaultRoleId": 2,
-                                  "autoAddusers": false,
-                                  "uniqueIdentifier": false,
-                                  "createdAt": "2024-06-09T19:14:26Z",
-                                  "updatedAt": "2024-06-09T19:14:26Z"
-                                },
-                                {
-                                  "id": 2,
-                                  "organizationId": 1,
-                                  "name": "Back-end Team",
-                                  "defaultRoleId": 3,
-                                  "autoAddusers": false,
-                                  "uniqueIdentifier": false,
-                                  "createdAt": "2024-06-09T19:15:26Z",
-                                  "updatedAt": "2024-06-09T19:15:26Z"
-                                }
-                              ]
-                            }
-                          ]
-                        }
-                      ]
+                          "author": "fossas",
+                          "link": null,
+                          "url": "https://github.com/myorg/myrepo"
+                        },
+                        "teams": [
+                          {
+                            "id": 1,
+                            "name": "Front-end Team",
+                            "uniqueId": null,
+                            "teamType": "team"
+                          },
+                          {
+                            "id": 2,
+                            "name": "Back-end Team",
+                            "uniqueId": null,
+                            "teamType": "team"
+                          }
+                        ]
+                      }
                     }
                   ]
                 }
@@ -31695,69 +36571,167 @@
         },
         "responses": {
           "200": {
-            "description": "The release group could not be found",
+            "description": "The updated release, including its projects",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "integer"
+                  "allOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "description": "Release ID"
+                        },
+                        "title": {
+                          "type": "string",
+                          "description": "Release title/version"
+                        },
+                        "projectGroupId": {
+                          "type": "integer",
+                          "description": "The release group which this belongs to"
+                        },
+                        "dependency_count": {
+                          "type": "integer",
+                          "description": "The count of dependencies in this release",
+                          "nullable": true
+                        },
+                        "license_count": {
+                          "type": "integer",
+                          "description": "The count of licenses in this release",
+                          "nullable": true
+                        },
+                        "unresolved_licensing_issue_count": {
+                          "type": "integer",
+                          "description": "The number of licensing issues in this release",
+                          "nullable": true
+                        },
+                        "unresolved_security_issue_count": {
+                          "type": "integer",
+                          "description": "The number of security issues in this release",
+                          "nullable": true
+                        },
+                        "unresolved_quality_issue_count": {
+                          "type": "integer",
+                          "description": "The number of quality issues in this release",
+                          "nullable": true
+                        },
+                        "publishedOnPortal": {
+                          "description": "If this release has been published on an SBOM portal",
+                          "type": "string",
+                          "enum": [
+                            "attribution_txt",
+                            "spdx_tagged",
+                            "cyclonedx_json",
+                            "spdx_json",
+                            "cyclonedx_xml",
+                            "pending"
+                          ],
+                          "nullable": true
+                        },
+                        "publishedAt": {
+                          "type": "string",
+                          "format": "date-time",
+                          "description": "When the release was published to the portal"
+                        },
+                        "reportPath": {
+                          "type": "string",
+                          "description": "Path to the SBOM report for this release",
+                          "nullable": true
+                        },
+                        "publishedLicenses": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "description": "List of published license IDs",
+                          "nullable": true
+                        }
+                      },
+                      "example": {
+                        "id": 1,
+                        "title": "1.0.0",
+                        "projectGroupId": 1,
+                        "dependency_count": 50,
+                        "license_count": 10,
+                        "unresolved_licensing_issue_count": 2,
+                        "unresolved_security_issue_count": 3,
+                        "unresolved_quality_issue_count": 1,
+                        "publishedOnPortal": "cyclonedx_json",
+                        "publishedAt": "2024-07-09T19:14:26Z",
+                        "reportPath": "/reports/1.0.0/sbom.cyclonedx.json",
+                        "publishedLicenses": [
+                          "MIT",
+                          "Apache-2.0"
+                        ]
+                      }
                     },
-                    "title": {
-                      "type": "string"
-                    },
-                    "organizationId": {
-                      "type": "integer"
-                    },
-                    "policyId": {
-                      "type": [
-                        "null",
-                        "integer"
-                      ]
-                    },
-                    "securityPolicyId": {
-                      "type": [
-                        "null",
-                        "integer"
-                      ]
-                    },
-                    "qualityPolicyId": {
-                      "type": [
-                        "null",
-                        "integer"
-                      ]
-                    },
-                    "publicOnPortal": {
-                      "type": "boolean"
-                    },
-                    "reportCustomText": {
-                      "type": [
-                        "null",
-                        "string"
-                      ]
-                    },
-                    "createdAt": {
-                      "type": "string",
-                      "format": "date-time"
-                    },
-                    "updatedAt": {
-                      "type": "string",
-                      "format": "date-time"
+                    {
+                      "type": "object",
+                      "properties": {
+                        "projects": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "projectId": {
+                                "type": "string"
+                              },
+                              "projectGroupReleaseId": {
+                                "type": "integer"
+                              },
+                              "branch": {
+                                "type": "string"
+                              },
+                              "revisionId": {
+                                "type": "string"
+                              },
+                              "createdAt": {
+                                "type": "string",
+                                "format": "date-time"
+                              },
+                              "updatedAt": {
+                                "type": "string",
+                                "format": "date-time"
+                              }
+                            },
+                            "example": {
+                              "projectId": "custom+1/github.com/myrepo",
+                              "projectGroupReleaseId": 1,
+                              "branch": "main",
+                              "revisionId": "rev001",
+                              "createdAt": "2024-07-09T19:14:26Z",
+                              "updatedAt": "2024-07-09T19:14:26Z"
+                            }
+                          }
+                        }
+                      }
                     }
-                  },
-                  "example": {
-                    "id": 1,
-                    "title": "My Release Group",
-                    "organizationId": 1000,
-                    "policyId": 1001,
-                    "securityPolicyId": 1002,
-                    "qualityPolicyId": null,
-                    "publicOnPortal": true,
-                    "customReportText": null,
-                    "createdAt": "2024-07-09T21:51:20.671Z",
-                    "updatedAt": "2024-07-09T21:51:20.671Z"
-                  }
+                  ]
+                },
+                "example": {
+                  "id": 1,
+                  "title": "2.0.0",
+                  "projectGroupId": 1,
+                  "dependency_count": null,
+                  "license_count": null,
+                  "unresolved_licensing_issue_count": null,
+                  "unresolved_security_issue_count": null,
+                  "unresolved_quality_issue_count": null,
+                  "publishedOnPortal": null,
+                  "publishedAt": null,
+                  "reportPath": null,
+                  "publishedLicenses": null,
+                  "projects": [
+                    {
+                      "projectId": "custom+1/org/project",
+                      "projectGroupReleaseId": 1,
+                      "branch": "main",
+                      "revisionId": "rev001",
+                      "createdAt": "2024-07-09T19:14:26Z",
+                      "updatedAt": "2024-07-09T19:14:26Z"
+                    }
+                  ]
                 }
               }
             }
@@ -31851,7 +36825,7 @@
             }
           },
           "403": {
-            "description": "The requesting user is not allowed to edit this release group",
+            "description": "The requesting user is not allowed to edit this release",
             "content": {
               "application/json": {
                 "schema": {
@@ -31882,7 +36856,7 @@
                 "example": {
                   "uuid": "00000000-0000-0000-0000-000000000000",
                   "code": 2005,
-                  "message": "You are not permitted to edit this release group.",
+                  "message": "You are not permitted to edit this release.",
                   "name": "ForbiddenError",
                   "httpStatusCode": 403
                 }
@@ -32127,6 +37101,20 @@
                             ],
                             "description": "FOSSA internal representation of the source language for the given repository/project"
                           },
+                          "source": {
+                            "type": [
+                              "string",
+                              "null"
+                            ],
+                            "description": "The source the Revision originated from (for example `github`, `cli`, `archive`, `container`, `sbom`, or `binary`)"
+                          },
+                          "unresolved_issue_count": {
+                            "type": [
+                              "number",
+                              "null"
+                            ],
+                            "description": "The number of unresolved issues found for this Revision"
+                          },
                           "error": {
                             "type": [
                               "string",
@@ -32169,27 +37157,6 @@
                           "updatedAt": {
                             "type": "string",
                             "description": "when the Revision was last updated in the FOSSA Database"
-                          },
-                          "author": {
-                            "type": [
-                              "string",
-                              "null"
-                            ],
-                            "description": "The author of the Revision"
-                          },
-                          "link": {
-                            "type": [
-                              "string",
-                              "null"
-                            ],
-                            "description": "The link associated with the Revision"
-                          },
-                          "url": {
-                            "type": [
-                              "string",
-                              "null"
-                            ],
-                            "description": "The url associated with the Revision"
                           }
                         }
                       },
@@ -32887,56 +37854,57 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "allOf": [
-                    {
-                      "type": "object",
-                      "properties": {
-                        "id": {
-                          "type": "integer",
-                          "example": 123
+                  "type": "array",
+                  "items": {
+                    "allOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "integer",
+                            "example": 123
+                          },
+                          "scanned_at": {
+                            "type": "string",
+                            "format": "date-time",
+                            "example": "2024-07-02T22:56:38.769Z"
+                          },
+                          "organizationId": {
+                            "type": "integer",
+                            "example": 1
+                          },
+                          "projectGroupReleaseId": {
+                            "type": "integer",
+                            "example": 123
+                          },
+                          "createdAt": {
+                            "type": "string",
+                            "format": "date-time",
+                            "example": "2024-07-02T22:56:38.769Z"
+                          },
+                          "updatedAt": {
+                            "type": "string",
+                            "format": "date-time",
+                            "example": "2024-07-02T22:56:38.769Z"
+                          }
                         },
-                        "scanned_at": {
-                          "type": "string",
-                          "format": "date-time",
-                          "example": "2024-07-02T22:56:38.769Z"
-                        },
-                        "organizationId": {
-                          "type": "integer",
-                          "example": 1
-                        },
-                        "projectGroupReleaseId": {
-                          "type": "integer",
-                          "example": 123
-                        },
-                        "createdAt": {
-                          "type": "string",
-                          "format": "date-time",
-                          "example": "2024-07-02T22:56:38.769Z"
-                        },
-                        "updatedAt": {
-                          "type": "string",
-                          "format": "date-time",
-                          "example": "2024-07-02T22:56:38.769Z"
+                        "example": {
+                          "value": {
+                            "id": 1,
+                            "scanned_at": "2024-07-09T19:14:26Z",
+                            "organizationId": 100,
+                            "projectGroupReleaseId": 200,
+                            "createdAt": "2024-07-09T18:14:26Z",
+                            "updatedAt": "2024-07-09T19:14:26Z"
+                          }
                         }
                       },
-                      "example": {
-                        "value": {
-                          "id": 1,
-                          "scanned_at": "2024-07-09T19:14:26Z",
-                          "organizationId": 100,
-                          "projectGroupReleaseId": 200,
-                          "createdAt": "2024-07-09T18:14:26Z",
-                          "updatedAt": "2024-07-09T19:14:26Z"
-                        }
-                      }
-                    },
-                    {
-                      "type": "object",
-                      "properties": {
-                        "revisionScans": {
-                          "type": "array",
-                          "items": [
-                            {
+                      {
+                        "type": "object",
+                        "properties": {
+                          "revisionScans": {
+                            "type": "array",
+                            "items": {
                               "type": "object",
                               "properties": {
                                 "id": {
@@ -32944,11 +37912,11 @@
                                 }
                               }
                             }
-                          ]
+                          }
                         }
                       }
-                    }
-                  ]
+                    ]
+                  }
                 },
                 "example": [
                   {
@@ -33162,6 +38130,530 @@
                       "message": "Release (id: 123) was not found",
                       "name": "NotFoundError",
                       "httpStatusCode": 404
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/project_group/{groupId}/release/{releaseId}/attribution/{format}": {
+      "get": {
+        "description": "Generate a release group release's attribution report (V2).\n\nBehavior depends on the query parameters:\n- When `preview` or `download` is set, the report is generated synchronously and streamed back.\n- Otherwise the report is queued as a background job and the response contains the `taskId`\n  to poll for completion (used for publishing and emailing).\n\n**Note:** Not all report options are valid for every report format. Use your release\ngroup's Reports UI to see which options apply to a given format.\n",
+        "operationId": "queueReleaseGroupAttributionReportV2",
+        "tags": [
+          "Release Groups"
+        ],
+        "security": [
+          {
+            "ApiToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "groupId",
+            "description": "The ID of the release group",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "releaseId",
+            "description": "The ID of the release within the release group",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "format",
+            "description": "The format of the report",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "HTML",
+                "MD",
+                "PDF",
+                "CSV",
+                "TXT",
+                "SPDX",
+                "SPDX_JSON",
+                "CYCLONEDX_JSON",
+                "CYCLONEDX_XML"
+              ]
+            }
+          },
+          {
+            "name": "preview",
+            "description": "Whether to preview the report inline rather than generate a downloadable file (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "download",
+            "description": "Whether to stream the report back directly for download (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "isPublishing",
+            "description": "Whether to publish the report to the SBOM portal. Requires portal-manage permission and an enabled SBOM portal.",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "projectGroupTitle",
+            "description": "Override for the release group title shown in the report.",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "projectGroupReleaseTitle",
+            "description": "Override for the release title shown in the report.",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "projectGroupUrl",
+            "description": "URL to embed in the release group report metadata.",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "uri"
+            }
+          },
+          {
+            "name": "dependencyInfoOptions[]",
+            "description": "Per-dependency columns/fields to include in the report.",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "Project",
+                  "Library",
+                  "Authors",
+                  "Description",
+                  "ConcludedLicense",
+                  "License",
+                  "CustomTextLicense",
+                  "FullTextLicense",
+                  "OtherLicenses",
+                  "FilePath",
+                  "Source",
+                  "ProjectUrl",
+                  "PackageDownloadUrl",
+                  "DependencyPaths",
+                  "IssueNotes",
+                  "Copyrights",
+                  "LicenseFileURL"
+                ]
+              }
+            }
+          },
+          {
+            "name": "includeDeepDependencies",
+            "description": "Whether to include deep dependencies (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeDirectDependencies",
+            "description": "Whether to include direct dependencies (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeFOSSADependencies",
+            "description": "Whether to include FOSSA-managed dependencies (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeLicenseList",
+            "description": "Whether to include the license list (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeLicenseScan",
+            "description": "Whether to include the first-party license scan (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeProjectLicense",
+            "description": "Whether to include the project's declared license (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeCopyrightList",
+            "description": "Whether to include the copyright list (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeFileMatches",
+            "description": "Whether to include license file matches (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeOpenVulnerabilities",
+            "description": "Whether to include open vulnerabilities (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeClosedVulnerabilities",
+            "description": "Whether to include closed vulnerabilities (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeDependencySummary",
+            "description": "Whether to include the dependency summary (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeLicenseHeaders",
+            "description": "Whether to include license headers (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includePackageLabels",
+            "description": "Whether to include the package labels assigned to each dependency (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "excludeUnknownDependencies",
+            "description": "Whether to exclude unknown (unresolved) dependencies from the report (default is false, meaning unknown dependencies are included)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "excludeFields",
+            "description": "Object controlling which dependencies are excluded from the report. The only supported\nnested field is `packageLabels`: a non-empty array of package-label values; dependencies\ncarrying any of these labels are excluded from the report.\n\nThe server parses the query string with the `qs` library, so the array is sent using\nbracket-and-index notation rather than standard OpenAPI `deepObject` serialization. For\nexample, to exclude two labels send (before URL-encoding):\n`excludeFields[packageLabels][0]=internal&excludeFields[packageLabels][1]=vendored`.\n",
+            "required": false,
+            "in": "query",
+            "style": "deepObject",
+            "explode": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "packageLabels": {
+                  "type": "array",
+                  "minItems": 1,
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "Package labels whose dependencies should be excluded from the report"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Either the streamed report (when `preview`/`download` is set) or, for a queued job,\nthe task identifier to poll for completion.\n",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "taskId"
+                  ],
+                  "properties": {
+                    "taskId": {
+                      "type": "string",
+                      "description": "The job token of the queued report-generation task"
+                    }
+                  }
+                }
+              },
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "BadRequest",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Bad API Token": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2010,
+                      "message": "API token is invalid",
+                      "name": "UnauthorizedError",
+                      "httpStatusCode": 401
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden \u2014 missing publish permission, or the SBOM portal is not enabled.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFound",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Not Found": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2004,
+                      "message": "Project not found: custom+1/example$abc123",
+                      "name": "NotFoundError",
+                      "httpStatusCode": 404
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Server Error": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2009,
+                      "message": "Sorry, we've encountered an unexpected error. We've recorded it. If you continue to see this, contact support at support@fossa.com and include the unique reference code: 00000000-0000-0000-0000-000000000000",
+                      "name": "InternalServerError",
+                      "httpStatusCode": 500
                     }
                   }
                 }
@@ -33628,6 +39120,7 @@
           }
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -33695,6 +39188,20 @@
                       ],
                       "description": "FOSSA internal representation of the source language for the given repository/project"
                     },
+                    "source": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "The source the Revision originated from (for example `github`, `cli`, `archive`, `container`, `sbom`, or `binary`)"
+                    },
+                    "unresolved_issue_count": {
+                      "type": [
+                        "number",
+                        "null"
+                      ],
+                      "description": "The number of unresolved issues found for this Revision"
+                    },
                     "error": {
                       "type": [
                         "string",
@@ -33737,27 +39244,49 @@
                     "updatedAt": {
                       "type": "string",
                       "description": "when the Revision was last updated in the FOSSA Database"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "BadRequest \u2014 returned when no request body is provided.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
                     },
-                    "author": {
-                      "type": [
-                        "string",
-                        "null"
-                      ],
-                      "description": "The author of the Revision"
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
                     },
-                    "link": {
-                      "type": [
-                        "string",
-                        "null"
-                      ],
-                      "description": "The link associated with the Revision"
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
                     },
-                    "url": {
-                      "type": [
-                        "string",
-                        "null"
-                      ],
-                      "description": "The url associated with the Revision"
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "No request body": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2000,
+                      "message": "No request body provided to endpoint",
+                      "name": "MalformedPayloadError",
+                      "httpStatusCode": 400
                     }
                   }
                 }
@@ -34018,15 +39547,23 @@
             }
           },
           {
-            "name": "excludePackageLabels",
-            "description": "Exclude dependencies with particular package labels from the report",
+            "name": "excludeFields",
+            "description": "Object controlling which dependencies are excluded from the report. The only supported\nnested field is `packageLabels`: a non-empty array of package-label values; dependencies\ncarrying any of these labels are excluded from the report.\n",
             "required": false,
             "in": "query",
+            "style": "deepObject",
+            "explode": true,
             "schema": {
-              "type": "array",
-              "items": {
-                "type": "string",
-                "description": "Set of labels to apply to a project"
+              "type": "object",
+              "properties": {
+                "packageLabels": {
+                  "type": "array",
+                  "minItems": 1,
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "Package labels whose dependencies should be excluded from the report"
+                }
               }
             }
           }
@@ -34340,7 +39877,7 @@
     },
     "/revisions/{locator}/attribution/json": {
       "get": {
-        "description": "Return a JSON report of a revision's attribution",
+        "description": "Return a JSON report of a revision's attribution.\n\n**Requires a Premium subscription.** Organizations below the Premium access level receive a `403`.\n",
         "operationId": "getRevisionAttributionJSON",
         "tags": [
           "Revisions"
@@ -34442,14 +39979,23 @@
             }
           },
           {
-            "name": "excludePackageLabels",
-            "description": "Exclude dependencies with particular package labels from the report",
+            "name": "excludeFields",
+            "description": "Object controlling which dependencies are excluded from the report. The only supported\nnested field is `packageLabels`: a non-empty array of package-label values; dependencies\ncarrying any of these labels are excluded from the report.\n\nThe server parses the query string with the `qs` library, so the array is sent using\nbracket-and-index notation rather than standard OpenAPI `deepObject` serialization. For\nexample, to exclude two labels send (before URL-encoding):\n`excludeFields[packageLabels][0]=internal&excludeFields[packageLabels][1]=vendored`.\n",
             "required": false,
             "in": "query",
+            "style": "deepObject",
+            "explode": true,
             "schema": {
-              "type": "array",
-              "items": {
-                "type": "string"
+              "type": "object",
+              "properties": {
+                "packageLabels": {
+                  "type": "array",
+                  "minItems": 1,
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "Package labels whose dependencies should be excluded from the report"
+                }
               }
             }
           }
@@ -34587,6 +40133,10 @@
                                 },
                                 "revisionId": {
                                   "description": "The revision ID of the notice match",
+                                  "type": "string"
+                                },
+                                "path": {
+                                  "description": "The file path of the notice match",
                                   "type": "string"
                                 },
                                 "contents": {
@@ -34745,6 +40295,10 @@
                                   "description": "The revision ID of the notice match",
                                   "type": "string"
                                 },
+                                "path": {
+                                  "description": "The file path of the notice match",
+                                  "type": "string"
+                                },
                                 "contents": {
                                   "description": "The contents of the notice match",
                                   "type": "string"
@@ -34808,6 +40362,10 @@
                           },
                           "revisionId": {
                             "description": "The revision ID of the notice match",
+                            "type": "string"
+                          },
+                          "path": {
+                            "description": "The file path of the notice match",
                             "type": "string"
                           },
                           "contents": {
@@ -35020,6 +40578,49 @@
               }
             }
           },
+          "403": {
+            "description": "Forbidden \u2014 requires a premium subscription.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Insufficient subscription": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2005,
+                      "message": "User not permissioned for feature. Feature requires \"premium\" subscription access level.",
+                      "name": "ForbiddenError",
+                      "httpStatusCode": 403
+                    }
+                  }
+                }
+              }
+            }
+          },
           "404": {
             "description": "Not Found",
             "content": {
@@ -35052,6 +40653,3204 @@
                 "examples": {
                   "No Revisions found": {
                     "value": "Not Found"
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Server Error": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2009,
+                      "message": "Sorry, we've encountered an unexpected error. We've recorded it. If you continue to see this, contact support at support@fossa.com and include the unique reference code: 00000000-0000-0000-0000-000000000000",
+                      "name": "InternalServerError",
+                      "httpStatusCode": 500
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/revisions/{locator}/attribution/json": {
+      "get": {
+        "description": "Return a JSON report of a revision's attribution (V2).\n\n**Requires a Premium subscription.** Organizations below the Premium access level receive a `403`.\n",
+        "operationId": "getRevisionAttributionJSONV2",
+        "tags": [
+          "Revisions"
+        ],
+        "security": [
+          {
+            "ApiToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "locator",
+            "description": "The URL-encoded locator of the revision",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "preview",
+            "description": "Whether to preview the report inline rather than generate a downloadable file (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeDeepDependencies",
+            "description": "Whether to include deep dependencies (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeHashAndVersionData",
+            "description": "Whether to include hash and version data (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "excludeUnknownDependencies",
+            "description": "Whether to exclude unknown (unresolved) dependencies from the report (default is false, meaning unknown dependencies are included)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeCopyrightList",
+            "description": "Whether to include the copyright list (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeFileMatches",
+            "description": "Whether to include license file matches (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeOpenVulnerabilities",
+            "description": "Whether to include open vulnerabilities (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeClosedVulnerabilities",
+            "description": "Whether to include closed vulnerabilities (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeNoticeFiles",
+            "description": "Whether to include the notice file match data (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includePackageLabels",
+            "description": "Whether to include the package labels assigned to each dependency (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "excludeFields",
+            "description": "Object controlling which dependencies are excluded from the report. The only supported\nnested field is `packageLabels`: a non-empty array of package-label values; dependencies\ncarrying any of these labels are excluded from the report.\n\nThe server parses the query string with the `qs` library, so the array is sent using\nbracket-and-index notation rather than standard OpenAPI `deepObject` serialization. For\nexample, to exclude two labels send (before URL-encoding):\n`excludeFields[packageLabels][0]=internal&excludeFields[packageLabels][1]=vendored`.\n",
+            "required": false,
+            "in": "query",
+            "style": "deepObject",
+            "explode": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "packageLabels": {
+                  "type": "array",
+                  "minItems": 1,
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "Package labels whose dependencies should be excluded from the report"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A JSON report of the revision's attribution",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "project": {
+                      "type": "object",
+                      "description": "Project information",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "description": "The name of the project"
+                        },
+                        "revision": {
+                          "type": "string",
+                          "description": "The revision of the project"
+                        }
+                      }
+                    },
+                    "directDependencies": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "package": {
+                            "description": "The package name",
+                            "type": "string"
+                          },
+                          "source": {
+                            "description": "The source of the package",
+                            "type": "string"
+                          },
+                          "version": {
+                            "description": "The version of the package",
+                            "type": "string"
+                          },
+                          "hash": {
+                            "description": "The hash of the package",
+                            "type": "string"
+                          },
+                          "authors": {
+                            "description": "The authors of the package",
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "description": {
+                            "description": "The description of the package",
+                            "type": "string"
+                          },
+                          "licenses": {
+                            "description": "The licenses of the package",
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "description": "The name of the license",
+                                  "type": "string"
+                                },
+                                "attribution": {
+                                  "description": "The attribution of the license",
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          },
+                          "otherLicenses": {
+                            "description": "The other licenses of the package",
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "description": "The name of the license",
+                                  "type": "string"
+                                },
+                                "attribution": {
+                                  "description": "The attribution of the license",
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          },
+                          "projectUrl": {
+                            "description": "The project URL",
+                            "type": "string"
+                          },
+                          "dependencyPaths": {
+                            "description": "The dependency paths",
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "notes": {
+                            "description": "The notes of the package",
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "downloadUrl": {
+                            "required": false,
+                            "description": "The download URL",
+                            "type": "string"
+                          },
+                          "isGolang": {
+                            "required": false,
+                            "description": "Whether the package is Golang",
+                            "type": "boolean"
+                          },
+                          "title": {
+                            "description": "The title of the package",
+                            "type": "string"
+                          },
+                          "noticeFiles": {
+                            "required": false,
+                            "description": "The notice file matches of the package",
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "description": "The ID of the notice match",
+                                  "type": "integer"
+                                },
+                                "revisionId": {
+                                  "description": "The revision ID of the notice match",
+                                  "type": "string"
+                                },
+                                "path": {
+                                  "description": "The file path of the notice match",
+                                  "type": "string"
+                                },
+                                "contents": {
+                                  "description": "The contents of the notice match",
+                                  "type": "string"
+                                },
+                                "copyrights": {
+                                  "description": "The copyrights of the notice match",
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                },
+                                "createdAt": {
+                                  "description": "The creation date of the notice match",
+                                  "type": "string",
+                                  "format": "date-time"
+                                },
+                                "updatedAt": {
+                                  "description": "The update date of the notice match",
+                                  "type": "string",
+                                  "format": "date-time"
+                                },
+                                "corrected": {
+                                  "description": "Whether the notice match has been manually corrected",
+                                  "type": "boolean"
+                                },
+                                "ignored": {
+                                  "description": "Whether the notice match has been manually ignored",
+                                  "type": "boolean"
+                                }
+                              }
+                            }
+                          },
+                          "packageLabels": {
+                            "required": false,
+                            "description": "All applicable package labels assigned to the package, including globally applied labels, project applied labels, and revision applied labels that match this package in this revision.",
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "deepDependencies": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "package": {
+                            "description": "The package name",
+                            "type": "string"
+                          },
+                          "source": {
+                            "description": "The source of the package",
+                            "type": "string"
+                          },
+                          "version": {
+                            "description": "The version of the package",
+                            "type": "string"
+                          },
+                          "hash": {
+                            "description": "The hash of the package",
+                            "type": "string"
+                          },
+                          "authors": {
+                            "description": "The authors of the package",
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "description": {
+                            "description": "The description of the package",
+                            "type": "string"
+                          },
+                          "licenses": {
+                            "description": "The licenses of the package",
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "description": "The name of the license",
+                                  "type": "string"
+                                },
+                                "attribution": {
+                                  "description": "The attribution of the license",
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          },
+                          "otherLicenses": {
+                            "description": "The other licenses of the package",
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "description": "The name of the license",
+                                  "type": "string"
+                                },
+                                "attribution": {
+                                  "description": "The attribution of the license",
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          },
+                          "projectUrl": {
+                            "description": "The project URL",
+                            "type": "string"
+                          },
+                          "dependencyPaths": {
+                            "description": "The dependency paths",
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "notes": {
+                            "description": "The notes of the package",
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "downloadUrl": {
+                            "required": false,
+                            "description": "The download URL",
+                            "type": "string"
+                          },
+                          "isGolang": {
+                            "required": false,
+                            "description": "Whether the package is Golang",
+                            "type": "boolean"
+                          },
+                          "title": {
+                            "description": "The title of the package",
+                            "type": "string"
+                          },
+                          "noticeFiles": {
+                            "required": false,
+                            "description": "The notice file matches of the package",
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "description": "The ID of the notice match",
+                                  "type": "integer"
+                                },
+                                "revisionId": {
+                                  "description": "The revision ID of the notice match",
+                                  "type": "string"
+                                },
+                                "path": {
+                                  "description": "The file path of the notice match",
+                                  "type": "string"
+                                },
+                                "contents": {
+                                  "description": "The contents of the notice match",
+                                  "type": "string"
+                                },
+                                "copyrights": {
+                                  "description": "The copyrights of the notice match",
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                },
+                                "createdAt": {
+                                  "description": "The creation date of the notice match",
+                                  "type": "string",
+                                  "format": "date-time"
+                                },
+                                "updatedAt": {
+                                  "description": "The update date of the notice match",
+                                  "type": "string",
+                                  "format": "date-time"
+                                },
+                                "corrected": {
+                                  "description": "Whether the notice match has been manually corrected",
+                                  "type": "boolean"
+                                },
+                                "ignored": {
+                                  "description": "Whether the notice match has been manually ignored",
+                                  "type": "boolean"
+                                }
+                              }
+                            }
+                          },
+                          "packageLabels": {
+                            "required": false,
+                            "description": "All applicable package labels assigned to the package, including globally applied labels, project applied labels, and revision applied labels that match this package in this revision.",
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "licenses": {
+                      "description": "A record of license names to their text",
+                      "type": "object"
+                    },
+                    "copyrightsByLicense": {
+                      "description": "A record of license names to their copyrights",
+                      "type": "object"
+                    },
+                    "noticeFiles": {
+                      "description": "A list of notice file matches",
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "description": "The ID of the notice match",
+                            "type": "integer"
+                          },
+                          "revisionId": {
+                            "description": "The revision ID of the notice match",
+                            "type": "string"
+                          },
+                          "path": {
+                            "description": "The file path of the notice match",
+                            "type": "string"
+                          },
+                          "contents": {
+                            "description": "The contents of the notice match",
+                            "type": "string"
+                          },
+                          "copyrights": {
+                            "description": "The copyrights of the notice match",
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "createdAt": {
+                            "description": "The creation date of the notice match",
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "updatedAt": {
+                            "description": "The update date of the notice match",
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "corrected": {
+                            "description": "Whether the notice match has been manually corrected",
+                            "type": "boolean"
+                          },
+                          "ignored": {
+                            "description": "Whether the notice match has been manually ignored",
+                            "type": "boolean"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "examples": {
+                  "Report": {
+                    "value": {
+                      "project": {
+                        "name": "My Project",
+                        "revision": "1.0.0"
+                      },
+                      "directDependencies": [
+                        {
+                          "package": "My Package",
+                          "source": "My Source",
+                          "version": "1.0.0",
+                          "hash": "1234",
+                          "authors": [
+                            "Author 1",
+                            "Author 2"
+                          ],
+                          "description": "My Description",
+                          "licenses": [
+                            {
+                              "name": "MIT",
+                              "attribution": "Attribution..."
+                            }
+                          ],
+                          "otherLicenses": [
+                            {
+                              "name": "My Other License",
+                              "attribution": "My Other Attribution"
+                            }
+                          ],
+                          "projectUrl": "http://example.com",
+                          "dependencyPaths": [
+                            "1"
+                          ],
+                          "notes": [
+                            "My Note"
+                          ],
+                          "downloadUrl": "http://example.com",
+                          "isGolang": false,
+                          "title": "My Title",
+                          "noticeFiles": [],
+                          "packageLabels": [
+                            "globally applied label",
+                            "project applied label",
+                            "revision applied label",
+                            "my custom label"
+                          ]
+                        }
+                      ],
+                      "deepDependencies": [
+                        {
+                          "package": "My Package",
+                          "source": "My Source",
+                          "version": "1.0.0",
+                          "hash": "1234",
+                          "authors": [
+                            "Author 1",
+                            "Author 2"
+                          ],
+                          "description": "My Description",
+                          "licenses": [
+                            {
+                              "name": "MIT",
+                              "attribution": "Attribution..."
+                            }
+                          ],
+                          "otherLicenses": [
+                            {
+                              "name": "My Other License",
+                              "attribution": "My Other Attribution"
+                            }
+                          ],
+                          "projectUrl": "http://example.com",
+                          "dependencyPaths": [
+                            "1"
+                          ],
+                          "notes": [
+                            "My Note"
+                          ],
+                          "downloadUrl": "http://example.com",
+                          "isGolang": false,
+                          "title": "My Title",
+                          "noticeFiles": [
+                            {
+                              "value": {
+                                "id": 1,
+                                "revisionId": "archive+1/NoticeFileTester$1.0",
+                                "path": "vendored/notice-file-tester/NOTICE.txt",
+                                "contents": "Apache Commons Lang\nCopyright 2001-2017 The Apache Software Foundation\n\nThis product includes software developed at\nThe Apache Software Foundation (http://www.apache.org/).\n\nThis product includes software from the Spring Framework,\nunder the Apache License 2.0 (see: StringUtils.containsWhitespace())\n",
+                                "copyrights": [
+                                  "2001-2017 The Apache Software Foundation"
+                                ],
+                                "createdAt": "2024-10-04T15:56:37.579Z",
+                                "updatedAt": "2024-10-04T15:56:37.579Z",
+                                "corrected": false,
+                                "ignored": false
+                              }
+                            }
+                          ],
+                          "packageLabels": [
+                            "dev-dependency-label"
+                          ]
+                        }
+                      ],
+                      "licenses": {
+                        "MIT": "MIT License"
+                      },
+                      "copyrightsByLicense": {
+                        "MIT": "Copyright 2020"
+                      },
+                      "noticeFiles": [
+                        {
+                          "value": {
+                            "id": 1,
+                            "revisionId": "archive+1/NoticeFileTester$1.0",
+                            "path": "vendored/notice-file-tester/NOTICE.txt",
+                            "contents": "Apache Commons Lang\nCopyright 2001-2017 The Apache Software Foundation\n\nThis product includes software developed at\nThe Apache Software Foundation (http://www.apache.org/).\n\nThis product includes software from the Spring Framework,\nunder the Apache License 2.0 (see: StringUtils.containsWhitespace())\n",
+                            "copyrights": [
+                              "2001-2017 The Apache Software Foundation"
+                            ],
+                            "createdAt": "2024-10-04T15:56:37.579Z",
+                            "updatedAt": "2024-10-04T15:56:37.579Z",
+                            "corrected": false,
+                            "ignored": false
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Bad API Token": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2010,
+                      "message": "API token is invalid",
+                      "name": "UnauthorizedError",
+                      "httpStatusCode": 401
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden \u2014 requires a premium subscription.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Insufficient subscription": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2005,
+                      "message": "User not permissioned for feature. Feature requires \"premium\" subscription access level.",
+                      "name": "ForbiddenError",
+                      "httpStatusCode": 403
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFound",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Not Found": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2004,
+                      "message": "Project not found: custom+1/example$abc123",
+                      "name": "NotFoundError",
+                      "httpStatusCode": 404
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Server Error": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2009,
+                      "message": "Sorry, we've encountered an unexpected error. We've recorded it. If you continue to see this, contact support at support@fossa.com and include the unique reference code: 00000000-0000-0000-0000-000000000000",
+                      "name": "InternalServerError",
+                      "httpStatusCode": 500
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/revisions/{locator}/attribution/email": {
+      "get": {
+        "description": "Queue a job to generate and email a revision's attribution report (V2).\n\n**Note:** Not all report options are valid for every report format. Use your project's\nReports UI to see which options apply to a given format.\n",
+        "operationId": "getRevisionAttributionEmailV2",
+        "tags": [
+          "Revisions"
+        ],
+        "security": [
+          {
+            "ApiToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "locator",
+            "description": "The URL-encoded locator of the revision",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "access",
+            "description": "The public BOM access ID. When provided, the report is generated for the public BOM associated with this ID.",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "preview",
+            "description": "Whether to preview the report inline rather than generate a downloadable file (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "format",
+            "description": "The format of the report",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "HTML",
+                "MD",
+                "PDF",
+                "CSV",
+                "TXT",
+                "SPDX",
+                "SPDX_JSON",
+                "CYCLONEDX_JSON",
+                "CYCLONEDX_XML"
+              ]
+            }
+          },
+          {
+            "name": "includeDeepDependencies",
+            "description": "Whether to include deep dependencies (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeDirectDependencies",
+            "description": "Whether to include direct dependencies (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeLicenseList",
+            "description": "Whether to include the license list (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeLicenseScan",
+            "description": "Whether to include the first-party license scan (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeProjectLicense",
+            "description": "Whether to include the project's declared license (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeCopyrightList",
+            "description": "Whether to include the copyright list (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeFileMatches",
+            "description": "Whether to include license file matches (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeOpenVulnerabilities",
+            "description": "Whether to include open vulnerabilities (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeClosedVulnerabilities",
+            "description": "Whether to include closed vulnerabilities (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeDependencySummary",
+            "description": "Whether to include the dependency summary (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeLicenseHeaders",
+            "description": "Whether to include license headers (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includePackageLabels",
+            "description": "Whether to include the package labels assigned to each dependency (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "excludeUnknownDependencies",
+            "description": "Whether to exclude unknown (unresolved) dependencies from the report (default is false, meaning unknown dependencies are included)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "excludeFields",
+            "description": "Object controlling which dependencies are excluded from the report. The only supported\nnested field is `packageLabels`: a non-empty array of package-label values; dependencies\ncarrying any of these labels are excluded from the report.\n\nThe server parses the query string with the `qs` library, so the array is sent using\nbracket-and-index notation rather than standard OpenAPI `deepObject` serialization. For\nexample, to exclude two labels send (before URL-encoding):\n`excludeFields[packageLabels][0]=internal&excludeFields[packageLabels][1]=vendored`.\n",
+            "required": false,
+            "in": "query",
+            "style": "deepObject",
+            "explode": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "packageLabels": {
+                  "type": "array",
+                  "minItems": 1,
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "Package labels whose dependencies should be excluded from the report"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The queued background task that will generate and send the report",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Metadata describing a background task that has been queued for processing.",
+                  "properties": {
+                    "id": {
+                      "type": "integer",
+                      "description": "Unique identifier for the task"
+                    },
+                    "task": {
+                      "type": "string",
+                      "description": "Name of the task being run"
+                    },
+                    "jobToken": {
+                      "type": "string",
+                      "description": "Token used to poll for the task's status and result"
+                    },
+                    "status": {
+                      "type": "string",
+                      "description": "Current status of the task",
+                      "enum": [
+                        "CREATED",
+                        "ASSIGNED",
+                        "RUNNING",
+                        "SUCCEEDED",
+                        "FAILED"
+                      ]
+                    },
+                    "attempt_number": {
+                      "type": "integer",
+                      "description": "Number of times the task has been attempted"
+                    },
+                    "maxRetries": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ],
+                      "description": "Maximum number of retries permitted for the task"
+                    },
+                    "started": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "format": "date-time",
+                      "description": "When the task started running, or null if it has not started"
+                    },
+                    "finished": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "format": "date-time",
+                      "description": "When the task finished, or null if it has not finished"
+                    },
+                    "scheduledStartTime": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "format": "date-time",
+                      "description": "When the task is scheduled to start, or null"
+                    },
+                    "pod": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Identifier of the pod running the task, or null"
+                    },
+                    "context": {
+                      "type": "object",
+                      "description": "Task-specific context payload",
+                      "additionalProperties": true
+                    },
+                    "createdAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "description": "When the task record was created"
+                    },
+                    "updatedAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "description": "When the task record was last updated"
+                    }
+                  }
+                },
+                "examples": {
+                  "Job": {
+                    "value": {
+                      "status": "CREATED",
+                      "jobToken": "00000000-0000-0000-0000-000000000000",
+                      "id": 12345,
+                      "task": "GenerateRevisionReport",
+                      "maxRetries": 10,
+                      "attempt_number": 1
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Bad API Token": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2010,
+                      "message": "API token is invalid",
+                      "name": "UnauthorizedError",
+                      "httpStatusCode": 401
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFound",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Not Found": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2004,
+                      "message": "Project not found: custom+1/example$abc123",
+                      "name": "NotFoundError",
+                      "httpStatusCode": 404
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Server Error": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2009,
+                      "message": "Sorry, we've encountered an unexpected error. We've recorded it. If you continue to see this, contact support at support@fossa.com and include the unique reference code: 00000000-0000-0000-0000-000000000000",
+                      "name": "InternalServerError",
+                      "httpStatusCode": 500
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/revisions/{locator}/attribution/preview": {
+      "get": {
+        "description": "Generate and return an inline preview of a revision's attribution report (V2).\n\n**Note:** Not all report options are valid for every report format. Use your project's\nReports UI to see which options apply to a given format.\n",
+        "operationId": "getRevisionAttributionPreviewV2",
+        "tags": [
+          "Revisions"
+        ],
+        "security": [
+          {
+            "ApiToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "locator",
+            "description": "The URL-encoded locator of the revision",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "format",
+            "description": "The format of the report",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "HTML",
+                "MD",
+                "PDF",
+                "CSV",
+                "TXT",
+                "SPDX",
+                "SPDX_JSON",
+                "CYCLONEDX_JSON",
+                "CYCLONEDX_XML"
+              ]
+            }
+          },
+          {
+            "name": "access",
+            "description": "The public BOM access ID. When provided, the report is generated for the public BOM associated with this ID.",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "preview",
+            "description": "Whether to preview the report inline rather than generate a downloadable file (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeDeepDependencies",
+            "description": "Whether to include deep dependencies (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeDirectDependencies",
+            "description": "Whether to include direct dependencies (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeLicenseList",
+            "description": "Whether to include the license list (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeLicenseScan",
+            "description": "Whether to include the first-party license scan (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeProjectLicense",
+            "description": "Whether to include the project's declared license (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeCopyrightList",
+            "description": "Whether to include the copyright list (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeFileMatches",
+            "description": "Whether to include license file matches (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeOpenVulnerabilities",
+            "description": "Whether to include open vulnerabilities (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeClosedVulnerabilities",
+            "description": "Whether to include closed vulnerabilities (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeDependencySummary",
+            "description": "Whether to include the dependency summary (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeLicenseHeaders",
+            "description": "Whether to include license headers (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includePackageLabels",
+            "description": "Whether to include the package labels assigned to each dependency (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeHashAndVersionData",
+            "description": "Whether to include hash and version data (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "excludeUnknownDependencies",
+            "description": "Whether to exclude unknown (unresolved) dependencies from the report (default is false, meaning unknown dependencies are included)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "excludeFields",
+            "description": "Object controlling which dependencies are excluded from the report. The only supported\nnested field is `packageLabels`: a non-empty array of package-label values; dependencies\ncarrying any of these labels are excluded from the report.\n\nThe server parses the query string with the `qs` library, so the array is sent using\nbracket-and-index notation rather than standard OpenAPI `deepObject` serialization. For\nexample, to exclude two labels send (before URL-encoding):\n`excludeFields[packageLabels][0]=internal&excludeFields[packageLabels][1]=vendored`.\n",
+            "required": false,
+            "in": "query",
+            "style": "deepObject",
+            "explode": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "packageLabels": {
+                  "type": "array",
+                  "minItems": 1,
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "Package labels whose dependencies should be excluded from the report"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The rendered report preview. The `Content-Type` varies by the requested `format`\n(e.g. `text/html` for HTML, `application/json` for JSON-based formats).\n",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Bad API Token": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2010,
+                      "message": "API token is invalid",
+                      "name": "UnauthorizedError",
+                      "httpStatusCode": 401
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFound",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Not Found": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2004,
+                      "message": "Project not found: custom+1/example$abc123",
+                      "name": "NotFoundError",
+                      "httpStatusCode": 404
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Server Error": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2009,
+                      "message": "Sorry, we've encountered an unexpected error. We've recorded it. If you continue to see this, contact support at support@fossa.com and include the unique reference code: 00000000-0000-0000-0000-000000000000",
+                      "name": "InternalServerError",
+                      "httpStatusCode": 500
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/revisions/{locator}/attribution/download": {
+      "get": {
+        "description": "Generate and stream a revision's attribution report as a downloadable file (V2).\n\n**Note:** Not all report options are valid for every report format. Use your project's\nReports UI to see which options apply to a given format.\n",
+        "operationId": "getRevisionAttributionDownloadV2",
+        "tags": [
+          "Revisions"
+        ],
+        "security": [
+          {
+            "ApiToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "locator",
+            "description": "The URL-encoded locator of the revision",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "format",
+            "description": "The format of the report",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "HTML",
+                "MD",
+                "PDF",
+                "CSV",
+                "TXT",
+                "SPDX",
+                "SPDX_JSON",
+                "CYCLONEDX_JSON",
+                "CYCLONEDX_XML"
+              ]
+            }
+          },
+          {
+            "name": "access",
+            "description": "The public BOM access ID. When provided, the report is generated for the public BOM associated with this ID.",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "includeDeepDependencies",
+            "description": "Whether to include deep dependencies (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeDirectDependencies",
+            "description": "Whether to include direct dependencies (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeLicenseList",
+            "description": "Whether to include the license list (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeLicenseScan",
+            "description": "Whether to include the first-party license scan (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeProjectLicense",
+            "description": "Whether to include the project's declared license (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeCopyrightList",
+            "description": "Whether to include the copyright list (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeFileMatches",
+            "description": "Whether to include license file matches (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeOpenVulnerabilities",
+            "description": "Whether to include open vulnerabilities (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeClosedVulnerabilities",
+            "description": "Whether to include closed vulnerabilities (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeDependencySummary",
+            "description": "Whether to include the dependency summary (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeLicenseHeaders",
+            "description": "Whether to include license headers (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includePackageLabels",
+            "description": "Whether to include the package labels assigned to each dependency (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeHashAndVersionData",
+            "description": "Whether to include hash and version data (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "excludeUnknownDependencies",
+            "description": "Whether to exclude unknown (unresolved) dependencies from the report (default is false, meaning unknown dependencies are included)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "excludeFields",
+            "description": "Object controlling which dependencies are excluded from the report. The only supported\nnested field is `packageLabels`: a non-empty array of package-label values; dependencies\ncarrying any of these labels are excluded from the report.\n\nThe server parses the query string with the `qs` library, so the array is sent using\nbracket-and-index notation rather than standard OpenAPI `deepObject` serialization. For\nexample, to exclude two labels send (before URL-encoding):\n`excludeFields[packageLabels][0]=internal&excludeFields[packageLabels][1]=vendored`.\n",
+            "required": false,
+            "in": "query",
+            "style": "deepObject",
+            "explode": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "packageLabels": {
+                  "type": "array",
+                  "minItems": 1,
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "Package labels whose dependencies should be excluded from the report"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The generated report, streamed as a file. The response sets\n`Content-Disposition: inline` and a `Content-Type` matching the requested `format`.\n",
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Bad Request": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2003,
+                      "message": "Invalid request",
+                      "name": "BadRequestError",
+                      "httpStatusCode": 400
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Bad API Token": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2010,
+                      "message": "API token is invalid",
+                      "name": "UnauthorizedError",
+                      "httpStatusCode": 401
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFound",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Not Found": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2004,
+                      "message": "Project not found: custom+1/example$abc123",
+                      "name": "NotFoundError",
+                      "httpStatusCode": 404
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Server Error": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2009,
+                      "message": "Sorry, we've encountered an unexpected error. We've recorded it. If you continue to see this, contact support at support@fossa.com and include the unique reference code: 00000000-0000-0000-0000-000000000000",
+                      "name": "InternalServerError",
+                      "httpStatusCode": 500
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/revisions/{locator}/attribution/full/{format}": {
+      "get": {
+        "description": "Generate and stream a revision's attribution report in the given format with **all**\nreport options enabled (V2). Intended for the `fossa report attribution` CLI flow.\n",
+        "operationId": "getRevisionAttributionFullV2",
+        "tags": [
+          "Revisions"
+        ],
+        "security": [
+          {
+            "ApiToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "locator",
+            "description": "The URL-encoded locator of the revision",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "format",
+            "description": "The format of the report",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "HTML",
+                "MD",
+                "PDF",
+                "CSV",
+                "TXT",
+                "SPDX",
+                "SPDX_JSON",
+                "CYCLONEDX_JSON",
+                "CYCLONEDX_XML"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The generated full report, streamed as a file. The response sets\n`Content-Disposition: inline` and a `Content-Type` matching the path `format`.\n",
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Bad Request": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2003,
+                      "message": "Invalid request",
+                      "name": "BadRequestError",
+                      "httpStatusCode": 400
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Bad API Token": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2010,
+                      "message": "API token is invalid",
+                      "name": "UnauthorizedError",
+                      "httpStatusCode": 401
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFound",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Not Found": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2004,
+                      "message": "Project not found: custom+1/example$abc123",
+                      "name": "NotFoundError",
+                      "httpStatusCode": 404
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Server Error": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2009,
+                      "message": "Sorry, we've encountered an unexpected error. We've recorded it. If you continue to see this, contact support at support@fossa.com and include the unique reference code: 00000000-0000-0000-0000-000000000000",
+                      "name": "InternalServerError",
+                      "httpStatusCode": 500
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/revisions/{locator}/attribution": {
+      "get": {
+        "description": "Generate and stream a revision's attribution report (V2). This is the catch-all report\nendpoint; the report `format` and contents are controlled via query parameters.\n\n**Note:** Not all report options are valid for every report format. Use your project's\nReports UI to see which options apply to a given format.\n",
+        "operationId": "getRevisionAttributionV2",
+        "tags": [
+          "Revisions"
+        ],
+        "security": [
+          {
+            "ApiToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "locator",
+            "description": "The URL-encoded locator of the revision",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "format",
+            "description": "The format of the report",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "HTML",
+                "MD",
+                "PDF",
+                "CSV",
+                "TXT",
+                "SPDX",
+                "SPDX_JSON",
+                "CYCLONEDX_JSON",
+                "CYCLONEDX_XML"
+              ]
+            }
+          },
+          {
+            "name": "access",
+            "description": "The public BOM access ID. When provided, the report is generated for the public BOM associated with this ID.",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "includeDeepDependencies",
+            "description": "Whether to include deep dependencies (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeDirectDependencies",
+            "description": "Whether to include direct dependencies (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeLicenseList",
+            "description": "Whether to include the license list (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeLicenseScan",
+            "description": "Whether to include the first-party license scan (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeProjectLicense",
+            "description": "Whether to include the project's declared license (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeCopyrightList",
+            "description": "Whether to include the copyright list (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeFileMatches",
+            "description": "Whether to include license file matches (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeOpenVulnerabilities",
+            "description": "Whether to include open vulnerabilities (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeClosedVulnerabilities",
+            "description": "Whether to include closed vulnerabilities (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeDependencySummary",
+            "description": "Whether to include the dependency summary (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeLicenseHeaders",
+            "description": "Whether to include license headers (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includePackageLabels",
+            "description": "Whether to include the package labels assigned to each dependency (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeHashAndVersionData",
+            "description": "Whether to include hash and version data (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "excludeUnknownDependencies",
+            "description": "Whether to exclude unknown (unresolved) dependencies from the report (default is false, meaning unknown dependencies are included)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "excludeFields",
+            "description": "Object controlling which dependencies are excluded from the report. The only supported\nnested field is `packageLabels`: a non-empty array of package-label values; dependencies\ncarrying any of these labels are excluded from the report.\n\nThe server parses the query string with the `qs` library, so the array is sent using\nbracket-and-index notation rather than standard OpenAPI `deepObject` serialization. For\nexample, to exclude two labels send (before URL-encoding):\n`excludeFields[packageLabels][0]=internal&excludeFields[packageLabels][1]=vendored`.\n",
+            "required": false,
+            "in": "query",
+            "style": "deepObject",
+            "explode": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "packageLabels": {
+                  "type": "array",
+                  "minItems": 1,
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "Package labels whose dependencies should be excluded from the report"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The generated report, streamed as a file. The response sets\n`Content-Disposition: inline` and a `Content-Type` matching the requested `format`.\n",
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Bad API Token": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2010,
+                      "message": "API token is invalid",
+                      "name": "UnauthorizedError",
+                      "httpStatusCode": 401
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFound",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Not Found": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2004,
+                      "message": "Project not found: custom+1/example$abc123",
+                      "name": "NotFoundError",
+                      "httpStatusCode": 404
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Server Error": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2009,
+                      "message": "Sorry, we've encountered an unexpected error. We've recorded it. If you continue to see this, contact support at support@fossa.com and include the unique reference code: 00000000-0000-0000-0000-000000000000",
+                      "name": "InternalServerError",
+                      "httpStatusCode": 500
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/revisions/{locator}/attribution/public": {
+      "post": {
+        "description": "Create a public attribution report link for a revision (V2). Queues a background job to\ngenerate the report and upload it to S3, and returns the pending `Report` record together\nwith the queued `task`.\n\n**Requires a Premium subscription** and project view + report-link permissions.\n\n**Note:** Not all report options are valid for every report format. Use your project's\nReports UI to see which options apply to a given format.\n",
+        "operationId": "createRevisionAttributionPublicReportV2",
+        "tags": [
+          "Revisions"
+        ],
+        "security": [
+          {
+            "ApiToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "locator",
+            "description": "The URL-encoded locator of the revision",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "format",
+            "description": "The format of the report",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "HTML",
+                "MD",
+                "PDF",
+                "CSV",
+                "TXT",
+                "SPDX",
+                "SPDX_JSON",
+                "CYCLONEDX_JSON",
+                "CYCLONEDX_XML"
+              ]
+            }
+          },
+          {
+            "name": "emails",
+            "description": "A single email address used as the report recipient and, for SPDX-style reports, the\nauthor identifier. Despite the plural name, this accepts exactly one address \u2014 not a list.\n",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "includeDeepDependencies",
+            "description": "Whether to include deep dependencies (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeDirectDependencies",
+            "description": "Whether to include direct dependencies (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeLicenseList",
+            "description": "Whether to include the license list (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeLicenseScan",
+            "description": "Whether to include the first-party license scan (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeProjectLicense",
+            "description": "Whether to include the project's declared license (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeCopyrightList",
+            "description": "Whether to include the copyright list (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeFileMatches",
+            "description": "Whether to include license file matches (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeOpenVulnerabilities",
+            "description": "Whether to include open vulnerabilities (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeClosedVulnerabilities",
+            "description": "Whether to include closed vulnerabilities (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeDependencySummary",
+            "description": "Whether to include the dependency summary (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeLicenseHeaders",
+            "description": "Whether to include license headers (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includePackageLabels",
+            "description": "Whether to include the package labels assigned to each dependency (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "excludeUnknownDependencies",
+            "description": "Whether to exclude unknown (unresolved) dependencies from the report (default is false, meaning unknown dependencies are included)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "excludeFields",
+            "description": "Object controlling which dependencies are excluded from the report. The only supported\nnested field is `packageLabels`: a non-empty array of package-label values; dependencies\ncarrying any of these labels are excluded from the report.\n\nThe server parses the query string with the `qs` library, so the array is sent using\nbracket-and-index notation rather than standard OpenAPI `deepObject` serialization. For\nexample, to exclude two labels send (before URL-encoding):\n`excludeFields[packageLabels][0]=internal&excludeFields[packageLabels][1]=vendored`.\n",
+            "required": false,
+            "in": "query",
+            "style": "deepObject",
+            "explode": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "packageLabels": {
+                  "type": "array",
+                  "minItems": 1,
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "Package labels whose dependencies should be excluded from the report"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "The created public report record and the queued generation task",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "report": {
+                      "type": "object",
+                      "description": "The created public report record",
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "description": "The report ID"
+                        },
+                        "uuid": {
+                          "type": "string",
+                          "description": "The public UUID used in the report's URL"
+                        },
+                        "url": {
+                          "type": "string",
+                          "description": "The eventual S3 URL of the generated report"
+                        },
+                        "public": {
+                          "type": "boolean",
+                          "description": "Whether the report is publicly accessible"
+                        },
+                        "organizationId": {
+                          "type": "integer"
+                        },
+                        "projectId": {
+                          "type": "string"
+                        },
+                        "revisionId": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "task": {
+                      "type": "object",
+                      "description": "Metadata describing a background task that has been queued for processing.",
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "description": "Unique identifier for the task"
+                        },
+                        "task": {
+                          "type": "string",
+                          "description": "Name of the task being run"
+                        },
+                        "jobToken": {
+                          "type": "string",
+                          "description": "Token used to poll for the task's status and result"
+                        },
+                        "status": {
+                          "type": "string",
+                          "description": "Current status of the task",
+                          "enum": [
+                            "CREATED",
+                            "ASSIGNED",
+                            "RUNNING",
+                            "SUCCEEDED",
+                            "FAILED"
+                          ]
+                        },
+                        "attempt_number": {
+                          "type": "integer",
+                          "description": "Number of times the task has been attempted"
+                        },
+                        "maxRetries": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ],
+                          "description": "Maximum number of retries permitted for the task"
+                        },
+                        "started": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "format": "date-time",
+                          "description": "When the task started running, or null if it has not started"
+                        },
+                        "finished": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "format": "date-time",
+                          "description": "When the task finished, or null if it has not finished"
+                        },
+                        "scheduledStartTime": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "format": "date-time",
+                          "description": "When the task is scheduled to start, or null"
+                        },
+                        "pod": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "description": "Identifier of the pod running the task, or null"
+                        },
+                        "context": {
+                          "type": "object",
+                          "description": "Task-specific context payload",
+                          "additionalProperties": true
+                        },
+                        "createdAt": {
+                          "type": "string",
+                          "format": "date-time",
+                          "description": "When the task record was created"
+                        },
+                        "updatedAt": {
+                          "type": "string",
+                          "format": "date-time",
+                          "description": "When the task record was last updated"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "BadRequest",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Bad API Token": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2010,
+                      "message": "API token is invalid",
+                      "name": "UnauthorizedError",
+                      "httpStatusCode": 401
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden \u2014 requires a premium subscription.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Insufficient subscription": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2005,
+                      "message": "User not permissioned for feature. Feature requires \"premium\" subscription access level.",
+                      "name": "ForbiddenError",
+                      "httpStatusCode": 403
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFound",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Not Found": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2004,
+                      "message": "Project not found: custom+1/example$abc123",
+                      "name": "NotFoundError",
+                      "httpStatusCode": 404
+                    }
                   }
                 }
               }
@@ -35170,7 +43969,7 @@
             }
           },
           {
-            "name": "excludedLowPriority",
+            "name": "excludeLowPriority",
             "description": "Whether to exclude Low Priority section (default is false)",
             "required": false,
             "in": "query",
@@ -35181,6 +43980,42 @@
           {
             "name": "excludeOutdatedDependencies",
             "description": "Whether to exclude Outdated Dependencies section (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "demo",
+            "description": "Whether to generate the report in demo mode (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "includeTransitiveVulns",
+            "description": "Whether to include transitive vulnerabilities (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "deduplicateOutdatedDeps",
+            "description": "Whether to deduplicate outdated dependencies (default is false)",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "includeMalware",
+            "description": "Whether to include malware findings (default is false). Only takes effect when the\norganization has the malware-issues feature enabled.\n",
             "required": false,
             "in": "query",
             "schema": {
@@ -35251,7 +44086,7 @@
             }
           },
           "403": {
-            "description": "Forbidden",
+            "description": "Forbidden. Returned when the organization is below the Premium subscription level (a\n`ForbiddenError`), or when the organization does not have Security enabled (a\n`FeatureAccessRestrictedError`).\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -35279,12 +44114,25 @@
                     }
                   }
                 },
-                "example": {
-                  "uuid": "00000000-0000-0000-0000-000000000000",
-                  "code": 1006,
-                  "message": "fixPlanReport is not enabled in this organization.",
-                  "name": "FeatureAccessRestrictedError",
-                  "httpStatusCode": 403
+                "examples": {
+                  "Premium required": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2005,
+                      "message": "User not permissioned for feature. Feature requires \"premium\" subscription access level.",
+                      "name": "ForbiddenError",
+                      "httpStatusCode": 403
+                    }
+                  },
+                  "Security not enabled": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 1006,
+                      "message": "Your organization must have Security permissions enabled to view this feature.",
+                      "name": "FeatureAccessRestrictedError",
+                      "httpStatusCode": 403
+                    }
+                  }
                 }
               }
             }
@@ -35316,6 +44164,49 @@
               "text/plain": {
                 "schema": {
                   "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "BadRequest",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "InvalidSBOMProject": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2004,
+                      "message": "The revision is not associated with an SBOM",
+                      "name": "BadRequestError",
+                      "httpStatusCode": 400
+                    }
+                  }
                 }
               }
             }
@@ -35779,6 +44670,10 @@
                         "description": "The revision ID of the notice match",
                         "type": "string"
                       },
+                      "path": {
+                        "description": "The file path of the notice match",
+                        "type": "string"
+                      },
                       "contents": {
                         "description": "The contents of the notice match",
                         "type": "string"
@@ -35912,9 +44807,7 @@
                 "properties": {
                   "limit": {
                     "type": "integer",
-                    "description": "Maximum number of dependencies to return (min 1, max 10000)",
-                    "minimum": 1,
-                    "maximum": 10000,
+                    "description": "Maximum number of dependencies to return. The value is clamped server-side to the\nrange 25\u2013100: any value below 25 is treated as 25, and any value above 100 is treated as 100.\n",
                     "example": 100
                   },
                   "offset": {
@@ -35985,7 +44878,7 @@
         },
         "responses": {
           "200": {
-            "description": "A streaming JSON array of dependencies. Each dependency object contains detailed information including\nthe dependency lock, project metadata, licenses, and issues.\n",
+            "description": "A streaming JSON array of dependencies. Each dependency object contains detailed information including\nthe dependency lock, project metadata, licenses, and issues.\n\n**Note**: Because the array is streamed, the `200` status is sent before the body is fully written. If an\nerror occurs partway through streaming, the response ends with an in-stream error object of the shape\n`{ \"error\": string }` appended to the JSON output rather than a separate error status code.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -36411,23 +45304,16 @@
             }
           },
           "404": {
-            "description": "Revision not found",
+            "description": "Revision not found. The response body is the plain-text string `Not Found` (sent via\n`res.sendStatus(404)`), not a JSON object.\n",
             "content": {
-              "application/json": {
+              "text/plain": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  }
+                  "type": "string"
                 },
                 "examples": {
                   "notFound": {
                     "summary": "Revision not found",
-                    "value": {
-                      "error": "Revision not found"
-                    }
+                    "value": "Not Found"
                   }
                 }
               }
@@ -36507,11 +45393,9 @@
             "name": "limit",
             "in": "query",
             "required": false,
-            "description": "Maximum number of dependencies to return (min 1, max 10000)",
+            "description": "Maximum number of dependencies to return. The value is clamped server-side to the\nrange 25\u2013100: any value below 25 is treated as 25, and any value above 100 is treated as 100.\n",
             "schema": {
               "type": "integer",
-              "minimum": 1,
-              "maximum": 10000,
               "example": 100
             }
           },
@@ -36577,7 +45461,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A streaming JSON array of dependencies. Each dependency object contains detailed information including\nthe dependency lock, project metadata, licenses, and issues.\n",
+            "description": "A streaming JSON array of dependencies. Each dependency object contains detailed information including\nthe dependency lock, project metadata, licenses, and issues.\n\n**Note**: Because the array is streamed, the `200` status is sent before the body is fully written. If an\nerror occurs partway through streaming, the response ends with an in-stream error object of the shape\n`{ \"error\": string }` appended to the JSON output rather than a separate error status code.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -37003,14 +45887,325 @@
             }
           },
           "404": {
+            "description": "Revision not found. The response body is the plain-text string `Not Found` (sent via\n`res.sendStatus(404)`), not a JSON object.\n",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                },
+                "examples": {
+                  "notFound": {
+                    "summary": "Revision not found",
+                    "value": "Not Found"
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Server Error": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2009,
+                      "message": "Sorry, we've encountered an unexpected error. We've recorded it. If you continue to see this, contact support at support@fossa.com and include the unique reference code: 00000000-0000-0000-0000-000000000000",
+                      "name": "InternalServerError",
+                      "httpStatusCode": 500
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/revisions/{locator}/scans": {
+      "get": {
+        "description": "Retrieve a paginated list of scans for a given revision, ordered by scan time descending, with ties broken by id DESC for deterministic pagination.\nScans are filtered to the organization that owns the revision's project, so public and private projects behave consistently.\nRequires an authenticated user.\n",
+        "operationId": "getRevisionScans",
+        "tags": [
+          "Revisions"
+        ],
+        "security": [
+          {
+            "ApiToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "locator",
+            "description": "The URL-encoded locator of the revision",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "example": "custom%2B1234%2Fmy-project%24abcd1234"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "description": "The 1-indexed page of results to return",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 1,
+              "example": 1
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "description": "The number of scans to return per page (maximum 50)",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 50,
+              "default": 10,
+              "example": 10
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A paginated list of revision scans.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "results",
+                    "page",
+                    "pageSize",
+                    "totalCount"
+                  ],
+                  "properties": {
+                    "results": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "integer",
+                            "description": "Unique identifier for the scan"
+                          },
+                          "scanned_at": {
+                            "type": "string",
+                            "format": "date-time",
+                            "description": "Timestamp when the scan was performed"
+                          },
+                          "scanType": {
+                            "type": "string",
+                            "enum": [
+                              "project"
+                            ],
+                            "description": "The scan type. This endpoint only returns project scans."
+                          },
+                          "revisionId": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "The locator of the revision the scan belongs to"
+                          },
+                          "organizationId": {
+                            "type": "integer",
+                            "nullable": true,
+                            "description": "The organization that owns the scan"
+                          },
+                          "releaseScanId": {
+                            "type": "integer",
+                            "nullable": true,
+                            "description": "Associated release scan identifier, if any"
+                          },
+                          "licensingPolicyVersionId": {
+                            "type": "integer",
+                            "nullable": true,
+                            "description": "The licensing policy version used during this scan"
+                          },
+                          "securityPolicyVersionId": {
+                            "type": "integer",
+                            "nullable": true,
+                            "description": "The security policy version used during this scan"
+                          },
+                          "qualityPolicyVersionId": {
+                            "type": "integer",
+                            "nullable": true,
+                            "description": "The quality policy version used during this scan"
+                          },
+                          "createdAt": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "updatedAt": {
+                            "type": "string",
+                            "format": "date-time"
+                          }
+                        }
+                      }
+                    },
+                    "page": {
+                      "type": "integer",
+                      "description": "The current page number",
+                      "example": 1
+                    },
+                    "pageSize": {
+                      "type": "integer",
+                      "description": "The number of items requested per page",
+                      "example": 10
+                    },
+                    "totalCount": {
+                      "type": "integer",
+                      "description": "The total number of scans matching the query across all pages",
+                      "example": 42
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid pagination parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "badRequest": {
+                    "summary": "Invalid pagination parameters",
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2003,
+                      "message": "Validation error: Invalid input: expected number, received NaN at \"page\"",
+                      "name": "BadRequestError",
+                      "httpStatusCode": 400
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Bad API Token": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2010,
+                      "message": "API token is invalid",
+                      "name": "UnauthorizedError",
+                      "httpStatusCode": 401
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
             "description": "Revision not found",
             "content": {
               "application/json": {
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "error": {
-                      "type": "string"
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
                     }
                   }
                 },
@@ -37018,7 +46213,11 @@
                   "notFound": {
                     "summary": "Revision not found",
                     "value": {
-                      "error": "Revision not found"
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2004,
+                      "message": "This revision does not exist.",
+                      "name": "NotFoundError",
+                      "httpStatusCode": 404
                     }
                   }
                 }
@@ -37139,20 +46338,12 @@
           },
           {
             "name": "sort",
-            "description": "The sort order(s) to apply to the builds",
+            "description": "The sort order(s) to apply to the builds. Accepts a comma-separated list of one or more columns. Prefix a column with `-` to sort it in descending order (ascending is the default). Valid columns are: `cliVersionId`, `createdAt`, `id`, `locator`, `ownerId`, `taskId`, `updatedAt`. For example, `-createdAt,id` sorts by `createdAt` descending then `id` ascending.\n",
             "required": false,
             "in": "query",
             "schema": {
               "type": "string",
-              "enum": [
-                "cliVersionId",
-                "createdAt",
-                "id",
-                "locator",
-                "ownerId",
-                "taskId",
-                "updatedAt"
-              ]
+              "example": "-createdAt,id"
             }
           }
         ],
@@ -37235,7 +46426,7 @@
                           },
                           "projectId": {
                             "description": "The project locator of the project for the build",
-                            "type": "integer"
+                            "type": "string"
                           },
                           "message": {
                             "description": "The message for the revision",
@@ -37285,6 +46476,14 @@
                           "maxRetries": {
                             "description": "The maximum number of retries for the task",
                             "type": "integer"
+                          },
+                          "scheduledStartTime": {
+                            "description": "The date and time the task is scheduled to start",
+                            "type": [
+                              "string",
+                              "null"
+                            ],
+                            "format": "date-time"
                           }
                         }
                       }
@@ -37320,7 +46519,8 @@
                           "createdAt": "2021-01-01T00:00:00Z",
                           "updatedAt": "2021-01-01T00:00:00Z",
                           "attempt_number": 1,
-                          "maxRetries": 1
+                          "maxRetries": 1,
+                          "scheduledStartTime": "2021-01-01T00:00:00Z"
                         }
                       },
                       {
@@ -37349,7 +46549,8 @@
                           "createdAt": "2021-01-01T00:00:00Z",
                           "updatedAt": "2021-01-01T00:00:00Z",
                           "attempt_number": 1,
-                          "maxRetries": 1
+                          "maxRetries": 1,
+                          "scheduledStartTime": "2021-01-01T00:00:00Z"
                         }
                       }
                     ]
@@ -37515,20 +46716,12 @@
           },
           {
             "name": "sort",
-            "description": "The sort order(s) to apply to the builds",
+            "description": "The sort order(s) to apply to the builds. Accepts a comma-separated list of one or more columns. Prefix a column with `-` to sort it in descending order (ascending is the default). Valid columns are: `cliVersionId`, `createdAt`, `id`, `locator`, `ownerId`, `taskId`, `updatedAt`. For example, `-createdAt,id` sorts by `createdAt` descending then `id` ascending.\n",
             "required": false,
             "in": "query",
             "schema": {
               "type": "string",
-              "enum": [
-                "cliVersionId",
-                "createdAt",
-                "id",
-                "locator",
-                "ownerId",
-                "taskId",
-                "updatedAt"
-              ]
+              "example": "-createdAt,id"
             }
           }
         ],
@@ -37715,6 +46908,10 @@
                       "super": {
                         "type": "boolean",
                         "description": "Whether the user is a super user"
+                      },
+                      "isServiceAccount": {
+                        "type": "boolean",
+                        "description": "Whether the user is a service account"
                       },
                       "joined": {
                         "type": [
@@ -37970,6 +47167,7 @@
                         "email_verified": true,
                         "demo": false,
                         "super": false,
+                        "isServiceAccount": false,
                         "joined": "2020-01-01",
                         "last_visit": "2020-01-01",
                         "terms_agreed": "2020-01-01",
@@ -38130,281 +47328,282 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "id": {
-                        "type": "integer",
-                        "description": "The user's unique identifier"
-                      },
-                      "username": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "The user's username"
-                      },
-                      "email": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "The user's email address"
-                      },
-                      "email_verified": {
-                        "type": [
-                          "boolean",
-                          "null"
-                        ],
-                        "description": "Whether the user's email address has been verified"
-                      },
-                      "demo": {
-                        "type": "boolean",
-                        "description": "Whether the user is a demo user"
-                      },
-                      "super": {
-                        "type": "boolean",
-                        "description": "Whether the user is a super user"
-                      },
-                      "joined": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "format": "date-time",
-                        "description": "The date the user joined the organization"
-                      },
-                      "last_visit": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "format": "date-time",
-                        "description": "The date the user last visited the organization"
-                      },
-                      "terms_agreed": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "format": "date-time",
-                        "description": "The date the user agreed to the organization's terms"
-                      },
-                      "full_name": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "The user's full name"
-                      },
-                      "phone": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "The user's phone number"
-                      },
-                      "role": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "The user's role in the organization"
-                      },
-                      "organizationId": {
-                        "type": "integer",
-                        "description": "The organization the user belongs to"
-                      },
-                      "sso_only": {
-                        "type": "boolean",
-                        "description": "Whether the user is SSO only"
-                      },
-                      "enabled": {
-                        "type": "boolean",
-                        "description": "Whether the user is enabled"
-                      },
-                      "has_set_password": {
-                        "type": [
-                          "boolean",
-                          "null"
-                        ],
-                        "description": "Whether the user has set a password"
-                      },
-                      "install_admin": {
-                        "type": [
-                          "boolean",
-                          "null"
-                        ],
-                        "description": "Whether the user is an install admin"
-                      },
-                      "createdAt": {
-                        "type": "string",
-                        "format": "date-time",
-                        "description": "The date the user was created"
-                      },
-                      "updatedAt": {
-                        "type": "string",
-                        "format": "date-time",
-                        "description": "The date the user was last updated"
-                      },
-                      "userRole": {
-                        "type": "object",
-                        "properties": {
-                          "roleId": {
-                            "type": "integer",
-                            "description": "The user's Organization role ID"
-                          },
-                          "role": {
-                            "type": "object",
-                            "properties": {
-                              "id": {
-                                "type": "integer",
-                                "description": "The role's unique identifier"
-                              },
-                              "organizationId": {
-                                "type": "integer",
-                                "description": "The organization the role belongs to"
-                              },
-                              "isCustom": {
-                                "type": "boolean",
-                                "description": "Whether the role is custom"
-                              },
-                              "name": {
-                                "type": "string",
-                                "description": "The role's name"
-                              },
-                              "scope": {
-                                "type": "string",
-                                "description": "The role's scope"
-                              }
-                            }
-                          }
-                        }
-                      },
-                      "tokens": {
-                        "type": "array",
-                        "items": {
+                  "properties": {
+                    "id": {
+                      "type": "integer",
+                      "description": "The user's unique identifier"
+                    },
+                    "username": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "The user's username"
+                    },
+                    "email": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "The user's email address"
+                    },
+                    "email_verified": {
+                      "type": [
+                        "boolean",
+                        "null"
+                      ],
+                      "description": "Whether the user's email address has been verified"
+                    },
+                    "demo": {
+                      "type": "boolean",
+                      "description": "Whether the user is a demo user"
+                    },
+                    "super": {
+                      "type": "boolean",
+                      "description": "Whether the user is a super user"
+                    },
+                    "isServiceAccount": {
+                      "type": "boolean",
+                      "description": "Whether the user is a service account"
+                    },
+                    "joined": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "format": "date-time",
+                      "description": "The date the user joined the organization"
+                    },
+                    "last_visit": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "format": "date-time",
+                      "description": "The date the user last visited the organization"
+                    },
+                    "terms_agreed": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "format": "date-time",
+                      "description": "The date the user agreed to the organization's terms"
+                    },
+                    "full_name": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "The user's full name"
+                    },
+                    "phone": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "The user's phone number"
+                    },
+                    "role": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "The user's role in the organization"
+                    },
+                    "organizationId": {
+                      "type": "integer",
+                      "description": "The organization the user belongs to"
+                    },
+                    "sso_only": {
+                      "type": "boolean",
+                      "description": "Whether the user is SSO only"
+                    },
+                    "enabled": {
+                      "type": "boolean",
+                      "description": "Whether the user is enabled"
+                    },
+                    "has_set_password": {
+                      "type": [
+                        "boolean",
+                        "null"
+                      ],
+                      "description": "Whether the user has set a password"
+                    },
+                    "install_admin": {
+                      "type": [
+                        "boolean",
+                        "null"
+                      ],
+                      "description": "Whether the user is an install admin"
+                    },
+                    "createdAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "description": "The date the user was created"
+                    },
+                    "updatedAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "description": "The date the user was last updated"
+                    },
+                    "userRole": {
+                      "type": "object",
+                      "properties": {
+                        "roleId": {
+                          "type": "integer",
+                          "description": "The user's Organization role ID"
+                        },
+                        "role": {
                           "type": "object",
                           "properties": {
                             "id": {
                               "type": "integer",
-                              "description": "The token's unique identifier"
+                              "description": "The role's unique identifier"
+                            },
+                            "organizationId": {
+                              "type": "integer",
+                              "description": "The organization the role belongs to"
+                            },
+                            "isCustom": {
+                              "type": "boolean",
+                              "description": "Whether the role is custom"
                             },
                             "name": {
                               "type": "string",
-                              "description": "The token's name"
+                              "description": "The role's name"
                             },
-                            "isDisabled": {
-                              "type": "boolean"
-                            },
-                            "updatedAt": {
+                            "scope": {
                               "type": "string",
-                              "format": "date-time",
-                              "description": "The date the token was last updated"
-                            },
-                            "createdAt": {
-                              "type": "string",
-                              "format": "date-time",
-                              "description": "The date the token was created"
-                            },
-                            "meta": {
-                              "type": "object",
-                              "properties": {
-                                "pushOnly": {
-                                  "type": "boolean",
-                                  "description": "Whether the token is push only"
-                                }
-                              },
-                              "defaultPolicyId": {
-                                "type": "integer",
-                                "description": "The token's default licensing policy ID"
-                              },
-                              "defaultSecurityPolicyId": {
-                                "type": "integer",
-                                "description": "The token's default security policy ID"
-                              },
-                              "defaultQualityPolicyId": {
-                                "type": "integer",
-                                "description": "The token's default quality policy ID"
-                              }
+                              "description": "The role's scope"
                             }
                           }
                         }
-                      },
-                      "teamUsers": {
-                        "type": "array",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "roleId": {
-                              "type": "integer",
-                              "description": "The user's role ID"
-                            },
-                            "team": {
-                              "type": "object",
-                              "properties": {
-                                "id": {
-                                  "type": "integer",
-                                  "description": "The team's unique identifier"
-                                },
-                                "name": {
-                                  "type": "string",
-                                  "description": "The team's name"
-                                }
-                              }
-                            }
-                          }
-                        }
-                      },
-                      "organization": {
+                      }
+                    },
+                    "tokens": {
+                      "type": "array",
+                      "items": {
                         "type": "object",
                         "properties": {
                           "id": {
                             "type": "integer",
-                            "description": "The organization's unique identifier"
+                            "description": "The token's unique identifier"
                           },
-                          "title": {
-                            "type": "string",
-                            "description": "The organization's title"
-                          },
-                          "access_level": {
-                            "type": "string",
-                            "description": "The organization's access level"
-                          }
-                        }
-                      },
-                      "github": {
-                        "type": "object",
-                        "properties": {
                           "name": {
                             "type": "string",
-                            "description": "The user's GitHub username"
+                            "description": "The token's name"
                           },
-                          "email": {
-                            "type": "string",
-                            "description": "The user's GitHub email address"
+                          "isDisabled": {
+                            "type": "boolean"
                           },
-                          "avatar_url": {
+                          "updatedAt": {
                             "type": "string",
-                            "description": "The user's GitHub avatar URL"
+                            "format": "date-time",
+                            "description": "The date the token was last updated"
+                          },
+                          "createdAt": {
+                            "type": "string",
+                            "format": "date-time",
+                            "description": "The date the token was created"
+                          },
+                          "meta": {
+                            "type": "object",
+                            "properties": {
+                              "pushOnly": {
+                                "type": "boolean",
+                                "description": "Whether the token is push only"
+                              }
+                            },
+                            "defaultPolicyId": {
+                              "type": "integer",
+                              "description": "The token's default licensing policy ID"
+                            },
+                            "defaultSecurityPolicyId": {
+                              "type": "integer",
+                              "description": "The token's default security policy ID"
+                            },
+                            "defaultQualityPolicyId": {
+                              "type": "integer",
+                              "description": "The token's default quality policy ID"
+                            }
                           }
                         }
-                      },
-                      "bitbucketCloud": {
+                      }
+                    },
+                    "teamUsers": {
+                      "type": "array",
+                      "items": {
                         "type": "object",
                         "properties": {
-                          "name": {
-                            "type": "string",
-                            "description": "The user's Bitbucket Cloud username"
+                          "roleId": {
+                            "type": "integer",
+                            "description": "The user's role ID"
                           },
-                          "email": {
-                            "type": "string",
-                            "description": "The user's Bitbucket Cloud email address"
-                          },
-                          "avatar_url": {
-                            "type": "string",
-                            "description": "The user's Bitbucket Cloud avatar URL"
+                          "team": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "integer",
+                                "description": "The team's unique identifier"
+                              },
+                              "name": {
+                                "type": "string",
+                                "description": "The team's name"
+                              }
+                            }
                           }
+                        }
+                      }
+                    },
+                    "organization": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "description": "The organization's unique identifier"
+                        },
+                        "title": {
+                          "type": "string",
+                          "description": "The organization's title"
+                        },
+                        "access_level": {
+                          "type": "string",
+                          "description": "The organization's access level"
+                        }
+                      }
+                    },
+                    "github": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "description": "The user's GitHub username"
+                        },
+                        "email": {
+                          "type": "string",
+                          "description": "The user's GitHub email address"
+                        },
+                        "avatar_url": {
+                          "type": "string",
+                          "description": "The user's GitHub avatar URL"
+                        }
+                      }
+                    },
+                    "bitbucketCloud": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "description": "The user's Bitbucket Cloud username"
+                        },
+                        "email": {
+                          "type": "string",
+                          "description": "The user's Bitbucket Cloud email address"
+                        },
+                        "avatar_url": {
+                          "type": "string",
+                          "description": "The user's Bitbucket Cloud avatar URL"
                         }
                       }
                     }
@@ -38419,6 +47618,7 @@
                       "email_verified": true,
                       "demo": false,
                       "super": false,
+                      "isServiceAccount": false,
                       "joined": "2020-01-01",
                       "last_visit": "2020-01-01",
                       "terms_agreed": "2020-01-01",
@@ -38496,6 +47696,48 @@
                       "message": "User does not have permission to view this resource",
                       "name": "ForbiddenError",
                       "httpStatusCode": 403
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No user with the given ID was found in the organization",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "userNotFound": {
+                    "value": {
+                      "message": "No user with id 12345 found",
+                      "name": "NotFoundError",
+                      "code": 2004,
+                      "httpStatusCode": 404
                     }
                   }
                 }
@@ -38580,7 +47822,6 @@
                   "email": {
                     "type": "string",
                     "format": "email",
-                    "maxLength": 255,
                     "description": "Optional email address for the service account",
                     "example": "api-service@company.com"
                   },
@@ -38740,7 +47981,7 @@
             }
           },
           "400": {
-            "description": "Bad Request",
+            "description": "Bad Request. Returned when the request body fails validation, when neither\n`orgRoleId` nor `team` is supplied, or when a user with the given username or\nemail already exists in the organization.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -38769,12 +48010,21 @@
                   }
                 },
                 "examples": {
-                  "Bad Request Parameter/Body": {
+                  "missingRoleOrTeam": {
+                    "summary": "Neither orgRoleId nor team was provided",
                     "value": {
-                      "uuid": "00000000-0000-0000-0000-000000000000",
-                      "code": 2003,
-                      "message": "Parse error at root.X: ...",
+                      "message": "At least one of \"orgRoleId\" or \"team\" must be specified",
                       "name": "BadRequestError",
+                      "code": 2003,
+                      "httpStatusCode": 400
+                    }
+                  },
+                  "duplicateUser": {
+                    "summary": "A user with the same username or email already exists",
+                    "value": {
+                      "message": "A user with this username or email already exists.",
+                      "name": "BadRequestError",
+                      "code": 2003,
                       "httpStatusCode": 400
                     }
                   }
@@ -39656,7 +48906,7 @@
                           "isSnippetConversion": {
                             "type": "boolean"
                           },
-                          "concludedLicenses": {
+                          "conclusions": {
                             "type": "object",
                             "properties": {
                               "scoped": {
@@ -39702,6 +48952,137 @@
                             "type": "array",
                             "items": {
                               "type": "string"
+                            }
+                          },
+                          "discoveredLicenses": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "licenseGroups": {
+                            "type": "array",
+                            "description": "The grouped licenses discovered for this dependency.",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "licenseGroupId": {
+                                  "type": "integer"
+                                },
+                                "signature": {
+                                  "type": "string"
+                                },
+                                "ignored": {
+                                  "type": "boolean"
+                                },
+                                "isDeclared": {
+                                  "type": "boolean"
+                                },
+                                "licenses": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "title": {
+                                        "type": "string"
+                                      },
+                                      "licenseId": {
+                                        "type": "string"
+                                      },
+                                      "ignored": {
+                                        "type": "boolean"
+                                      },
+                                      "url": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "licenseGroupId": {
+                                        "type": "integer"
+                                      },
+                                      "revisionLicenseId": {
+                                        "type": "integer"
+                                      },
+                                      "projectCorrectionId": {
+                                        "type": [
+                                          "integer",
+                                          "null"
+                                        ]
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "labels": {
+                            "type": "array",
+                            "description": "The package label assignments applied to this dependency.",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "integer",
+                                  "description": "The ID of the package label assignment."
+                                },
+                                "createdAt": {
+                                  "type": "string",
+                                  "format": "date-time",
+                                  "description": "The date and time the package label assignment was created."
+                                },
+                                "updatedAt": {
+                                  "type": "string",
+                                  "format": "date-time",
+                                  "description": "The date and time the package label assignment was last updated."
+                                },
+                                "organizationId": {
+                                  "type": "integer",
+                                  "description": "The ID of the organization that owns the package label assignment."
+                                },
+                                "labelId": {
+                                  "type": "integer",
+                                  "description": "The ID of the label that was assigned to the package."
+                                },
+                                "packageId": {
+                                  "type": "string",
+                                  "description": "The ID of the package that the label was assigned to."
+                                },
+                                "packageVersion": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "description": "The version of the package that the label was assigned to or null if the label was assigned to all versions."
+                                },
+                                "scope": {
+                                  "type": "string",
+                                  "description": "The scope of the package label assignment.",
+                                  "enum": [
+                                    "org",
+                                    "project",
+                                    "revision"
+                                  ]
+                                },
+                                "scopeId": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "description": "The ID of the scope that the label was assigned to or null if the label was assigned to all scopes."
+                                },
+                                "name": {
+                                  "type": "string",
+                                  "description": "The name of the label that was assigned to the package."
+                                }
+                              },
+                              "required": [
+                                "id",
+                                "createdAt",
+                                "updatedAt",
+                                "organizationId",
+                                "labelId",
+                                "packageId",
+                                "scope",
+                                "scopeId",
+                                "name"
+                              ]
                             }
                           },
                           "depth": {
@@ -39831,8 +49212,9 @@
                         }
                       }
                     },
-                    "count": {
-                      "type": "integer"
+                    "total": {
+                      "type": "integer",
+                      "description": "The total number of dependencies matching the filters, across all pages."
                     }
                   }
                 },
@@ -39848,7 +49230,7 @@
                           "isIgnored": false,
                           "isUnknown": false,
                           "isSnippetConversion": false,
-                          "concludedLicenses": {
+                          "conclusions": {
                             "scoped": {
                               "licenses": [
                                 "MIT",
@@ -39886,11 +49268,7 @@
                               "id": 123,
                               "type": "policy_conflict",
                               "status": "active",
-                              "license": "Apache",
-                              "analysisSnippetId": 123,
-                              "vulnId": null,
-                              "cvssScore": null,
-                              "projectId": "custom+123/myproject$1.2.3"
+                              "license": "Apache"
                             }
                           ],
                           "rootProjects": [
@@ -39914,7 +49292,7 @@
                           "isIgnored": false,
                           "isUnknown": false,
                           "isSnippetConversion": false,
-                          "concludedLicenses": {
+                          "conclusions": {
                             "scoped": {
                               "licenses": [
                                 null
@@ -40104,7 +49482,7 @@
     "/v2/revisions/{locator}/dependencies/{dependencyRevisionLocator}": {
       "get": {
         "operationId": "getProjectDependency",
-        "description": "Get a single dependency by locator for a given project revision",
+        "description": "Get a single dependency by locator for a given project revision.\n\n**Note:** Unlike the list endpoint (`GET /v2/revisions/{locator}/dependencies`), this\nsingle-dependency endpoint returns the full, unsanitized dependency object. In addition to\nthe fields documented in the response schema below, the payload includes these extra fields:\n\n- Top-level: `authors`, `description`, `url`, `individualLicenses`, `groupedLicenses`, `sourceType`, `lastPublishedDate`\n- Each entry in `rootProjects` additionally includes `type`, `teams`, `paths`, and `depth`\n- Each entry in `issues` additionally includes `notes`\n",
         "tags": [
           "Dependencies"
         ],
@@ -40202,7 +49580,7 @@
                         "isSnippetConversion": {
                           "type": "boolean"
                         },
-                        "concludedLicenses": {
+                        "conclusions": {
                           "type": "object",
                           "properties": {
                             "scoped": {
@@ -40248,6 +49626,137 @@
                           "type": "array",
                           "items": {
                             "type": "string"
+                          }
+                        },
+                        "discoveredLicenses": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "licenseGroups": {
+                          "type": "array",
+                          "description": "The grouped licenses discovered for this dependency.",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "licenseGroupId": {
+                                "type": "integer"
+                              },
+                              "signature": {
+                                "type": "string"
+                              },
+                              "ignored": {
+                                "type": "boolean"
+                              },
+                              "isDeclared": {
+                                "type": "boolean"
+                              },
+                              "licenses": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "title": {
+                                      "type": "string"
+                                    },
+                                    "licenseId": {
+                                      "type": "string"
+                                    },
+                                    "ignored": {
+                                      "type": "boolean"
+                                    },
+                                    "url": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    },
+                                    "licenseGroupId": {
+                                      "type": "integer"
+                                    },
+                                    "revisionLicenseId": {
+                                      "type": "integer"
+                                    },
+                                    "projectCorrectionId": {
+                                      "type": [
+                                        "integer",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "labels": {
+                          "type": "array",
+                          "description": "The package label assignments applied to this dependency.",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "integer",
+                                "description": "The ID of the package label assignment."
+                              },
+                              "createdAt": {
+                                "type": "string",
+                                "format": "date-time",
+                                "description": "The date and time the package label assignment was created."
+                              },
+                              "updatedAt": {
+                                "type": "string",
+                                "format": "date-time",
+                                "description": "The date and time the package label assignment was last updated."
+                              },
+                              "organizationId": {
+                                "type": "integer",
+                                "description": "The ID of the organization that owns the package label assignment."
+                              },
+                              "labelId": {
+                                "type": "integer",
+                                "description": "The ID of the label that was assigned to the package."
+                              },
+                              "packageId": {
+                                "type": "string",
+                                "description": "The ID of the package that the label was assigned to."
+                              },
+                              "packageVersion": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "The version of the package that the label was assigned to or null if the label was assigned to all versions."
+                              },
+                              "scope": {
+                                "type": "string",
+                                "description": "The scope of the package label assignment.",
+                                "enum": [
+                                  "org",
+                                  "project",
+                                  "revision"
+                                ]
+                              },
+                              "scopeId": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "The ID of the scope that the label was assigned to or null if the label was assigned to all scopes."
+                              },
+                              "name": {
+                                "type": "string",
+                                "description": "The name of the label that was assigned to the package."
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "createdAt",
+                              "updatedAt",
+                              "organizationId",
+                              "labelId",
+                              "packageId",
+                              "scope",
+                              "scopeId",
+                              "name"
+                            ]
                           }
                         },
                         "depth": {
@@ -40388,7 +49897,7 @@
                         "isIgnored": false,
                         "isUnknown": false,
                         "isSnippetConversion": false,
-                        "concludedLicenses": {
+                        "conclusions": {
                           "scoped": {
                             "licenses": [
                               "Apache-2.0",
@@ -40770,6 +50279,23 @@
                 ]
               }
             }
+          },
+          {
+            "name": "status[]",
+            "description": "Filter dependencies by status",
+            "in": "query",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "analyzing",
+                  "analyzed",
+                  "failed",
+                  "unknown"
+                ]
+              }
+            }
           }
         ],
         "responses": {
@@ -40923,7 +50449,7 @@
     "/v2/dependencies/{locator}": {
       "get": {
         "operationId": "getGlobalDependency",
-        "description": "Get a single dependency by locator in the global scope",
+        "description": "Get a single dependency by locator in the global scope.\n\n**Note:** Unlike the list endpoints, this single-dependency endpoint returns the full,\nunsanitized dependency object, including extra top-level fields and additional fields on\nthe nested `rootProjects` and `issues` entries. See the response schema for the full contract.\n",
         "tags": [
           "Dependencies"
         ],
@@ -40992,199 +50518,549 @@
                   "type": "object",
                   "properties": {
                     "dependency": {
-                      "type": "object",
-                      "properties": {
-                        "locator": {
-                          "type": "string"
-                        },
-                        "title": {
-                          "type": "string"
-                        },
-                        "isManual": {
-                          "type": "boolean"
-                        },
-                        "isIgnored": {
-                          "type": "boolean"
-                        },
-                        "isUnknown": {
-                          "type": "boolean"
-                        },
-                        "isSnippetConversion": {
-                          "type": "boolean"
-                        },
-                        "concludedLicenses": {
+                      "allOf": [
+                        {
                           "type": "object",
                           "properties": {
-                            "scoped": {
-                              "type": "object",
-                              "properties": {
-                                "licenses": {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "string"
-                                  }
-                                },
-                                "lastEditedBy": {
-                                  "type": "string"
-                                },
-                                "updatedAt": {
-                                  "type": "string"
-                                }
-                              }
-                            },
-                            "base": {
-                              "type": "object",
-                              "properties": {
-                                "licenses": {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "string"
-                                  }
-                                },
-                                "justification": {
-                                  "type": "string"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "licenses": {
-                          "type": "array",
-                          "items": {
-                            "type": "string"
-                          }
-                        },
-                        "declaredLicenses": {
-                          "type": "array",
-                          "items": {
-                            "type": "string"
-                          }
-                        },
-                        "depth": {
-                          "type": "integer"
-                        },
-                        "originPaths": {
-                          "type": "array",
-                          "items": {
-                            "type": "string"
-                          }
-                        },
-                        "status": {
-                          "type": "object",
-                          "properties": {
-                            "error": {
+                            "locator": {
                               "type": "string"
                             },
-                            "resolved": {
+                            "title": {
+                              "type": "string"
+                            },
+                            "isManual": {
                               "type": "boolean"
                             },
-                            "unsupported": {
+                            "isIgnored": {
                               "type": "boolean"
                             },
-                            "analyzing": {
+                            "isUnknown": {
                               "type": "boolean"
-                            }
-                          }
-                        },
-                        "issues": {
-                          "type": "array",
-                          "items": {
-                            "type": "object",
-                            "properties": {
-                              "id": {
-                                "type": "integer"
-                              },
-                              "type": {
-                                "type": "string"
-                              },
-                              "status": {
-                                "type": "string",
-                                "enum": [
-                                  "active",
-                                  "ignored"
-                                ]
-                              },
-                              "license": {
-                                "type": "string"
-                              },
-                              "cvssScore": {
-                                "type": "number"
+                            },
+                            "isSnippetConversion": {
+                              "type": "boolean"
+                            },
+                            "conclusions": {
+                              "type": "object",
+                              "properties": {
+                                "scoped": {
+                                  "type": "object",
+                                  "properties": {
+                                    "licenses": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "lastEditedBy": {
+                                      "type": "string"
+                                    },
+                                    "updatedAt": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "base": {
+                                  "type": "object",
+                                  "properties": {
+                                    "licenses": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "justification": {
+                                      "type": "string"
+                                    }
+                                  }
+                                }
                               }
-                            }
-                          }
-                        },
-                        "rootProjects": {
-                          "type": "array",
-                          "items": {
-                            "type": "object",
-                            "properties": {
-                              "title": {
+                            },
+                            "licenses": {
+                              "type": "array",
+                              "items": {
                                 "type": "string"
-                              },
-                              "revision": {
+                              }
+                            },
+                            "declaredLicenses": {
+                              "type": "array",
+                              "items": {
                                 "type": "string"
-                              },
-                              "branch": {
+                              }
+                            },
+                            "discoveredLicenses": {
+                              "type": "array",
+                              "items": {
                                 "type": "string"
-                              },
-                              "conclusions": {
+                              }
+                            },
+                            "licenseGroups": {
+                              "type": "array",
+                              "description": "The grouped licenses discovered for this dependency.",
+                              "items": {
                                 "type": "object",
                                 "properties": {
-                                  "scoped": {
+                                  "licenseGroupId": {
+                                    "type": "integer"
+                                  },
+                                  "signature": {
+                                    "type": "string"
+                                  },
+                                  "ignored": {
+                                    "type": "boolean"
+                                  },
+                                  "isDeclared": {
+                                    "type": "boolean"
+                                  },
+                                  "licenses": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "title": {
+                                          "type": "string"
+                                        },
+                                        "licenseId": {
+                                          "type": "string"
+                                        },
+                                        "ignored": {
+                                          "type": "boolean"
+                                        },
+                                        "url": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "licenseGroupId": {
+                                          "type": "integer"
+                                        },
+                                        "revisionLicenseId": {
+                                          "type": "integer"
+                                        },
+                                        "projectCorrectionId": {
+                                          "type": [
+                                            "integer",
+                                            "null"
+                                          ]
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "labels": {
+                              "type": "array",
+                              "description": "The package label assignments applied to this dependency.",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "id": {
+                                    "type": "integer",
+                                    "description": "The ID of the package label assignment."
+                                  },
+                                  "createdAt": {
+                                    "type": "string",
+                                    "format": "date-time",
+                                    "description": "The date and time the package label assignment was created."
+                                  },
+                                  "updatedAt": {
+                                    "type": "string",
+                                    "format": "date-time",
+                                    "description": "The date and time the package label assignment was last updated."
+                                  },
+                                  "organizationId": {
+                                    "type": "integer",
+                                    "description": "The ID of the organization that owns the package label assignment."
+                                  },
+                                  "labelId": {
+                                    "type": "integer",
+                                    "description": "The ID of the label that was assigned to the package."
+                                  },
+                                  "packageId": {
+                                    "type": "string",
+                                    "description": "The ID of the package that the label was assigned to."
+                                  },
+                                  "packageVersion": {
+                                    "type": "string",
+                                    "nullable": true,
+                                    "description": "The version of the package that the label was assigned to or null if the label was assigned to all versions."
+                                  },
+                                  "scope": {
+                                    "type": "string",
+                                    "description": "The scope of the package label assignment.",
+                                    "enum": [
+                                      "org",
+                                      "project",
+                                      "revision"
+                                    ]
+                                  },
+                                  "scopeId": {
+                                    "type": "string",
+                                    "nullable": true,
+                                    "description": "The ID of the scope that the label was assigned to or null if the label was assigned to all scopes."
+                                  },
+                                  "name": {
+                                    "type": "string",
+                                    "description": "The name of the label that was assigned to the package."
+                                  }
+                                },
+                                "required": [
+                                  "id",
+                                  "createdAt",
+                                  "updatedAt",
+                                  "organizationId",
+                                  "labelId",
+                                  "packageId",
+                                  "scope",
+                                  "scopeId",
+                                  "name"
+                                ]
+                              }
+                            },
+                            "depth": {
+                              "type": "integer"
+                            },
+                            "originPaths": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "status": {
+                              "type": "object",
+                              "properties": {
+                                "error": {
+                                  "type": "string"
+                                },
+                                "resolved": {
+                                  "type": "boolean"
+                                },
+                                "unsupported": {
+                                  "type": "boolean"
+                                },
+                                "analyzing": {
+                                  "type": "boolean"
+                                }
+                              }
+                            },
+                            "issues": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "id": {
+                                    "type": "integer"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  },
+                                  "status": {
+                                    "type": "string",
+                                    "enum": [
+                                      "active",
+                                      "ignored"
+                                    ]
+                                  },
+                                  "license": {
+                                    "type": "string"
+                                  },
+                                  "cvssScore": {
+                                    "type": "number"
+                                  }
+                                }
+                              }
+                            },
+                            "rootProjects": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "title": {
+                                    "type": "string"
+                                  },
+                                  "revision": {
+                                    "type": "string"
+                                  },
+                                  "branch": {
+                                    "type": "string"
+                                  },
+                                  "conclusions": {
                                     "type": "object",
                                     "properties": {
-                                      "licenses": {
-                                        "type": "array",
-                                        "items": {
-                                          "type": "string"
+                                      "scoped": {
+                                        "type": "object",
+                                        "properties": {
+                                          "licenses": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "lastEditedBy": {
+                                            "type": "string"
+                                          },
+                                          "updatedAt": {
+                                            "type": "string"
+                                          }
                                         }
                                       },
-                                      "lastEditedBy": {
+                                      "base": {
+                                        "type": "object",
+                                        "properties": {
+                                          "licenses": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "justification": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "layerDepth": {
+                              "type": "number"
+                            },
+                            "cpes": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "vendoredPaths": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "version": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "authors": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "description": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "individualLicenses": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "groupedLicenses": {
+                              "type": "array",
+                              "description": "The flattened, grouped licenses discovered for this dependency.",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "title": {
+                                    "type": "string"
+                                  },
+                                  "licenseId": {
+                                    "type": "string"
+                                  },
+                                  "ignored": {
+                                    "type": "boolean"
+                                  },
+                                  "url": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "licenseGroupId": {
+                                    "type": "integer"
+                                  },
+                                  "revisionLicenseId": {
+                                    "type": "integer"
+                                  },
+                                  "projectCorrectionId": {
+                                    "type": [
+                                      "integer",
+                                      "null"
+                                    ]
+                                  },
+                                  "group": {
+                                    "type": "object",
+                                    "properties": {
+                                      "isDeclared": {
+                                        "type": "boolean"
+                                      },
+                                      "ignored": {
+                                        "type": "boolean"
+                                      },
+                                      "signature": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "sourceType": {
+                              "type": "string"
+                            },
+                            "lastPublishedDate": {
+                              "type": "string",
+                              "format": "date-time"
+                            },
+                            "rootProjects": {
+                              "type": "array",
+                              "items": {
+                                "allOf": [
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "title": {
                                         "type": "string"
                                       },
-                                      "updatedAt": {
+                                      "revision": {
                                         "type": "string"
+                                      },
+                                      "branch": {
+                                        "type": "string"
+                                      },
+                                      "conclusions": {
+                                        "type": "object",
+                                        "properties": {
+                                          "scoped": {
+                                            "type": "object",
+                                            "properties": {
+                                              "licenses": {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "lastEditedBy": {
+                                                "type": "string"
+                                              },
+                                              "updatedAt": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          },
+                                          "base": {
+                                            "type": "object",
+                                            "properties": {
+                                              "licenses": {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "justification": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          }
+                                        }
                                       }
                                     }
                                   },
-                                  "base": {
+                                  {
                                     "type": "object",
                                     "properties": {
-                                      "licenses": {
+                                      "type": {
+                                        "type": "string",
+                                        "enum": [
+                                          "snippet",
+                                          "dependency"
+                                        ]
+                                      },
+                                      "teams": {
                                         "type": "array",
                                         "items": {
-                                          "type": "string"
+                                          "type": "object",
+                                          "properties": {
+                                            "id": {
+                                              "type": "integer"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "uniqueId": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            },
+                                            "teamType": {
+                                              "type": "string"
+                                            }
+                                          }
                                         }
                                       },
-                                      "justification": {
-                                        "type": "string"
+                                      "paths": {
+                                        "type": "array",
+                                        "description": "The dependency paths from the root project to this dependency.",
+                                        "items": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      },
+                                      "depth": {
+                                        "type": "integer"
                                       }
                                     }
+                                  }
+                                ]
+                              }
+                            },
+                            "issues": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "id": {
+                                    "type": "integer"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  },
+                                  "status": {
+                                    "type": "string",
+                                    "enum": [
+                                      "active",
+                                      "ignored"
+                                    ]
+                                  },
+                                  "license": {
+                                    "type": "string"
+                                  },
+                                  "cvssScore": {
+                                    "type": "number"
+                                  },
+                                  "malwareReportName": {
+                                    "type": "string"
                                   }
                                 }
                               }
                             }
                           }
-                        },
-                        "layerDepth": {
-                          "type": "number"
-                        },
-                        "cpes": {
-                          "type": "array",
-                          "items": {
-                            "type": "string"
-                          }
-                        },
-                        "vendoredPaths": {
-                          "type": "array",
-                          "items": {
-                            "type": "string"
-                          }
-                        },
-                        "version": {
-                          "type": "string"
                         }
-                      }
+                      ]
                     }
                   }
                 },
@@ -41198,7 +51074,7 @@
                         "isIgnored": false,
                         "isUnknown": false,
                         "isSnippetConversion": false,
-                        "concludedLicenses": {
+                        "conclusions": {
                           "scoped": {
                             "licenses": [
                               "Apache-2.0",
@@ -42082,7 +51958,7 @@
                           "isSnippetConversion": {
                             "type": "boolean"
                           },
-                          "concludedLicenses": {
+                          "conclusions": {
                             "type": "object",
                             "properties": {
                               "scoped": {
@@ -42128,6 +52004,137 @@
                             "type": "array",
                             "items": {
                               "type": "string"
+                            }
+                          },
+                          "discoveredLicenses": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "licenseGroups": {
+                            "type": "array",
+                            "description": "The grouped licenses discovered for this dependency.",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "licenseGroupId": {
+                                  "type": "integer"
+                                },
+                                "signature": {
+                                  "type": "string"
+                                },
+                                "ignored": {
+                                  "type": "boolean"
+                                },
+                                "isDeclared": {
+                                  "type": "boolean"
+                                },
+                                "licenses": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "title": {
+                                        "type": "string"
+                                      },
+                                      "licenseId": {
+                                        "type": "string"
+                                      },
+                                      "ignored": {
+                                        "type": "boolean"
+                                      },
+                                      "url": {
+                                        "type": [
+                                          "string",
+                                          "null"
+                                        ]
+                                      },
+                                      "licenseGroupId": {
+                                        "type": "integer"
+                                      },
+                                      "revisionLicenseId": {
+                                        "type": "integer"
+                                      },
+                                      "projectCorrectionId": {
+                                        "type": [
+                                          "integer",
+                                          "null"
+                                        ]
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "labels": {
+                            "type": "array",
+                            "description": "The package label assignments applied to this dependency.",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "integer",
+                                  "description": "The ID of the package label assignment."
+                                },
+                                "createdAt": {
+                                  "type": "string",
+                                  "format": "date-time",
+                                  "description": "The date and time the package label assignment was created."
+                                },
+                                "updatedAt": {
+                                  "type": "string",
+                                  "format": "date-time",
+                                  "description": "The date and time the package label assignment was last updated."
+                                },
+                                "organizationId": {
+                                  "type": "integer",
+                                  "description": "The ID of the organization that owns the package label assignment."
+                                },
+                                "labelId": {
+                                  "type": "integer",
+                                  "description": "The ID of the label that was assigned to the package."
+                                },
+                                "packageId": {
+                                  "type": "string",
+                                  "description": "The ID of the package that the label was assigned to."
+                                },
+                                "packageVersion": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "description": "The version of the package that the label was assigned to or null if the label was assigned to all versions."
+                                },
+                                "scope": {
+                                  "type": "string",
+                                  "description": "The scope of the package label assignment.",
+                                  "enum": [
+                                    "org",
+                                    "project",
+                                    "revision"
+                                  ]
+                                },
+                                "scopeId": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "description": "The ID of the scope that the label was assigned to or null if the label was assigned to all scopes."
+                                },
+                                "name": {
+                                  "type": "string",
+                                  "description": "The name of the label that was assigned to the package."
+                                }
+                              },
+                              "required": [
+                                "id",
+                                "createdAt",
+                                "updatedAt",
+                                "organizationId",
+                                "labelId",
+                                "packageId",
+                                "scope",
+                                "scopeId",
+                                "name"
+                              ]
                             }
                           },
                           "depth": {
@@ -42257,8 +52264,9 @@
                         }
                       }
                     },
-                    "count": {
-                      "type": "integer"
+                    "total": {
+                      "type": "integer",
+                      "description": "The total number of dependencies matching the filters, across all pages."
                     }
                   }
                 },
@@ -42274,7 +52282,7 @@
                           "isIgnored": false,
                           "isUnknown": false,
                           "isSnippetConversion": false,
-                          "concludedLicenses": {
+                          "conclusions": {
                             "scoped": {
                               "licenses": [
                                 "MIT",
@@ -42312,11 +52320,7 @@
                               "id": 123,
                               "type": "policy_conflict",
                               "status": "active",
-                              "license": "Apache",
-                              "analysisSnippetId": 123,
-                              "vulnId": null,
-                              "cvssScore": null,
-                              "projectId": "custom+123/myproject$1.2.3"
+                              "license": "Apache"
                             }
                           ],
                           "rootProjects": [
@@ -42340,7 +52344,7 @@
                           "isIgnored": false,
                           "isUnknown": false,
                           "isSnippetConversion": false,
-                          "concludedLicenses": {
+                          "conclusions": {
                             "scoped": {
                               "licenses": [
                                 null
@@ -42530,7 +52534,7 @@
     "/v2/release-groups/{projectGroupId}/releases/{projectGroupReleaseId}/dependencies/{dependencyRevisionLocator}": {
       "get": {
         "operationId": "getReleaseGroupDependency",
-        "description": "Get a single dependency by locator for a given release group",
+        "description": "Get a single dependency by locator for a given release group.\n\n**Note:** Unlike the list endpoint (`GET /v2/release-groups/{projectGroupId}/releases/{projectGroupReleaseId}/dependencies`),\nthis single-dependency endpoint returns the full, unsanitized dependency object. In addition to\nthe fields documented in the response schema below, the payload includes these extra fields:\n\n- Top-level: `authors`, `description`, `url`, `individualLicenses`, `groupedLicenses`, `sourceType`, `lastPublishedDate`\n- Each entry in `rootProjects` additionally includes `type`, `teams`, `paths`, and `depth`\n- Each entry in `issues` additionally includes `notes`\n",
         "tags": [
           "Dependencies"
         ],
@@ -42637,7 +52641,7 @@
                         "isSnippetConversion": {
                           "type": "boolean"
                         },
-                        "concludedLicenses": {
+                        "conclusions": {
                           "type": "object",
                           "properties": {
                             "scoped": {
@@ -42683,6 +52687,137 @@
                           "type": "array",
                           "items": {
                             "type": "string"
+                          }
+                        },
+                        "discoveredLicenses": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "licenseGroups": {
+                          "type": "array",
+                          "description": "The grouped licenses discovered for this dependency.",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "licenseGroupId": {
+                                "type": "integer"
+                              },
+                              "signature": {
+                                "type": "string"
+                              },
+                              "ignored": {
+                                "type": "boolean"
+                              },
+                              "isDeclared": {
+                                "type": "boolean"
+                              },
+                              "licenses": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "title": {
+                                      "type": "string"
+                                    },
+                                    "licenseId": {
+                                      "type": "string"
+                                    },
+                                    "ignored": {
+                                      "type": "boolean"
+                                    },
+                                    "url": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    },
+                                    "licenseGroupId": {
+                                      "type": "integer"
+                                    },
+                                    "revisionLicenseId": {
+                                      "type": "integer"
+                                    },
+                                    "projectCorrectionId": {
+                                      "type": [
+                                        "integer",
+                                        "null"
+                                      ]
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "labels": {
+                          "type": "array",
+                          "description": "The package label assignments applied to this dependency.",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "integer",
+                                "description": "The ID of the package label assignment."
+                              },
+                              "createdAt": {
+                                "type": "string",
+                                "format": "date-time",
+                                "description": "The date and time the package label assignment was created."
+                              },
+                              "updatedAt": {
+                                "type": "string",
+                                "format": "date-time",
+                                "description": "The date and time the package label assignment was last updated."
+                              },
+                              "organizationId": {
+                                "type": "integer",
+                                "description": "The ID of the organization that owns the package label assignment."
+                              },
+                              "labelId": {
+                                "type": "integer",
+                                "description": "The ID of the label that was assigned to the package."
+                              },
+                              "packageId": {
+                                "type": "string",
+                                "description": "The ID of the package that the label was assigned to."
+                              },
+                              "packageVersion": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "The version of the package that the label was assigned to or null if the label was assigned to all versions."
+                              },
+                              "scope": {
+                                "type": "string",
+                                "description": "The scope of the package label assignment.",
+                                "enum": [
+                                  "org",
+                                  "project",
+                                  "revision"
+                                ]
+                              },
+                              "scopeId": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "The ID of the scope that the label was assigned to or null if the label was assigned to all scopes."
+                              },
+                              "name": {
+                                "type": "string",
+                                "description": "The name of the label that was assigned to the package."
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "createdAt",
+                              "updatedAt",
+                              "organizationId",
+                              "labelId",
+                              "packageId",
+                              "scope",
+                              "scopeId",
+                              "name"
+                            ]
                           }
                         },
                         "depth": {
@@ -42823,7 +52958,7 @@
                         "isIgnored": false,
                         "isUnknown": false,
                         "isSnippetConversion": false,
-                        "concludedLicenses": {
+                        "conclusions": {
                           "scoped": {
                             "licenses": [
                               "Apache-2.0",
@@ -43220,6 +53355,23 @@
                 "enum": [
                   "managed",
                   "vendored"
+                ]
+              }
+            }
+          },
+          {
+            "name": "status[]",
+            "description": "Filter dependencies by status",
+            "in": "query",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "analyzing",
+                  "analyzed",
+                  "failed",
+                  "unknown"
                 ]
               }
             }
@@ -44002,6 +54154,24 @@
                         }
                       }
                     },
+                    "packageLabels": {
+                      "type": "array",
+                      "description": "The organization's package labels, each with the count of packages it is assigned to.",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "integer"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "packageCount": {
+                            "type": "integer"
+                          }
+                        }
+                      }
+                    },
                     "title": {
                       "type": "string"
                     },
@@ -44016,6 +54186,16 @@
                     },
                     "disableNonCustomTeamUserRoles": {
                       "type": "boolean"
+                    },
+                    "snippetSourceCodeRetentionDays": {
+                      "type": "integer",
+                      "minimum": 1,
+                      "maximum": 30,
+                      "description": "Number of days source code from snippet matches is retained. Must be between 1 and 30."
+                    },
+                    "licenseConcludedEnabled": {
+                      "type": "boolean",
+                      "description": "Whether the license-concluded workflow is enabled for the organization."
                     }
                   }
                 },
@@ -44029,11 +54209,20 @@
                           "projectCount": 10
                         }
                       ],
+                      "packageLabels": [
+                        {
+                          "name": "internal",
+                          "id": 5,
+                          "packageCount": 42
+                        }
+                      ],
                       "title": "title",
                       "email": "test@fossa.com",
                       "defaultRoleId": 1,
                       "dependencySignatures": "1,2,3",
-                      "disableNonCustomTeamUserRoles": false
+                      "disableNonCustomTeamUserRoles": false,
+                      "snippetSourceCodeRetentionDays": 30,
+                      "licenseConcludedEnabled": true
                     }
                   }
                 }
@@ -44200,6 +54389,13 @@
                       "type": "string"
                     }
                   },
+                  "packageLabels": {
+                    "type": "array",
+                    "description": "Package label names to set on the organization.",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
                   "title": {
                     "type": "string"
                   },
@@ -44214,6 +54410,16 @@
                   },
                   "disableNonCustomTeamUserRoles": {
                     "type": "boolean"
+                  },
+                  "snippetSourceCodeRetentionDays": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 30,
+                    "description": "Number of days to retain source code from snippet matches. Must be between 1 and 30, or a 400 is returned."
+                  },
+                  "licenseConcludedEnabled": {
+                    "type": "boolean",
+                    "description": "Whether the license-concluded workflow is enabled for the organization."
                   }
                 }
               },
@@ -44224,11 +54430,17 @@
                       "critical",
                       "low"
                     ],
+                    "packageLabels": [
+                      "internal",
+                      "external"
+                    ],
                     "title": "title",
                     "email": "test@fossa.com",
                     "defaultRoleId": 1,
                     "dependencySignatures": "1,2,3",
-                    "disableNonCustomTeamUserRoles": false
+                    "disableNonCustomTeamUserRoles": false,
+                    "snippetSourceCodeRetentionDays": 30,
+                    "licenseConcludedEnabled": true
                   }
                 }
               }
@@ -44756,6 +54968,49 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Invalid Settings Payload": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2003,
+                      "message": "Couldn't update organization settings",
+                      "name": "InvalidPayloadError",
+                      "httpStatusCode": 422
+                    }
+                  }
+                }
+              }
+            }
           }
         }
       },
@@ -44794,6 +55049,1181 @@
               },
               "example": [
                 "defaultProjectPrivacy"
+              ]
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "No content"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Bad API Token": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2010,
+                      "message": "API token is invalid",
+                      "name": "UnauthorizedError",
+                      "httpStatusCode": 401
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Forbidden": {
+                    "value": {
+                      "message": "Forbidden"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFound",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "No Organization Found": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2004,
+                      "message": "Organization not found.",
+                      "name": "NotFoundError",
+                      "httpStatusCode": 404
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/organizations/{id}/settings/projects/quick-import-scan-methods": {
+      "get": {
+        "operationId": "getOrganizationProjectScanMethodsSettings",
+        "description": "Get default quick import scan methods settings for an organization",
+        "tags": [
+          "Organization Settings"
+        ],
+        "security": [
+          {
+            "ApiToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "projectDefaultQuickImportVendoredDetectionEnabled": {
+                      "type": "boolean"
+                    },
+                    "projectDefaultQuickImportSnippetDetectionEnabled": {
+                      "type": "boolean"
+                    }
+                  }
+                },
+                "example": {
+                  "projectDefaultQuickImportVendoredDetectionEnabled": false,
+                  "projectDefaultQuickImportSnippetDetectionEnabled": false
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Bad API Token": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2010,
+                      "message": "API token is invalid",
+                      "name": "UnauthorizedError",
+                      "httpStatusCode": 401
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Forbidden": {
+                    "value": {
+                      "message": "Forbidden"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFound",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "No Organization Found": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2004,
+                      "message": "Organization not found.",
+                      "name": "NotFoundError",
+                      "httpStatusCode": 404
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "updateOrganizationProjectScanMethodsSettings",
+        "description": "Update default quick import scan methods settings for an organization",
+        "tags": [
+          "Organization Settings"
+        ],
+        "security": [
+          {
+            "ApiToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "projectDefaultQuickImportVendoredDetectionEnabled",
+                  "projectDefaultQuickImportSnippetDetectionEnabled"
+                ],
+                "properties": {
+                  "projectDefaultQuickImportVendoredDetectionEnabled": {
+                    "type": "boolean"
+                  },
+                  "projectDefaultQuickImportSnippetDetectionEnabled": {
+                    "type": "boolean"
+                  }
+                }
+              },
+              "example": {
+                "projectDefaultQuickImportVendoredDetectionEnabled": true,
+                "projectDefaultQuickImportSnippetDetectionEnabled": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "No content"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Bad API Token": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2010,
+                      "message": "API token is invalid",
+                      "name": "UnauthorizedError",
+                      "httpStatusCode": 401
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Forbidden": {
+                    "value": {
+                      "message": "Forbidden"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFound",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "No Organization Found": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2004,
+                      "message": "Organization not found.",
+                      "name": "NotFoundError",
+                      "httpStatusCode": 404
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Invalid Settings Payload": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2003,
+                      "message": "Couldn't update organization settings",
+                      "name": "InvalidPayloadError",
+                      "httpStatusCode": 422
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "operationId": "propagateOrganizationProjectScanMethodsSettings",
+        "description": "Propagate quick import scan methods settings to all projects in the organization",
+        "tags": [
+          "Organization Settings"
+        ],
+        "security": [
+          {
+            "ApiToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "enum": [
+                    "projectDefaultQuickImportVendoredDetectionEnabled",
+                    "projectDefaultQuickImportSnippetDetectionEnabled"
+                  ]
+                }
+              },
+              "example": [
+                "projectDefaultQuickImportVendoredDetectionEnabled"
+              ]
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "No content"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Bad API Token": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2010,
+                      "message": "API token is invalid",
+                      "name": "UnauthorizedError",
+                      "httpStatusCode": 401
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Forbidden": {
+                    "value": {
+                      "message": "Forbidden"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFound",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "No Organization Found": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2004,
+                      "message": "Organization not found.",
+                      "name": "NotFoundError",
+                      "httpStatusCode": 404
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/organizations/{id}/settings/projects/hidden-snippet-urls": {
+      "get": {
+        "operationId": "getOrganizationProjectHiddenSnippetUrlsSettings",
+        "description": "Get the default excluded snippet repository URLs for an organization",
+        "tags": [
+          "Organization Settings"
+        ],
+        "security": [
+          {
+            "ApiToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "projectDefaultHiddenSnippetUrls": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "format": "uri"
+                      }
+                    }
+                  }
+                },
+                "example": {
+                  "projectDefaultHiddenSnippetUrls": [
+                    "https://github.com/acme/repo"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Bad API Token": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2010,
+                      "message": "API token is invalid",
+                      "name": "UnauthorizedError",
+                      "httpStatusCode": 401
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Forbidden": {
+                    "value": {
+                      "message": "Forbidden"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFound",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "No Organization Found": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2004,
+                      "message": "Organization not found.",
+                      "name": "NotFoundError",
+                      "httpStatusCode": 404
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "updateOrganizationProjectHiddenSnippetUrlsSettings",
+        "description": "Update the default excluded snippet repository URLs for an organization. Entries are trimmed, blank entries dropped, each must be a valid URL, and duplicates are removed.",
+        "tags": [
+          "Organization Settings"
+        ],
+        "security": [
+          {
+            "ApiToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "projectDefaultHiddenSnippetUrls"
+                ],
+                "properties": {
+                  "projectDefaultHiddenSnippetUrls": {
+                    "type": "array",
+                    "maxItems": 100,
+                    "items": {
+                      "type": "string",
+                      "format": "uri",
+                      "maxLength": 2048
+                    }
+                  }
+                }
+              },
+              "example": {
+                "projectDefaultHiddenSnippetUrls": [
+                  "https://github.com/acme/repo"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "No content"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Invalid URL": {
+                    "value": {
+                      "uuid": "e307c56c-1343-41c8-bd68-a2a1877f2632",
+                      "code": 2003,
+                      "message": "Validation error: Invalid URL",
+                      "name": "BadRequestError",
+                      "httpStatusCode": 400
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Bad API Token": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2010,
+                      "message": "API token is invalid",
+                      "name": "UnauthorizedError",
+                      "httpStatusCode": 401
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Forbidden": {
+                    "value": {
+                      "message": "Forbidden"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFound",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "No Organization Found": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2004,
+                      "message": "Organization not found.",
+                      "name": "NotFoundError",
+                      "httpStatusCode": 404
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Invalid Settings Payload": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2003,
+                      "message": "Couldn't update organization settings",
+                      "name": "InvalidPayloadError",
+                      "httpStatusCode": 422
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "operationId": "propagateOrganizationProjectHiddenSnippetUrlsSettings",
+        "description": "Propagate the excluded snippet repository URLs to all projects in the organization",
+        "tags": [
+          "Organization Settings"
+        ],
+        "security": [
+          {
+            "ApiToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "enum": [
+                    "projectDefaultHiddenSnippetUrls"
+                  ]
+                }
+              },
+              "example": [
+                "projectDefaultHiddenSnippetUrls"
               ]
             }
           }
@@ -45283,6 +56713,49 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Invalid Settings Payload": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2003,
+                      "message": "Couldn't update organization settings",
+                      "name": "InvalidPayloadError",
+                      "httpStatusCode": 422
+                    }
+                  }
+                }
+              }
+            }
           }
         }
       },
@@ -45506,6 +56979,10 @@
                     "projectDefaultSnippetLicensingIssueScanningEnabled": {
                       "type": "boolean",
                       "description": "Enable or disable snippet licensing issue scanning by default for projects in the organization"
+                    },
+                    "projectDefaultVendoredLicensingIssueScanningEnabled": {
+                      "type": "boolean",
+                      "description": "Enable or disable licensing issue scanning for vendored dependencies by default for projects in the organization"
                     }
                   }
                 },
@@ -45514,7 +56991,8 @@
                   "projectDefaultLicensingIssueScanningEnabled": true,
                   "projectDefaultLicensingStatusCheckEnabled": true,
                   "projectDefaultStatusCheckFilterLicensing": 1,
-                  "projectDefaultSnippetLicensingIssueScanningEnabled": true
+                  "projectDefaultSnippetLicensingIssueScanningEnabled": true,
+                  "projectDefaultVendoredLicensingIssueScanningEnabled": false
                 }
               }
             }
@@ -45688,6 +57166,10 @@
                   "projectDefaultSnippetLicensingIssueScanningEnabled": {
                     "type": "boolean",
                     "description": "Enable or disable snippet licensing issue scanning by default for projects in the organization"
+                  },
+                  "projectDefaultVendoredLicensingIssueScanningEnabled": {
+                    "type": "boolean",
+                    "description": "Enable or disable licensing issue scanning for vendored dependencies by default for projects in the organization"
                   }
                 }
               }
@@ -45901,7 +57383,8 @@
                     "projectDefaultLicensingIssueScanningEnabled",
                     "projectDefaultLicensingStatusCheckEnabled",
                     "projectDefaultStatusCheckFilterLicensing",
-                    "projectDefaultSnippetLicensingIssueScanningEnabled"
+                    "projectDefaultSnippetLicensingIssueScanningEnabled",
+                    "projectDefaultVendoredLicensingIssueScanningEnabled"
                   ]
                 }
               }
@@ -46085,6 +57568,10 @@
                     "projectDefaultSnippetSecurityIssueScanningEnabled": {
                       "type": "boolean",
                       "description": "Enable or disable snippet security issue scanning by default for projects in the organization"
+                    },
+                    "projectDefaultVendoredSecurityIssueScanningEnabled": {
+                      "type": "boolean",
+                      "description": "Enable or disable security issue scanning for vendored dependencies by default for projects in the organization"
                     }
                   }
                 },
@@ -46095,7 +57582,8 @@
                       "projectDefaultSecurityIssueScanningEnabled": true,
                       "projectDefaultSecurityStatusCheckEnabled": true,
                       "projectDefaultStatusCheckFilterVulnerability": 4,
-                      "projectDefaultSnippetSecurityIssueScanningEnabled": false
+                      "projectDefaultSnippetSecurityIssueScanningEnabled": false,
+                      "projectDefaultVendoredSecurityIssueScanningEnabled": false
                     }
                   }
                 }
@@ -46264,6 +57752,10 @@
                   "projectDefaultSnippetSecurityIssueScanningEnabled": {
                     "type": "boolean",
                     "description": "Enable or disable snippet security issue scanning by default for projects in the organization"
+                  },
+                  "projectDefaultVendoredSecurityIssueScanningEnabled": {
+                    "type": "boolean",
+                    "description": "Enable or disable security issue scanning for vendored dependencies by default for projects in the organization"
                   }
                 }
               },
@@ -46274,7 +57766,8 @@
                     "projectDefaultSecurityIssueScanningEnabled": true,
                     "projectDefaultSecurityStatusCheckEnabled": true,
                     "projectDefaultStatusCheckFilterVulnerability": 4,
-                    "projectDefaultSnippetSecurityIssueScanningEnabled": false
+                    "projectDefaultSnippetSecurityIssueScanningEnabled": false,
+                    "projectDefaultVendoredSecurityIssueScanningEnabled": false
                   }
                 }
               }
@@ -46488,7 +57981,8 @@
                     "projectDefaultSecurityIssueScanningEnabled",
                     "projectDefaultSecurityStatusCheckEnabled",
                     "projectDefaultStatusCheckFilterVulnerability",
-                    "projectDefaultSnippetSecurityIssueScanningEnabled"
+                    "projectDefaultSnippetSecurityIssueScanningEnabled",
+                    "projectDefaultVendoredSecurityIssueScanningEnabled"
                   ]
                 }
               },
@@ -46497,7 +57991,8 @@
                 "projectDefaultSecurityIssueScanningEnabled",
                 "projectDefaultSecurityStatusCheckEnabled",
                 "projectDefaultStatusCheckFilterVulnerability",
-                "projectDefaultSnippetSecurityIssueScanningEnabled"
+                "projectDefaultSnippetSecurityIssueScanningEnabled",
+                "projectDefaultVendoredSecurityIssueScanningEnabled"
               ]
             }
           }
@@ -46675,6 +58170,10 @@
                     },
                     "projectDefaultStatusCheckFilterQuality": {
                       "type": "integer"
+                    },
+                    "projectDefaultVendoredQualityIssueScanningEnabled": {
+                      "type": "boolean",
+                      "description": "Enable or disable quality issue scanning for vendored dependencies by default for projects in the organization"
                     }
                   }
                 },
@@ -46684,7 +58183,8 @@
                       "defaultQualityPolicyId": 1,
                       "projectDefaultQualityIssueScanningEnabled": true,
                       "projectDefaultQualityStatusCheckEnabled": true,
-                      "projectDefaultStatusCheckFilterQuality": 1
+                      "projectDefaultStatusCheckFilterQuality": 1,
+                      "projectDefaultVendoredQualityIssueScanningEnabled": false
                     }
                   }
                 }
@@ -46856,6 +58356,10 @@
                   },
                   "projectDefaultStatusCheckFilterQuality": {
                     "type": "integer"
+                  },
+                  "projectDefaultVendoredQualityIssueScanningEnabled": {
+                    "type": "boolean",
+                    "description": "Enable or disable quality issue scanning for vendored dependencies by default for projects in the organization"
                   }
                 }
               },
@@ -46865,7 +58369,8 @@
                     "defaultQualityPolicyId": 1,
                     "projectDefaultQualityIssueScanningEnabled": true,
                     "projectDefaultQualityStatusCheckEnabled": true,
-                    "projectDefaultStatusCheckFilterQuality": 1
+                    "projectDefaultStatusCheckFilterQuality": 1,
+                    "projectDefaultVendoredQualityIssueScanningEnabled": false
                   }
                 }
               }
@@ -47078,7 +58583,8 @@
                     "defaultQualityPolicyId",
                     "projectDefaultQualityIssueScanningEnabled",
                     "projectDefaultQualityStatusCheckEnabled",
-                    "projectDefaultStatusCheckFilterQuality"
+                    "projectDefaultStatusCheckFilterQuality",
+                    "projectDefaultVendoredQualityIssueScanningEnabled"
                   ]
                 }
               },
@@ -47086,7 +58592,8 @@
                 "defaultQualityPolicyId",
                 "projectDefaultQualityIssueScanningEnabled",
                 "projectDefaultQualityStatusCheckEnabled",
-                "projectDefaultStatusCheckFilterQuality"
+                "projectDefaultStatusCheckFilterQuality",
+                "projectDefaultVendoredQualityIssueScanningEnabled"
               ]
             }
           }
@@ -47576,6 +59083,49 @@
                       "message": "Organization not found.",
                       "name": "NotFoundError",
                       "httpStatusCode": 404
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Invalid Settings Payload": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2003,
+                      "message": "Couldn't update organization settings",
+                      "name": "InvalidPayloadError",
+                      "httpStatusCode": 422
                     }
                   }
                 }
@@ -48479,6 +60029,27 @@
               "type": "string"
             },
             "description": "Dependency revision"
+          },
+          {
+            "name": "page",
+            "description": "The specific page of data to return",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 1
+            }
+          },
+          {
+            "name": "pageSize",
+            "description": "The number of items to return in each page of results",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 50,
+              "default": 10
+            }
           }
         ],
         "security": [
@@ -48635,6 +60206,49 @@
               }
             }
           },
+          "403": {
+            "description": "Forbidden \u2014 the Binary Decomposition feature is not enabled for this organization. Every `/api/binary` endpoint is gated behind the `binaryDecomposition` feature flag, so a request from an organization without it returns this error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Feature not enabled": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 1006,
+                      "message": "binaryDecomposition is not enabled in this organization.",
+                      "name": "FeatureAccessRestrictedError",
+                      "httpStatusCode": 403
+                    }
+                  }
+                }
+              }
+            }
+          },
           "404": {
             "description": "Not Found",
             "content": {
@@ -48745,6 +60359,27 @@
               "type": "string"
             },
             "description": "The ID of the component"
+          },
+          {
+            "name": "page",
+            "description": "The specific page of data to return",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 1
+            }
+          },
+          {
+            "name": "pageSize",
+            "description": "The number of items to return in each page of results",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 50,
+              "default": 10
+            }
           }
         ],
         "security": [
@@ -48896,6 +60531,49 @@
                   "Unauthorized": {
                     "value": {
                       "message": "Unauthorized"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden \u2014 the Binary Decomposition feature is not enabled for this organization. Every `/api/binary` endpoint is gated behind the `binaryDecomposition` feature flag, so a request from an organization without it returns this error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Feature not enabled": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 1006,
+                      "message": "binaryDecomposition is not enabled in this organization.",
+                      "name": "FeatureAccessRestrictedError",
+                      "httpStatusCode": 403
                     }
                   }
                 }
@@ -49112,6 +60790,49 @@
               }
             }
           },
+          "403": {
+            "description": "Forbidden \u2014 the Binary Decomposition feature is not enabled for this organization. Every `/api/binary` endpoint is gated behind the `binaryDecomposition` feature flag, so a request from an organization without it returns this error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Feature not enabled": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 1006,
+                      "message": "binaryDecomposition is not enabled in this organization.",
+                      "name": "FeatureAccessRestrictedError",
+                      "httpStatusCode": 403
+                    }
+                  }
+                }
+              }
+            }
+          },
           "404": {
             "description": "Not Found",
             "content": {
@@ -49227,6 +60948,15 @@
               "type": "string"
             },
             "description": "Path to find components at"
+          },
+          {
+            "name": "search",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Filter the results to dependencies whose title matches this search string."
           }
         ],
         "security": [
@@ -49439,6 +61169,49 @@
               }
             }
           },
+          "403": {
+            "description": "Forbidden \u2014 the Binary Decomposition feature is not enabled for this organization. Every `/api/binary` endpoint is gated behind the `binaryDecomposition` feature flag, so a request from an organization without it returns this error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Feature not enabled": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 1006,
+                      "message": "binaryDecomposition is not enabled in this organization.",
+                      "name": "FeatureAccessRestrictedError",
+                      "httpStatusCode": 403
+                    }
+                  }
+                }
+              }
+            }
+          },
           "404": {
             "description": "Not Found",
             "content": {
@@ -49559,20 +61332,22 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "confidences": {
-                    "type": "array",
-                    "items": {
+                  "required": [
+                    "confidences"
+                  ],
+                  "properties": {
+                    "confidences": {
                       "type": "object",
+                      "description": "A map keyed by dependency locator. Each value is the confidence string for that Binary Component dependency.",
                       "additionalProperties": {
-                        "type": "object",
-                        "properties": {
-                          "code": {
-                            "type": "integer"
-                          },
-                          "text": {
-                            "type": "string"
-                          }
-                        }
+                        "type": "string",
+                        "enum": [
+                          "Low",
+                          "Medium",
+                          "High",
+                          "Unknown"
+                        ],
+                        "description": "Confidence that the matched dependency is correct.\n\n| Value | Meaning |\n|---------|--------------------------------|\n| `High` | High confidence in the match |\n| `Medium` | Medium confidence in the match |\n| `Low` | Low confidence in the match |\n| `Unknown` | Confidence could not be determined |\n"
                       }
                     }
                   }
@@ -49664,6 +61439,49 @@
                   "Unauthorized": {
                     "value": {
                       "message": "Unauthorized"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden \u2014 the Binary Decomposition feature is not enabled for this organization. Every `/api/binary` endpoint is gated behind the `binaryDecomposition` feature flag, so a request from an organization without it returns this error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Feature not enabled": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 1006,
+                      "message": "binaryDecomposition is not enabled in this organization.",
+                      "name": "FeatureAccessRestrictedError",
+                      "httpStatusCode": 403
                     }
                   }
                 }
@@ -49799,20 +61617,22 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "confidences": {
-                    "type": "array",
-                    "items": {
+                  "required": [
+                    "confidences"
+                  ],
+                  "properties": {
+                    "confidences": {
                       "type": "object",
+                      "description": "A map keyed by dependency locator. Each value is the confidence string for that Binary Component dependency.",
                       "additionalProperties": {
-                        "type": "object",
-                        "properties": {
-                          "code": {
-                            "type": "integer"
-                          },
-                          "text": {
-                            "type": "string"
-                          }
-                        }
+                        "type": "string",
+                        "enum": [
+                          "Low",
+                          "Medium",
+                          "High",
+                          "Unknown"
+                        ],
+                        "description": "Confidence that the matched dependency is correct.\n\n| Value | Meaning |\n|---------|--------------------------------|\n| `High` | High confidence in the match |\n| `Medium` | Medium confidence in the match |\n| `Low` | Low confidence in the match |\n| `Unknown` | Confidence could not be determined |\n"
                       }
                     }
                   }
@@ -49901,6 +61721,49 @@
                   "Unauthorized": {
                     "value": {
                       "message": "Unauthorized"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden \u2014 the Binary Decomposition feature is not enabled for this organization. Every `/api/binary` endpoint is gated behind the `binaryDecomposition` feature flag, so a request from an organization without it returns this error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Feature not enabled": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 1006,
+                      "message": "binaryDecomposition is not enabled in this organization.",
+                      "name": "FeatureAccessRestrictedError",
+                      "httpStatusCode": 403
                     }
                   }
                 }
@@ -50131,6 +61994,49 @@
               }
             }
           },
+          "403": {
+            "description": "Forbidden \u2014 the Binary Decomposition feature is not enabled for this organization. Every `/api/binary` endpoint is gated behind the `binaryDecomposition` feature flag, so a request from an organization without it returns this error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Feature not enabled": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 1006,
+                      "message": "binaryDecomposition is not enabled in this organization.",
+                      "name": "FeatureAccessRestrictedError",
+                      "httpStatusCode": 403
+                    }
+                  }
+                }
+              }
+            }
+          },
           "404": {
             "description": "Not Found",
             "content": {
@@ -50229,7 +62135,7 @@
     "/binary/release-group/{releaseGroupId}/release/{releaseId}/components/paths": {
       "get": {
         "operationId": "getReleaseComponentsPaths",
-        "description": "Get Binary Decomposition Components by path for a a Release of a Release Group with at least one associated Binary Decomposition Scan",
+        "description": "Get Binary Decomposition Components by path for a Release of a Release Group with at least one associated Binary Decomposition Scan",
         "tags": [
           "Binary"
         ],
@@ -50260,6 +62166,15 @@
               "type": "string"
             },
             "description": "Path to find components at"
+          },
+          {
+            "name": "search",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Filter the results to dependencies whose title matches this search string."
           }
         ],
         "security": [
@@ -50472,6 +62387,49 @@
               }
             }
           },
+          "403": {
+            "description": "Forbidden \u2014 the Binary Decomposition feature is not enabled for this organization. Every `/api/binary` endpoint is gated behind the `binaryDecomposition` feature flag, so a request from an organization without it returns this error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Feature not enabled": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 1006,
+                      "message": "binaryDecomposition is not enabled in this organization.",
+                      "name": "FeatureAccessRestrictedError",
+                      "httpStatusCode": 403
+                    }
+                  }
+                }
+              }
+            }
+          },
           "404": {
             "description": "Not Found",
             "content": {
@@ -50597,17 +62555,22 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "confidences": {
-                    "type": "object",
-                    "additionalProperties": {
+                  "required": [
+                    "confidences"
+                  ],
+                  "properties": {
+                    "confidences": {
                       "type": "object",
-                      "properties": {
-                        "code": {
-                          "type": "integer"
-                        },
-                        "text": {
-                          "type": "string"
-                        }
+                      "description": "A map keyed by dependency locator. Each value is the confidence string for that Binary Component dependency.",
+                      "additionalProperties": {
+                        "type": "string",
+                        "enum": [
+                          "Low",
+                          "Medium",
+                          "High",
+                          "Unknown"
+                        ],
+                        "description": "Confidence that the matched dependency is correct.\n\n| Value | Meaning |\n|---------|--------------------------------|\n| `High` | High confidence in the match |\n| `Medium` | Medium confidence in the match |\n| `Low` | Low confidence in the match |\n| `Unknown` | Confidence could not be determined |\n"
                       }
                     }
                   }
@@ -50699,6 +62662,49 @@
                   "Unauthorized": {
                     "value": {
                       "message": "Unauthorized"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden \u2014 the Binary Decomposition feature is not enabled for this organization. Every `/api/binary` endpoint is gated behind the `binaryDecomposition` feature flag, so a request from an organization without it returns this error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Feature not enabled": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 1006,
+                      "message": "binaryDecomposition is not enabled in this organization.",
+                      "name": "FeatureAccessRestrictedError",
+                      "httpStatusCode": 403
                     }
                   }
                 }
@@ -50829,17 +62835,22 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "confidences": {
-                    "type": "object",
-                    "additionalProperties": {
+                  "required": [
+                    "confidences"
+                  ],
+                  "properties": {
+                    "confidences": {
                       "type": "object",
-                      "properties": {
-                        "code": {
-                          "type": "integer"
-                        },
-                        "text": {
-                          "type": "string"
-                        }
+                      "description": "A map keyed by dependency locator. Each value is the confidence string for that Binary Component dependency.",
+                      "additionalProperties": {
+                        "type": "string",
+                        "enum": [
+                          "Low",
+                          "Medium",
+                          "High",
+                          "Unknown"
+                        ],
+                        "description": "Confidence that the matched dependency is correct.\n\n| Value | Meaning |\n|---------|--------------------------------|\n| `High` | High confidence in the match |\n| `Medium` | Medium confidence in the match |\n| `Low` | Low confidence in the match |\n| `Unknown` | Confidence could not be determined |\n"
                       }
                     }
                   }
@@ -50934,6 +62945,49 @@
               }
             }
           },
+          "403": {
+            "description": "Forbidden \u2014 the Binary Decomposition feature is not enabled for this organization. Every `/api/binary` endpoint is gated behind the `binaryDecomposition` feature flag, so a request from an organization without it returns this error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Feature not enabled": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 1006,
+                      "message": "binaryDecomposition is not enabled in this organization.",
+                      "name": "FeatureAccessRestrictedError",
+                      "httpStatusCode": 403
+                    }
+                  }
+                }
+              }
+            }
+          },
           "404": {
             "description": "Not Found",
             "content": {
@@ -51022,7 +63076,7 @@
     "/oidc/providers": {
       "get": {
         "operationId": "listOIDCProviders",
-        "description": "List OIDC Providers",
+        "description": "List OIDC Providers.\n\nRequires a **premium** subscription; organizations below that tier receive a `403`.\n",
         "tags": [
           "OIDC"
         ],
@@ -51295,7 +63349,7 @@
             }
           },
           "403": {
-            "description": "Forbidden",
+            "description": "Forbidden \u2014 requires a premium subscription.",
             "content": {
               "application/json": {
                 "schema": {
@@ -51324,11 +63378,11 @@
                   }
                 },
                 "examples": {
-                  "No permission": {
+                  "Insufficient subscription": {
                     "value": {
                       "uuid": "00000000-0000-0000-0000-000000000000",
                       "code": 2005,
-                      "message": "User does not have permission to view this resource",
+                      "message": "User not permissioned for feature. Feature requires \"premium\" subscription access level.",
                       "name": "ForbiddenError",
                       "httpStatusCode": 403
                     }
@@ -51384,7 +63438,7 @@
       },
       "post": {
         "operationId": "createOIDCProvider",
-        "description": "Create a new OIDC Provider",
+        "description": "Create a new OIDC Provider.\n\nRequires a **premium** subscription; organizations below that tier receive a `403`.\nIf the caller lacks permission to create the provider, the endpoint responds with `401`.\n",
         "tags": [
           "OIDC"
         ],
@@ -51602,7 +63656,7 @@
             }
           },
           "403": {
-            "description": "Forbidden",
+            "description": "Forbidden \u2014 requires a premium subscription.",
             "content": {
               "application/json": {
                 "schema": {
@@ -51631,11 +63685,11 @@
                   }
                 },
                 "examples": {
-                  "No permission": {
+                  "Insufficient subscription": {
                     "value": {
                       "uuid": "00000000-0000-0000-0000-000000000000",
                       "code": 2005,
-                      "message": "User does not have permission to view this resource",
+                      "message": "User not permissioned for feature. Feature requires \"premium\" subscription access level.",
                       "name": "ForbiddenError",
                       "httpStatusCode": 403
                     }
@@ -51693,7 +63747,7 @@
     "/oidc/providers/{id}": {
       "get": {
         "operationId": "getOIDCProvider",
-        "description": "Get a specific OIDC Provider by ID",
+        "description": "Get a specific OIDC Provider by ID.\n\nRequires a **premium** subscription; organizations below that tier receive a `403`.\n\nIf the provider does not exist, belongs to another organization, or the caller\nlacks permission to view it, the endpoint responds with `401` (it does not\ndistinguish these cases with a `404`).\n",
         "tags": [
           "OIDC"
         ],
@@ -51819,7 +63873,7 @@
             }
           },
           "403": {
-            "description": "Forbidden",
+            "description": "Forbidden \u2014 requires a premium subscription.",
             "content": {
               "application/json": {
                 "schema": {
@@ -51848,45 +63902,13 @@
                   }
                 },
                 "examples": {
-                  "No permission": {
+                  "Insufficient subscription": {
                     "value": {
                       "uuid": "00000000-0000-0000-0000-000000000000",
                       "code": 2005,
-                      "message": "User does not have permission to view this resource",
+                      "message": "User not permissioned for feature. Feature requires \"premium\" subscription access level.",
                       "name": "ForbiddenError",
                       "httpStatusCode": 403
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "OIDC Provider not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "uuid": {
-                      "type": "string",
-                      "description": "Unique identifier associated with the error"
-                    },
-                    "code": {
-                      "type": "integer",
-                      "description": "fossa specific error code"
-                    },
-                    "message": {
-                      "type": "string",
-                      "description": "message associated with this error"
-                    },
-                    "name": {
-                      "type": "string",
-                      "description": "name of the error"
-                    },
-                    "httpStatusCode": {
-                      "type": "integer",
-                      "description": "http status code number"
                     }
                   }
                 }
@@ -51940,7 +63962,7 @@
       },
       "delete": {
         "operationId": "deleteOIDCProvider",
-        "description": "Delete an OIDC Provider. All associated trust relationships will be deleted as well.",
+        "description": "Delete an OIDC Provider. All associated trust relationships will be deleted as well.\n\nRequires a **premium** subscription; organizations below that tier receive a `403`.\n\nIf the provider does not exist, belongs to another organization, or the caller\nlacks permission to delete it, the endpoint responds with `401` (it does not\ndistinguish these cases with a `404`).\n",
         "tags": [
           "OIDC"
         ],
@@ -52052,7 +64074,7 @@
             }
           },
           "403": {
-            "description": "Forbidden",
+            "description": "Forbidden \u2014 requires a premium subscription.",
             "content": {
               "application/json": {
                 "schema": {
@@ -52081,45 +64103,13 @@
                   }
                 },
                 "examples": {
-                  "No permission": {
+                  "Insufficient subscription": {
                     "value": {
                       "uuid": "00000000-0000-0000-0000-000000000000",
                       "code": 2005,
-                      "message": "User does not have permission to view this resource",
+                      "message": "User not permissioned for feature. Feature requires \"premium\" subscription access level.",
                       "name": "ForbiddenError",
                       "httpStatusCode": 403
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "OIDC Provider not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "uuid": {
-                      "type": "string",
-                      "description": "Unique identifier associated with the error"
-                    },
-                    "code": {
-                      "type": "integer",
-                      "description": "fossa specific error code"
-                    },
-                    "message": {
-                      "type": "string",
-                      "description": "message associated with this error"
-                    },
-                    "name": {
-                      "type": "string",
-                      "description": "name of the error"
-                    },
-                    "httpStatusCode": {
-                      "type": "integer",
-                      "description": "http status code number"
                     }
                   }
                 }
@@ -52734,13 +64724,19 @@
                                     "example": "service-account-1"
                                   },
                                   "email": {
-                                    "type": "string",
-                                    "description": "The email of the service account associated with this trust relationship (if available)",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
+                                    "description": "The email of the service account associated with this trust relationship (`null` if the account has no email)",
                                     "example": "service-account@example.com"
                                   },
                                   "teamName": {
-                                    "type": "string",
-                                    "description": "The name of the team (if scope is team)",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
+                                    "description": "The name of the team. `null` for organization-scoped trust relationships (only team-scoped relationships have a team name).",
                                     "example": "Engineering Team"
                                   },
                                   "issuer": {
@@ -52751,7 +64747,6 @@
                                 },
                                 "required": [
                                   "username",
-                                  "teamName",
                                   "issuer"
                                 ]
                               }
@@ -53444,7 +65439,7 @@
     "/oidc/trust-relationships/{id}": {
       "get": {
         "operationId": "getOIDCTrustRelationship",
-        "description": "Get a specific OIDC Trust Relationship by ID",
+        "description": "Get a specific OIDC Trust Relationship by ID.\n\nRequires a **premium** subscription; organizations below that tier receive a `403`.\n\nIf the trust relationship does not exist, belongs to another organization, or the\ncaller lacks permission to view it, the endpoint responds with `401` (it does not\ndistinguish these cases with a `404`).\n",
         "tags": [
           "OIDC"
         ],
@@ -53610,13 +65605,19 @@
                           "example": "service-account-1"
                         },
                         "email": {
-                          "type": "string",
-                          "description": "The email of the service account associated with this trust relationship (if available)",
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "description": "The email of the service account associated with this trust relationship (`null` if the account has no email)",
                           "example": "service-account@example.com"
                         },
                         "teamName": {
-                          "type": "string",
-                          "description": "The name of the team (if scope is team)",
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "description": "The name of the team. `null` for organization-scoped trust relationships (only team-scoped relationships have a team name).",
                           "example": "Engineering Team"
                         },
                         "issuer": {
@@ -53627,7 +65628,6 @@
                       },
                       "required": [
                         "username",
-                        "teamName",
                         "issuer"
                       ]
                     }
@@ -53680,7 +65680,7 @@
             }
           },
           "403": {
-            "description": "Forbidden",
+            "description": "Forbidden \u2014 requires a premium subscription.",
             "content": {
               "application/json": {
                 "schema": {
@@ -53709,45 +65709,13 @@
                   }
                 },
                 "examples": {
-                  "No permission": {
+                  "Insufficient subscription": {
                     "value": {
                       "uuid": "00000000-0000-0000-0000-000000000000",
                       "code": 2005,
-                      "message": "User does not have permission to view this resource",
+                      "message": "User not permissioned for feature. Feature requires \"premium\" subscription access level.",
                       "name": "ForbiddenError",
                       "httpStatusCode": 403
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "OIDC Trust Relationship not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "uuid": {
-                      "type": "string",
-                      "description": "Unique identifier associated with the error"
-                    },
-                    "code": {
-                      "type": "integer",
-                      "description": "fossa specific error code"
-                    },
-                    "message": {
-                      "type": "string",
-                      "description": "message associated with this error"
-                    },
-                    "name": {
-                      "type": "string",
-                      "description": "name of the error"
-                    },
-                    "httpStatusCode": {
-                      "type": "integer",
-                      "description": "http status code number"
                     }
                   }
                 }
@@ -54484,7 +66452,7 @@
     "/oidc/token-exchange": {
       "post": {
         "operationId": "exchangeOIDCToken",
-        "description": "Exchange an OIDC token for a FOSSA API token",
+        "description": "Exchange an OIDC token for a FOSSA API token.\n\nThis endpoint is unauthenticated (no FOSSA API token is required); the caller\npresents an OIDC token issued by a trusted provider. Validation or lookup\nfailures (invalid token, unknown provider, or no matching trust relationship)\nare reported as a `400`.\n",
         "tags": [
           "OIDC"
         ],
@@ -54644,92 +66612,6 @@
               }
             }
           },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "uuid": {
-                      "type": "string",
-                      "description": "Unique identifier associated with the error"
-                    },
-                    "code": {
-                      "type": "integer",
-                      "description": "fossa specific error code"
-                    },
-                    "message": {
-                      "type": "string",
-                      "description": "message associated with this error"
-                    },
-                    "name": {
-                      "type": "string",
-                      "description": "name of the error"
-                    },
-                    "httpStatusCode": {
-                      "type": "integer",
-                      "description": "http status code number"
-                    }
-                  }
-                },
-                "examples": {
-                  "Bad API Token": {
-                    "value": {
-                      "uuid": "00000000-0000-0000-0000-000000000000",
-                      "code": 2010,
-                      "message": "API token is invalid",
-                      "name": "UnauthorizedError",
-                      "httpStatusCode": 401
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "uuid": {
-                      "type": "string",
-                      "description": "Unique identifier associated with the error"
-                    },
-                    "code": {
-                      "type": "integer",
-                      "description": "fossa specific error code"
-                    },
-                    "message": {
-                      "type": "string",
-                      "description": "message associated with this error"
-                    },
-                    "name": {
-                      "type": "string",
-                      "description": "name of the error"
-                    },
-                    "httpStatusCode": {
-                      "type": "integer",
-                      "description": "http status code number"
-                    }
-                  }
-                },
-                "examples": {
-                  "No permission": {
-                    "value": {
-                      "uuid": "00000000-0000-0000-0000-000000000000",
-                      "code": 2005,
-                      "message": "User does not have permission to view this resource",
-                      "name": "ForbiddenError",
-                      "httpStatusCode": 403
-                    }
-                  }
-                }
-              }
-            }
-          },
           "500": {
             "description": "Server Error",
             "content": {
@@ -54797,11 +66679,11 @@
           {
             "name": "path",
             "in": "query",
-            "required": true,
+            "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "The path to filter snippets by"
+            "description": "The path to filter snippets by. When omitted, paths are aggregated from the root."
           },
           {
             "name": "ids",
@@ -54858,6 +66740,23 @@
               }
             },
             "description": "Filter by package labels"
+          },
+          {
+            "name": "vendoredMatch",
+            "in": "query",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "vendored",
+                  "exVendored",
+                  "converted",
+                  "exConverted"
+                ]
+              }
+            },
+            "description": "Filter snippets by vendored/converted match status. Accepts one or more of:\n\n| Value | Description |\n|-------|-------------|\n| `vendored` | Include snippets that exist as a vendored dependency |\n| `exVendored` | Exclude snippets that exist as a vendored dependency |\n| `converted` | Include snippets that have been converted to vendored dependencies |\n| `exConverted` | Exclude snippets that have been converted to vendored dependencies |\n"
           }
         ],
         "responses": {
@@ -55040,6 +66939,49 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "NotFound",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Not Found": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2004,
+                      "message": "Project not found: custom+1/example$abc123",
+                      "name": "NotFoundError",
+                      "httpStatusCode": 404
+                    }
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -55126,6 +67068,23 @@
               }
             },
             "description": "Filter by package labels"
+          },
+          {
+            "name": "vendoredMatch",
+            "in": "query",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "vendored",
+                  "exVendored",
+                  "converted",
+                  "exConverted"
+                ]
+              }
+            },
+            "description": "Filter snippets by vendored/converted match status. Accepts one or more of:\n\n| Value | Description |\n|-------|-------------|\n| `vendored` | Include snippets that exist as a vendored dependency |\n| `exVendored` | Exclude snippets that exist as a vendored dependency |\n| `converted` | Include snippets that have been converted to vendored dependencies |\n| `exConverted` | Exclude snippets that have been converted to vendored dependencies |\n"
           },
           {
             "name": "sort",
@@ -55252,12 +67211,11 @@
                                 "status": {
                                   "type": "string",
                                   "enum": [
-                                    "approved",
                                     "denied",
                                     "flagged",
                                     "unknown"
                                   ],
-                                  "description": "Approval status of the license"
+                                  "description": "Approval status of the license (optional; absent for licenses with no issue)"
                                 },
                                 "issueId": {
                                   "type": "integer",
@@ -55266,8 +67224,7 @@
                               },
                               "required": [
                                 "signature",
-                                "type",
-                                "status"
+                                "type"
                               ]
                             },
                             "description": "Array of licenses associated with the snippet"
@@ -55425,6 +67382,14 @@
                               ]
                             },
                             "description": "Package labels assigned to this snippet"
+                          },
+                          "isVendored": {
+                            "type": "boolean",
+                            "description": "Whether the snippet exists as a vendored dependency"
+                          },
+                          "isConverted": {
+                            "type": "boolean",
+                            "description": "Whether the snippet has been converted to a vendored dependency"
                           }
                         },
                         "required": [
@@ -55439,7 +67404,9 @@
                           "highestMatchPercentage",
                           "licenses",
                           "labels",
-                          "issueCounts"
+                          "issueCounts",
+                          "isVendored",
+                          "isConverted"
                         ]
                       },
                       "description": "Array of snippets"
@@ -55454,17 +67421,17 @@
                       "minimum": 1,
                       "description": "Current page number"
                     },
-                    "count": {
+                    "pageSize": {
                       "type": "integer",
                       "minimum": 1,
-                      "description": "Number of items per page"
+                      "description": "Number of items requested per page"
                     }
                   },
                   "required": [
                     "results",
                     "totalCount",
                     "page",
-                    "count"
+                    "pageSize"
                   ]
                 }
               }
@@ -55598,6 +67565,49 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "NotFound",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Not Found": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2004,
+                      "message": "Project not found: custom+1/example$abc123",
+                      "name": "NotFoundError",
+                      "httpStatusCode": 404
+                    }
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -55684,6 +67694,23 @@
               }
             },
             "description": "Filter by package labels"
+          },
+          {
+            "name": "vendoredMatch",
+            "in": "query",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "vendored",
+                  "exVendored",
+                  "converted",
+                  "exConverted"
+                ]
+              }
+            },
+            "description": "Filter snippets by vendored/converted match status. Accepts one or more of:\n\n| Value | Description |\n|-------|-------------|\n| `vendored` | Include snippets that exist as a vendored dependency |\n| `exVendored` | Exclude snippets that exist as a vendored dependency |\n| `converted` | Include snippets that have been converted to vendored dependencies |\n| `exConverted` | Exclude snippets that have been converted to vendored dependencies |\n"
           }
         ],
         "responses": {
@@ -55834,6 +67861,49 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "NotFound",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Not Found": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2004,
+                      "message": "Project not found: custom+1/example$abc123",
+                      "name": "NotFoundError",
+                      "httpStatusCode": 404
+                    }
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -55920,6 +67990,23 @@
               }
             },
             "description": "Filter by package labels"
+          },
+          {
+            "name": "vendoredMatch",
+            "in": "query",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "vendored",
+                  "exVendored",
+                  "converted",
+                  "exConverted"
+                ]
+              }
+            },
+            "description": "Filter snippets by vendored/converted match status. Accepts one or more of:\n\n| Value | Description |\n|-------|-------------|\n| `vendored` | Include snippets that exist as a vendored dependency |\n| `exVendored` | Exclude snippets that exist as a vendored dependency |\n| `converted` | Include snippets that have been converted to vendored dependencies |\n| `exConverted` | Exclude snippets that have been converted to vendored dependencies |\n"
           },
           {
             "name": "sort",
@@ -56152,17 +68239,17 @@
                       "minimum": 1,
                       "description": "Current page number"
                     },
-                    "count": {
+                    "pageSize": {
                       "type": "integer",
                       "minimum": 1,
-                      "description": "Number of items per page"
+                      "description": "Number of items requested per page"
                     }
                   },
                   "required": [
                     "results",
                     "totalCount",
                     "page",
-                    "count"
+                    "pageSize"
                   ]
                 }
               }
@@ -56296,6 +68383,49 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "NotFound",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Not Found": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2004,
+                      "message": "Project not found: custom+1/example$abc123",
+                      "name": "NotFoundError",
+                      "httpStatusCode": 404
+                    }
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -56344,11 +68474,11 @@
           {
             "name": "path",
             "in": "query",
-            "required": true,
+            "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "The path to filter snippets by"
+            "description": "The path to filter snippets by. When omitted, paths are aggregated from the root."
           },
           {
             "name": "ids",
@@ -56405,6 +68535,23 @@
               }
             },
             "description": "Filter by package labels"
+          },
+          {
+            "name": "vendoredMatch",
+            "in": "query",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "vendored",
+                  "exVendored",
+                  "converted",
+                  "exConverted"
+                ]
+              }
+            },
+            "description": "Filter snippets by vendored/converted match status. Accepts one or more of:\n\n| Value | Description |\n|-------|-------------|\n| `vendored` | Include snippets that exist as a vendored dependency |\n| `exVendored` | Exclude snippets that exist as a vendored dependency |\n| `converted` | Include snippets that have been converted to vendored dependencies |\n| `exConverted` | Exclude snippets that have been converted to vendored dependencies |\n"
           }
         ],
         "responses": {
@@ -56587,6 +68734,49 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "NotFound",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Not Found": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2004,
+                      "message": "Project not found: custom+1/example$abc123",
+                      "name": "NotFoundError",
+                      "httpStatusCode": 404
+                    }
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -56696,6 +68886,23 @@
               }
             },
             "description": "Filter by package labels"
+          },
+          {
+            "name": "vendoredMatch",
+            "in": "query",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "vendored",
+                  "exVendored",
+                  "converted",
+                  "exConverted"
+                ]
+              }
+            },
+            "description": "Filter snippets by vendored/converted match status. Accepts one or more of:\n\n| Value | Description |\n|-------|-------------|\n| `vendored` | Include snippets that exist as a vendored dependency |\n| `exVendored` | Exclude snippets that exist as a vendored dependency |\n| `converted` | Include snippets that have been converted to vendored dependencies |\n| `exConverted` | Exclude snippets that have been converted to vendored dependencies |\n"
           },
           {
             "name": "sort",
@@ -56822,12 +69029,11 @@
                                 "status": {
                                   "type": "string",
                                   "enum": [
-                                    "approved",
                                     "denied",
                                     "flagged",
                                     "unknown"
                                   ],
-                                  "description": "Approval status of the license"
+                                  "description": "Approval status of the license (optional; absent for licenses with no issue)"
                                 },
                                 "issueId": {
                                   "type": "integer",
@@ -56836,8 +69042,7 @@
                               },
                               "required": [
                                 "signature",
-                                "type",
-                                "status"
+                                "type"
                               ]
                             },
                             "description": "Array of licenses associated with the snippet"
@@ -56995,6 +69200,14 @@
                               ]
                             },
                             "description": "Package labels assigned to this snippet"
+                          },
+                          "isVendored": {
+                            "type": "boolean",
+                            "description": "Whether the snippet exists as a vendored dependency"
+                          },
+                          "isConverted": {
+                            "type": "boolean",
+                            "description": "Whether the snippet has been converted to a vendored dependency"
                           }
                         },
                         "required": [
@@ -57009,7 +69222,9 @@
                           "highestMatchPercentage",
                           "licenses",
                           "labels",
-                          "issueCounts"
+                          "issueCounts",
+                          "isVendored",
+                          "isConverted"
                         ]
                       },
                       "description": "Array of snippets"
@@ -57024,17 +69239,17 @@
                       "minimum": 1,
                       "description": "Current page number"
                     },
-                    "count": {
+                    "pageSize": {
                       "type": "integer",
                       "minimum": 1,
-                      "description": "Number of items per page"
+                      "description": "Number of items requested per page"
                     }
                   },
                   "required": [
                     "results",
                     "totalCount",
                     "page",
-                    "count"
+                    "pageSize"
                   ]
                 }
               }
@@ -57168,6 +69383,49 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "NotFound",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Not Found": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2004,
+                      "message": "Project not found: custom+1/example$abc123",
+                      "name": "NotFoundError",
+                      "httpStatusCode": 404
+                    }
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -57277,6 +69535,23 @@
               }
             },
             "description": "Filter by package labels"
+          },
+          {
+            "name": "vendoredMatch",
+            "in": "query",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "vendored",
+                  "exVendored",
+                  "converted",
+                  "exConverted"
+                ]
+              }
+            },
+            "description": "Filter snippets by vendored/converted match status. Accepts one or more of:\n\n| Value | Description |\n|-------|-------------|\n| `vendored` | Include snippets that exist as a vendored dependency |\n| `exVendored` | Exclude snippets that exist as a vendored dependency |\n| `converted` | Include snippets that have been converted to vendored dependencies |\n| `exConverted` | Exclude snippets that have been converted to vendored dependencies |\n"
           },
           {
             "name": "sort",
@@ -57509,17 +69784,17 @@
                       "minimum": 1,
                       "description": "Current page number"
                     },
-                    "count": {
+                    "pageSize": {
                       "type": "integer",
                       "minimum": 1,
-                      "description": "Number of items per page"
+                      "description": "Number of items requested per page"
                     }
                   },
                   "required": [
                     "results",
                     "totalCount",
                     "page",
-                    "count"
+                    "pageSize"
                   ]
                 }
               }
@@ -57653,6 +69928,49 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "NotFound",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Not Found": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2004,
+                      "message": "Project not found: custom+1/example$abc123",
+                      "name": "NotFoundError",
+                      "httpStatusCode": 404
+                    }
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -57683,6 +70001,15 @@
               "type": "string"
             },
             "description": "The unique identifier of the snippet"
+          },
+          {
+            "name": "path",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "An optional file path used to hydrate the snippet match details for that path."
           }
         ],
         "responses": {
@@ -57727,6 +70054,10 @@
                             "file"
                           ],
                           "description": "Type of snippet detection (snippet=partial match, file=100% match)"
+                        },
+                        "matchCount": {
+                          "type": "integer",
+                          "description": "Total number of matches for this snippet"
                         },
                         "matches": {
                           "type": "array",
@@ -57807,12 +70138,11 @@
                               "status": {
                                 "type": "string",
                                 "enum": [
-                                  "approved",
                                   "denied",
                                   "flagged",
                                   "unknown"
                                 ],
-                                "description": "Approval status of the license"
+                                "description": "Approval status of the license (optional; absent for licenses with no issue)"
                               },
                               "issueId": {
                                 "type": "integer",
@@ -57821,8 +70151,7 @@
                             },
                             "required": [
                               "signature",
-                              "type",
-                              "status"
+                              "type"
                             ]
                           },
                           "description": "Array of licenses associated with the snippet"
@@ -57997,6 +70326,14 @@
                             }
                           },
                           "description": "Other versions of the package where this snippet was detected"
+                        },
+                        "isVendored": {
+                          "type": "boolean",
+                          "description": "Whether the snippet exists as a vendored dependency"
+                        },
+                        "isConverted": {
+                          "type": "boolean",
+                          "description": "Whether the snippet has been converted to a vendored dependency"
                         }
                       },
                       "required": [
@@ -58007,17 +70344,63 @@
                         "package",
                         "version",
                         "kind",
+                        "matchCount",
                         "matches",
                         "highestMatchPercentage",
                         "licenses",
                         "labels",
-                        "issueCounts"
+                        "issueCounts",
+                        "isVendored",
+                        "isConverted"
                       ]
                     }
                   },
                   "required": [
                     "snippet"
                   ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Bad Request Parameter/Body": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2003,
+                      "message": "Parse error at root.X: ...",
+                      "name": "BadRequestError",
+                      "httpStatusCode": 400
+                    }
+                  }
                 }
               }
             }
@@ -58140,7 +70523,11 @@
                 "examples": {
                   "SnippetNotFound": {
                     "value": {
-                      "error": "Snippet not found"
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2004,
+                      "message": "Snippet not found",
+                      "name": "NotFoundError",
+                      "httpStatusCode": 404
                     }
                   }
                 }
@@ -58306,6 +70693,49 @@
               }
             }
           },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Bad Request Parameter/Body": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2003,
+                      "message": "Parse error at root.X: ...",
+                      "name": "BadRequestError",
+                      "httpStatusCode": 400
+                    }
+                  }
+                }
+              }
+            }
+          },
           "401": {
             "description": "Unauthorized",
             "content": {
@@ -58424,7 +70854,11 @@
                 "examples": {
                   "SnippetMatchDetailsNotFound": {
                     "value": {
-                      "error": "Snippet match details not found"
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2004,
+                      "message": "Snippet match details not found",
+                      "name": "NotFoundError",
+                      "httpStatusCode": 404
                     }
                   }
                 }
@@ -58499,6 +70933,19 @@
                       "type": "string"
                     },
                     "description": "Filter by package labels"
+                  },
+                  "vendoredMatch": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "enum": [
+                        "vendored",
+                        "exVendored",
+                        "converted",
+                        "exConverted"
+                      ]
+                    },
+                    "description": "Filter by vendored/converted match status"
                   }
                 },
                 "required": [
@@ -58640,6 +71087,49 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "NotFound",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Not Found": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2004,
+                      "message": "Project not found: custom+1/example$abc123",
+                      "name": "NotFoundError",
+                      "httpStatusCode": 404
+                    }
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -58709,6 +71199,19 @@
                       "type": "string"
                     },
                     "description": "Filter by package labels"
+                  },
+                  "vendoredMatch": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "enum": [
+                        "vendored",
+                        "exVendored",
+                        "converted",
+                        "exConverted"
+                      ]
+                    },
+                    "description": "Filter by vendored/converted match status"
                   }
                 },
                 "required": [
@@ -58850,6 +71353,49 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "NotFound",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Not Found": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2004,
+                      "message": "Project not found: custom+1/example$abc123",
+                      "name": "NotFoundError",
+                      "httpStatusCode": 404
+                    }
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -58866,36 +71412,9 @@
             "ApiToken": []
           }
         ],
-        "parameters": [
-          {
-            "name": "page",
-            "description": "The page number for pagination (1-indexed)",
-            "required": false,
-            "in": "query",
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "default": 1
-            },
-            "example": 1
-          },
-          {
-            "name": "pageSize",
-            "description": "The number of items per page",
-            "required": false,
-            "in": "query",
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "maximum": 50,
-              "default": 50
-            },
-            "example": 50
-          }
-        ],
         "responses": {
           "200": {
-            "description": "A paginated list of saved report options",
+            "description": "A list of saved report options",
             "content": {
               "application/json": {
                 "schema": {
@@ -59005,10 +71524,6 @@
                                   "projects": {
                                     "type": "boolean",
                                     "description": "For release group reports, show which projects the dependency is present in"
-                                  },
-                                  "name": {
-                                    "type": "boolean",
-                                    "description": "The name of the dependency"
                                   },
                                   "authors": {
                                     "type": "boolean",
@@ -59131,32 +71646,14 @@
                           "updatedAt"
                         ]
                       }
-                    },
-                    "page": {
-                      "type": "integer",
-                      "description": "Current page number",
-                      "example": 1
-                    },
-                    "pageSize": {
-                      "type": "integer",
-                      "description": "Number of items per page",
-                      "example": 50
-                    },
-                    "total": {
-                      "type": "integer",
-                      "description": "Total number of report options",
-                      "example": 100
                     }
                   },
                   "required": [
-                    "results",
-                    "page",
-                    "pageSize",
-                    "total"
+                    "results"
                   ]
                 },
                 "examples": {
-                  "Paginated report options": {
+                  "Report options": {
                     "value": {
                       "results": [
                         {
@@ -59181,7 +71678,6 @@
                             },
                             "dependencyData": {
                               "projects": true,
-                              "name": true,
                               "authors": false,
                               "description": true,
                               "homepage": false,
@@ -59229,7 +71725,6 @@
                             },
                             "dependencyData": {
                               "projects": true,
-                              "name": true,
                               "authors": true,
                               "description": true,
                               "homepage": true,
@@ -59252,53 +71747,7 @@
                           "createdAt": "2024-01-16T14:20:00.000Z",
                           "updatedAt": "2024-01-16T14:20:00.000Z"
                         }
-                      ],
-                      "page": 1,
-                      "pageSize": 50,
-                      "total": 2
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "uuid": {
-                      "type": "string",
-                      "description": "Unique identifier associated with the error"
-                    },
-                    "code": {
-                      "type": "integer",
-                      "description": "fossa specific error code"
-                    },
-                    "message": {
-                      "type": "string",
-                      "description": "message associated with this error"
-                    },
-                    "name": {
-                      "type": "string",
-                      "description": "name of the error"
-                    },
-                    "httpStatusCode": {
-                      "type": "integer",
-                      "description": "http status code number"
-                    }
-                  }
-                },
-                "examples": {
-                  "Invalid page parameter": {
-                    "value": {
-                      "uuid": "00000000-0000-0000-0000-000000000000",
-                      "code": 2003,
-                      "message": "page must be a positive integer",
-                      "name": "BadRequestError",
-                      "httpStatusCode": 400
+                      ]
                     }
                   }
                 }
@@ -59503,10 +71952,6 @@
                             "type": "boolean",
                             "description": "For release group reports, show which projects the dependency is present in"
                           },
-                          "name": {
-                            "type": "boolean",
-                            "description": "The name of the dependency"
-                          },
                           "authors": {
                             "type": "boolean",
                             "description": "The authors of the dependency"
@@ -59634,7 +72079,6 @@
                       },
                       "dependencyData": {
                         "projects": true,
-                        "name": true,
                         "authors": false,
                         "description": true,
                         "homepage": false,
@@ -59681,7 +72125,6 @@
                       },
                       "dependencyData": {
                         "projects": true,
-                        "name": true,
                         "authors": true,
                         "description": true,
                         "homepage": true,
@@ -59814,10 +72257,6 @@
                             "projects": {
                               "type": "boolean",
                               "description": "For release group reports, show which projects the dependency is present in"
-                            },
-                            "name": {
-                              "type": "boolean",
-                              "description": "The name of the dependency"
                             },
                             "authors": {
                               "type": "boolean",
@@ -59964,7 +72403,6 @@
                         },
                         "dependencyData": {
                           "projects": true,
-                          "name": true,
                           "authors": false,
                           "description": true,
                           "homepage": false,
@@ -60014,7 +72452,6 @@
                         },
                         "dependencyData": {
                           "projects": true,
-                          "name": true,
                           "authors": true,
                           "description": true,
                           "homepage": true,
@@ -60388,9 +72825,6 @@
                           "projects": {
                             "type": "boolean"
                           },
-                          "name": {
-                            "type": "boolean"
-                          },
                           "authors": {
                             "type": "boolean"
                           },
@@ -60589,10 +73023,6 @@
                               "type": "boolean",
                               "description": "For release group reports, show which projects the dependency is present in"
                             },
-                            "name": {
-                              "type": "boolean",
-                              "description": "The name of the dependency"
-                            },
                             "authors": {
                               "type": "boolean",
                               "description": "The authors of the dependency"
@@ -60738,7 +73168,6 @@
                         },
                         "dependencyData": {
                           "projects": true,
-                          "name": true,
                           "authors": false,
                           "description": true,
                           "homepage": false,
@@ -61191,6 +73620,13 @@
               "application/json": {
                 "schema": {
                   "type": "object",
+                  "required": [
+                    "notificationDefaultEnabled",
+                    "notificationDefaultSlackScan",
+                    "notificationDefaultApiWebhookScan",
+                    "notificationDefaultEmailScanUsers",
+                    "notificationDefaultEmailScanUserType"
+                  ],
                   "properties": {
                     "notificationDefaultEnabled": {
                       "type": "boolean",
@@ -61199,6 +73635,10 @@
                     "notificationDefaultSlackScan": {
                       "type": "boolean",
                       "description": "the on/off status of slack notifications for scans"
+                    },
+                    "notificationDefaultApiWebhookScan": {
+                      "type": "boolean",
+                      "description": "the on/off status of API webhook notifications for scans"
                     },
                     "notificationDefaultEmailScanUsers": {
                       "type": "array",
@@ -61223,6 +73663,7 @@
                     "value": {
                       "notificationDefaultEnabled": true,
                       "notificationDefaultSlackScan": true,
+                      "notificationDefaultApiWebhookScan": false,
                       "notificationDefaultEmailScanUsers": [
                         1,
                         2
@@ -61387,6 +73828,13 @@
             "application/json": {
               "schema": {
                 "type": "object",
+                "required": [
+                  "notificationDefaultEnabled",
+                  "notificationDefaultSlackScan",
+                  "notificationDefaultApiWebhookScan",
+                  "notificationDefaultEmailScanUsers",
+                  "notificationDefaultEmailScanUserType"
+                ],
                 "properties": {
                   "notificationDefaultEnabled": {
                     "type": "boolean",
@@ -61395,6 +73843,10 @@
                   "notificationDefaultSlackScan": {
                     "type": "boolean",
                     "description": "the on/off status of slack notifications for scans"
+                  },
+                  "notificationDefaultApiWebhookScan": {
+                    "type": "boolean",
+                    "description": "the on/off status of API webhook notifications for scans"
                   },
                   "notificationDefaultEmailScanUsers": {
                     "type": "array",
@@ -61419,6 +73871,7 @@
                   "value": {
                     "notificationDefaultEnabled": true,
                     "notificationDefaultSlackScan": true,
+                    "notificationDefaultApiWebhookScan": false,
                     "notificationDefaultEmailScanUsers": [
                       1,
                       2
@@ -61558,6 +74011,49 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Invalid Settings Payload": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2003,
+                      "message": "Couldn't update organization settings",
+                      "name": "InvalidPayloadError",
+                      "httpStatusCode": 422
+                    }
+                  }
+                }
+              }
+            }
           }
         }
       },
@@ -61591,16 +74087,14 @@
                   "type": "string",
                   "enum": [
                     "notificationDefaultEmailScanUsers",
-                    "notificationDefaultEmailBuildUsers",
                     "notificationDefaultSlackScan",
-                    "notificationDefaultSlackBuild"
+                    "notificationDefaultApiWebhookScan"
                   ]
                 },
                 "example": [
                   "notificationDefaultEmailScanUsers",
-                  "notificationDefaultEmailBuildUsers",
                   "notificationDefaultSlackScan",
-                  "notificationDefaultSlackBuild"
+                  "notificationDefaultApiWebhookScan"
                 ]
               }
             }
@@ -62113,6 +74607,49 @@
                       "message": "Organization not found.",
                       "name": "NotFoundError",
                       "httpStatusCode": 404
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Invalid Settings Payload": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2003,
+                      "message": "Couldn't update organization settings",
+                      "name": "InvalidPayloadError",
+                      "httpStatusCode": 422
                     }
                   }
                 }
@@ -62857,6 +75394,472 @@
         }
       }
     },
+    "/organizations/{id}/logo": {
+      "delete": {
+        "operationId": "deleteOrganizationLogo",
+        "summary": "Delete organization logo",
+        "description": "Deletes the organization's logo from S3 storage and clears the image reference in the database.\n\nRequires the **Organization > Edit General Settings** permission.\n",
+        "tags": [
+          "Organization Settings"
+        ],
+        "security": [
+          {
+            "ApiToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "description": "The organization ID.",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "integer"
+            },
+            "example": 1234
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Logo successfully deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "description": "Indicates the logo was successfully deleted."
+                    }
+                  },
+                  "required": [
+                    "success"
+                  ]
+                },
+                "examples": {
+                  "Success": {
+                    "value": {
+                      "success": true
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Bad API Token": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2010,
+                      "message": "API token is invalid",
+                      "name": "UnauthorizedError",
+                      "httpStatusCode": 401
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "No permission": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2005,
+                      "message": "User does not have permission to view this resource",
+                      "name": "ForbiddenError",
+                      "httpStatusCode": 403
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/organizations/{id}/sbomReportDefaults": {
+      "put": {
+        "operationId": "updateOrganizationSBOMReportDefaults",
+        "summary": "Update organization SBOM report defaults",
+        "description": "Updates organization-level defaults used for SBOM report author metadata.\n\nThese values are used as fallback metadata when SBOM report requests omit\n`authorName`, `authorEmail`, or `supplier` query parameters.\n\nRequires a premium subscription.\n",
+        "tags": [
+          "Organization Settings"
+        ],
+        "security": [
+          {
+            "ApiToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "description": "The organization ID.",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "integer"
+            },
+            "example": 1234
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "sbomReportAuthorName": {
+                    "type": "string",
+                    "nullable": true
+                  },
+                  "sbomReportAuthorEmail": {
+                    "type": "string",
+                    "nullable": true
+                  },
+                  "sbomReportSupplier": {
+                    "type": "string",
+                    "nullable": true
+                  }
+                }
+              },
+              "examples": {
+                "UpdateSBOMReportDefaults": {
+                  "value": {
+                    "sbomReportAuthorName": "SBOM Team",
+                    "sbomReportAuthorEmail": "sbom@example.com",
+                    "sbomReportSupplier": "FOSSA"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "sbomReportAuthorName",
+                    "sbomReportAuthorEmail",
+                    "sbomReportSupplier"
+                  ],
+                  "properties": {
+                    "sbomReportAuthorName": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "sbomReportAuthorEmail": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "sbomReportSupplier": {
+                      "type": "string",
+                      "nullable": true
+                    }
+                  }
+                },
+                "examples": {
+                  "UpdatedSBOMReportDefaults": {
+                    "value": {
+                      "sbomReportAuthorName": "SBOM Team",
+                      "sbomReportAuthorEmail": "sbom@example.com",
+                      "sbomReportSupplier": "FOSSA"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Bad Request": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2003,
+                      "message": "Invalid request",
+                      "name": "BadRequestError",
+                      "httpStatusCode": 400
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Bad API Token": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2010,
+                      "message": "API token is invalid",
+                      "name": "UnauthorizedError",
+                      "httpStatusCode": 401
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden \u2014 the user lacks the required permission, or the organization does not have a premium subscription.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "No permission": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2005,
+                      "message": "User does not have permission to view this resource",
+                      "name": "ForbiddenError",
+                      "httpStatusCode": 403
+                    }
+                  },
+                  "Insufficient subscription": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2005,
+                      "message": "User not permissioned for feature. Feature requires \"premium\" subscription access level.",
+                      "name": "ForbiddenError",
+                      "httpStatusCode": 403
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFound",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "No Organization Found": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2004,
+                      "message": "Organization not found.",
+                      "name": "NotFoundError",
+                      "httpStatusCode": 404
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Server Error": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2009,
+                      "message": "Sorry, we've encountered an unexpected error. We've recorded it. If you continue to see this, contact support at support@fossa.com and include the unique reference code: 00000000-0000-0000-0000-000000000000",
+                      "name": "InternalServerError",
+                      "httpStatusCode": 500
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/organizations/{id}/saml": {
       "put": {
         "operationId": "updateOrganizationSamlSettings",
@@ -63402,6 +76405,600 @@
         }
       }
     },
+    "/organizations/{id}/scim": {
+      "get": {
+        "operationId": "getOrganizationScimStatus",
+        "description": "Get the SCIM provisioning status for an organization, reporting whether provisioning is currently active and whether the SSO method it requires is configured. Requires the `scimProvisioning` feature flag.",
+        "tags": [
+          "Organization Settings"
+        ],
+        "security": [
+          {
+            "ApiToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "isEnabled",
+                    "isSsoConfigured"
+                  ],
+                  "properties": {
+                    "isEnabled": {
+                      "type": "boolean",
+                      "description": "Whether SCIM provisioning is currently active for the organization. True when the organization has an enabled SCIM token; revoking the token turns this off."
+                    },
+                    "isSsoConfigured": {
+                      "type": "boolean",
+                      "description": "Whether the organization has an SSO method (SAML, LDAP, or Google) configured. SCIM provisions SSO-only users, so a SCIM token cannot be generated until this is true."
+                    }
+                  }
+                },
+                "examples": {
+                  "ScimStatus": {
+                    "value": {
+                      "isEnabled": true,
+                      "isSsoConfigured": true
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Bad API Token": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2010,
+                      "message": "API token is invalid",
+                      "name": "UnauthorizedError",
+                      "httpStatusCode": 401
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "No permission": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2005,
+                      "message": "User does not have permission to view this resource",
+                      "name": "ForbiddenError",
+                      "httpStatusCode": 403
+                    }
+                  },
+                  "SCIM provisioning not enabled": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2005,
+                      "message": "SCIM provisioning is not enabled for this organization.",
+                      "name": "ForbiddenError",
+                      "httpStatusCode": 403
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFound",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "No Organization Found": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2004,
+                      "message": "Organization not found.",
+                      "name": "NotFoundError",
+                      "httpStatusCode": 404
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/organizations/{id}/scim/token": {
+      "post": {
+        "operationId": "generateOrganizationScimToken",
+        "description": "Generate a SCIM bearer token for an organization, for an identity provider to authenticate against the `/api/scim` endpoints. Any existing scim token for the organization is revoked first, so at most one is ever valid. The token is returned only in this response and cannot be retrieved again. Requires the `scimProvisioning` feature flag and a configured SSO method.",
+        "tags": [
+          "Organization Settings"
+        ],
+        "security": [
+          {
+            "ApiToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "token"
+                  ],
+                  "properties": {
+                    "token": {
+                      "type": "string",
+                      "description": "The generated SCIM bearer token, for the identity provider to authenticate against the `/api/scim` endpoints. FOSSA stores only a hash of it, so this response is the only time it is ever returned \u2014 it cannot be retrieved again afterward."
+                    }
+                  }
+                },
+                "examples": {
+                  "ScimToken": {
+                    "value": {
+                      "token": "3f8a1c9e5b2d47a06e1f8c3b9d2a5e74c6f0b83d1e9a4c72f5b8d0a6e3c17b94"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "No SSO method configured": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2003,
+                      "message": "SCIM requires an SSO method to be configured for this organization.",
+                      "name": "BadRequestError",
+                      "httpStatusCode": 400
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Bad API Token": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2010,
+                      "message": "API token is invalid",
+                      "name": "UnauthorizedError",
+                      "httpStatusCode": 401
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "No permission": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2005,
+                      "message": "User does not have permission to view this resource",
+                      "name": "ForbiddenError",
+                      "httpStatusCode": 403
+                    }
+                  },
+                  "SCIM provisioning not enabled": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2005,
+                      "message": "SCIM provisioning is not enabled for this organization.",
+                      "name": "ForbiddenError",
+                      "httpStatusCode": 403
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFound",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "No Organization Found": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2004,
+                      "message": "Organization not found.",
+                      "name": "NotFoundError",
+                      "httpStatusCode": 404
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "revokeOrganizationScimToken",
+        "description": "Revoke the organization's SCIM token, disabling SCIM provisioning. The identity provider can no longer reach the `/api/scim` endpoints, but users it has already provisioned are left untouched. Succeeds even if the organization has no active token. Requires the `scimProvisioning` feature flag.",
+        "tags": [
+          "Organization Settings"
+        ],
+        "security": [
+          {
+            "ApiToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No content - SCIM token successfully revoked"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Bad API Token": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2010,
+                      "message": "API token is invalid",
+                      "name": "UnauthorizedError",
+                      "httpStatusCode": 401
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "No permission": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2005,
+                      "message": "User does not have permission to view this resource",
+                      "name": "ForbiddenError",
+                      "httpStatusCode": 403
+                    }
+                  },
+                  "SCIM provisioning not enabled": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2005,
+                      "message": "SCIM provisioning is not enabled for this organization.",
+                      "name": "ForbiddenError",
+                      "httpStatusCode": 403
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFound",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "No Organization Found": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2004,
+                      "message": "Organization not found.",
+                      "name": "NotFoundError",
+                      "httpStatusCode": 404
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/organizations/{id}/settings/languages/pod": {
       "get": {
         "operationId": "getOrganizationCocoapodsSettings",
@@ -63735,6 +77332,49 @@
                       "message": "Organization not found.",
                       "name": "NotFoundError",
                       "httpStatusCode": 404
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Invalid Settings Payload": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2003,
+                      "message": "Couldn't update organization settings",
+                      "name": "InvalidPayloadError",
+                      "httpStatusCode": 422
                     }
                   }
                 }
@@ -64194,6 +77834,49 @@
               }
             }
           },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Invalid Settings Payload": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2003,
+                      "message": "Couldn't update organization settings",
+                      "name": "InvalidPayloadError",
+                      "httpStatusCode": 422
+                    }
+                  }
+                }
+              }
+            }
+          },
           "500": {
             "description": "Server Error",
             "content": {
@@ -64647,6 +78330,49 @@
                       "message": "Organization not found.",
                       "name": "NotFoundError",
                       "httpStatusCode": 404
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Invalid Settings Payload": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2003,
+                      "message": "Couldn't update organization settings",
+                      "name": "InvalidPayloadError",
+                      "httpStatusCode": 422
                     }
                   }
                 }
@@ -65168,6 +78894,49 @@
               }
             }
           },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Invalid Settings Payload": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2003,
+                      "message": "Couldn't update organization settings",
+                      "name": "InvalidPayloadError",
+                      "httpStatusCode": 422
+                    }
+                  }
+                }
+              }
+            }
+          },
           "500": {
             "description": "Server Error",
             "content": {
@@ -65627,6 +79396,49 @@
               }
             }
           },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Invalid Settings Payload": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2003,
+                      "message": "Couldn't update organization settings",
+                      "name": "InvalidPayloadError",
+                      "httpStatusCode": 422
+                    }
+                  }
+                }
+              }
+            }
+          },
           "500": {
             "description": "Server Error",
             "content": {
@@ -66080,6 +79892,49 @@
                       "message": "Organization not found.",
                       "name": "NotFoundError",
                       "httpStatusCode": 404
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Invalid Settings Payload": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2003,
+                      "message": "Couldn't update organization settings",
+                      "name": "InvalidPayloadError",
+                      "httpStatusCode": 422
                     }
                   }
                 }
@@ -66662,6 +80517,49 @@
               }
             }
           },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Invalid Settings Payload": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2003,
+                      "message": "Couldn't update organization settings",
+                      "name": "InvalidPayloadError",
+                      "httpStatusCode": 422
+                    }
+                  }
+                }
+              }
+            }
+          },
           "500": {
             "description": "Server Error",
             "content": {
@@ -67225,6 +81123,49 @@
                       "message": "Organization not found.",
                       "name": "NotFoundError",
                       "httpStatusCode": 404
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier associated with the error"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "description": "fossa specific error code"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "message associated with this error"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "name of the error"
+                    },
+                    "httpStatusCode": {
+                      "type": "integer",
+                      "description": "http status code number"
+                    }
+                  }
+                },
+                "examples": {
+                  "Invalid Settings Payload": {
+                    "value": {
+                      "uuid": "00000000-0000-0000-0000-000000000000",
+                      "code": 2003,
+                      "message": "Couldn't update organization settings",
+                      "name": "InvalidPayloadError",
+                      "httpStatusCode": 422
                     }
                   }
                 }
@@ -68035,6 +81976,26 @@
                       "type": "string"
                     }
                   },
+                  "components": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "description": "Available Jira components to include when exporting tickets. Components can be made required in Jira and are passed by ID when creating issues.",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "description": "The corresponding component ID in the Jira site"
+                        },
+                        "displayName": {
+                          "type": "string",
+                          "description": "Display name of the component as shown in FOSSA"
+                        }
+                      }
+                    }
+                  },
                   "jiraProjectIds": {
                     "type": [
                       "array",
@@ -68063,7 +82024,7 @@
                           "description": "Display name to use in FOSSA"
                         },
                         "isRequired": {
-                          "type": "string",
+                          "type": "boolean",
                           "description": "On/off switch to tell FOSSA if the field is required when exporting tickets"
                         },
                         "defaultValue": {
@@ -68428,6 +82389,26 @@
                       "type": "string"
                     }
                   },
+                  "components": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "description": "Available Jira components to include when exporting tickets. Components can be made required in Jira and are passed by ID when creating issues.",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "description": "The corresponding component ID in the Jira site"
+                        },
+                        "displayName": {
+                          "type": "string",
+                          "description": "Display name of the component as shown in FOSSA"
+                        }
+                      }
+                    }
+                  },
                   "jiraProjectIds": {
                     "type": [
                       "array",
@@ -68456,7 +82437,7 @@
                           "description": "Display name to use in FOSSA"
                         },
                         "isRequired": {
-                          "type": "string",
+                          "type": "boolean",
                           "description": "On/off switch to tell FOSSA if the field is required when exporting tickets"
                         },
                         "defaultValue": {
@@ -68606,6 +82587,26 @@
                         "type": "string"
                       }
                     },
+                    "components": {
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "description": "Available Jira components to include when exporting tickets. Components can be made required in Jira and are passed by ID when creating issues.",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "description": "The corresponding component ID in the Jira site"
+                          },
+                          "displayName": {
+                            "type": "string",
+                            "description": "Display name of the component as shown in FOSSA"
+                          }
+                        }
+                      }
+                    },
                     "jiraProjectIds": {
                       "type": [
                         "array",
@@ -68634,7 +82635,7 @@
                             "description": "Display name to use in FOSSA"
                           },
                           "isRequired": {
-                            "type": "string",
+                            "type": "boolean",
                             "description": "On/off switch to tell FOSSA if the field is required when exporting tickets"
                           },
                           "defaultValue": {
@@ -68677,7 +82678,7 @@
                       "credentials": {
                         "basic": {
                           "username": "jira_user",
-                          "password": "········"
+                          "password": "\u00b7\u00b7\u00b7\u00b7\u00b7\u00b7\u00b7\u00b7"
                         }
                       },
                       "headers": {},
@@ -68964,6 +82965,26 @@
                           "type": "string"
                         }
                       },
+                      "components": {
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "description": "Available Jira components to include when exporting tickets. Components can be made required in Jira and are passed by ID when creating issues.",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "description": "The corresponding component ID in the Jira site"
+                            },
+                            "displayName": {
+                              "type": "string",
+                              "description": "Display name of the component as shown in FOSSA"
+                            }
+                          }
+                        }
+                      },
                       "jiraProjectIds": {
                         "type": [
                           "array",
@@ -68992,7 +83013,7 @@
                               "description": "Display name to use in FOSSA"
                             },
                             "isRequired": {
-                              "type": "string",
+                              "type": "boolean",
                               "description": "On/off switch to tell FOSSA if the field is required when exporting tickets"
                             },
                             "defaultValue": {
@@ -69037,7 +83058,7 @@
                         "credentials": {
                           "basic": {
                             "username": "jira_user",
-                            "password": "········"
+                            "password": "\u00b7\u00b7\u00b7\u00b7\u00b7\u00b7\u00b7\u00b7"
                           }
                         },
                         "headers": {},
@@ -69072,7 +83093,7 @@
                         "credentials": {
                           "basic": {
                             "username": "jira_user2",
-                            "password": "········"
+                            "password": "\u00b7\u00b7\u00b7\u00b7\u00b7\u00b7\u00b7\u00b7"
                           }
                         },
                         "headers": {},
@@ -69323,12 +83344,12 @@
           },
           {
             "name": "startingAfter",
-            "description": "The id to start after to filter audit logs to",
+            "description": "The audit log row id to start after (exclusive). Used as a cursor for pagination.",
             "required": false,
             "in": "query",
             "schema": {
               "type": "string",
-              "format": "date-time"
+              "example": "12345"
             }
           },
           {
@@ -69562,7 +83583,7 @@
                     "value": "Forbidden"
                   },
                   "Org not permissioned": {
-                    "value": "User not permissioned for feature. Feature requires premium subscription access level."
+                    "value": "User not permissioned for feature. Feature requires \"premium\" subscription access level."
                   }
                 }
               }
@@ -69786,7 +83807,7 @@
                   },
                   "Subscription required": {
                     "value": {
-                      "message": "User not permissioned for feature. Feature requires premium subscription access level."
+                      "message": "User not permissioned for feature. Feature requires \"premium\" subscription access level."
                     }
                   }
                 }
@@ -69985,12 +84006,12 @@
           },
           {
             "name": "startingAfter",
-            "description": "The id to start after to filter audit logs to",
+            "description": "The audit log row id to start after (exclusive). Used as a cursor for pagination.",
             "required": false,
             "in": "query",
             "schema": {
               "type": "string",
-              "format": "date-time"
+              "example": "12345"
             }
           },
           {
@@ -70036,7 +84057,7 @@
                     "value": "Forbidden"
                   },
                   "Org not permissioned": {
-                    "value": "User not permissioned for feature. Feature requires premium subscription access level."
+                    "value": "User not permissioned for feature. Feature requires \"premium\" subscription access level."
                   }
                 }
               }
@@ -70091,7 +84112,7 @@
     "/components/signed_url": {
       "get": {
         "operationId": "getSignedUrl",
-        "description": "Get a signed URL for uploading component files to FOSSA, to expire in 5 minutes' time.  Only SBOM imports are supported for non-premium accounts.",
+        "description": "Get a signed URL for uploading component files to FOSSA, to expire in 5 minutes' time.  Only SBOM imports are supported for non-premium accounts.  This endpoint accepts push-only tokens in addition to full API tokens.",
         "tags": [
           "Components"
         ],
@@ -70121,10 +84142,11 @@
               "type": "string",
               "enum": [
                 "archive",
-                "sbom"
+                "sbom",
+                "binary"
               ]
             },
-            "description": "The kind of file to be uploaded to the signed URL. If 'archive', the signed URL is for uplaoding a directory of source code. If 'sbom', the signed URL is for uploading an SBOM file (CycloneDX or SPDX).\n"
+            "description": "The kind of file to be uploaded to the signed URL. If 'archive', the signed URL is for uplaoding a directory of source code. If 'sbom', the signed URL is for uploading an SBOM file (CycloneDX or SPDX). If 'binary', the signed URL is for uploading a binary for binary decomposition; this is billing-gated and may return a 403 if the organization is outside its binary decomposition billing term or has exhausted its allowance.\n"
           }
         ],
         "security": [
@@ -70184,6 +84206,15 @@
                   },
                   "Org not permissioned": {
                     "value": "User not permissioned for feature. Feature requires premium subscription access level."
+                  },
+                  "Archive upload not permissioned": {
+                    "value": "Requires archiveAndLicenseUpload feature flag and premium access level."
+                  },
+                  "Outside binary decomposition billing term": {
+                    "value": "Outside of binary decomposition billing term. Contact support."
+                  },
+                  "Binary decomposition allowance exhausted": {
+                    "value": "You are out of binary decompositions. Contact support to increase your limit."
                   }
                 }
               }
@@ -70216,7 +84247,7 @@
     "/components/build": {
       "post": {
         "operationId": "build",
-        "description": "Upload a component and start asynchronously building it.  Only SBOM imports are supported for non-premium accounts.",
+        "description": "Upload a component and start asynchronously building it.  Only SBOM imports are supported for non-premium accounts.  This endpoint accepts push-only tokens in addition to full API tokens.",
         "tags": [
           "Components"
         ],
@@ -70485,6 +84516,140 @@
                       "httpStatusCode": 500
                     }
                   }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/components/resolve-purls": {
+      "post": {
+        "operationId": "resolvePurls",
+        "description": "Resolve a list of PURLs to the FOSSA components they identify and return the licensing data FOSSA has for each. PURLs that FOSSA has not analyzed yet are queued for an asynchronous build; poll again to retrieve their licensing once the build resolves. This endpoint accepts push-only tokens in addition to full API tokens.\n",
+        "tags": [
+          "Components"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "purls"
+                ],
+                "properties": {
+                  "purls": {
+                    "type": "array",
+                    "minItems": 1,
+                    "maxItems": 100,
+                    "description": "The PURLs (package URLs) to resolve. Between 1 and 100 entries.",
+                    "items": {
+                      "type": "string",
+                      "example": "pkg:maven/org.springframework.boot/spring-boot@3.5.6"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiToken": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A mapping from each supplied PURL to its resolution result: 'success' with licensing data, 'queued' if a build was needed to determine licensing, or 'error' if the PURL could not be resolved.\n",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "results": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "oneOf": [
+                          {
+                            "type": "object",
+                            "description": "The PURL resolved to a component with licensing data.",
+                            "properties": {
+                              "status": {
+                                "type": "string",
+                                "enum": [
+                                  "success"
+                                ]
+                              },
+                              "locator": {
+                                "type": "string"
+                              },
+                              "licenses": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object"
+                                }
+                              }
+                            }
+                          },
+                          {
+                            "type": "object",
+                            "description": "A build was queued to determine the component's licensing.",
+                            "properties": {
+                              "status": {
+                                "type": "string",
+                                "enum": [
+                                  "queued"
+                                ]
+                              },
+                              "locator": {
+                                "type": "string"
+                              },
+                              "taskId": {
+                                "type": "integer"
+                              }
+                            }
+                          },
+                          {
+                            "type": "object",
+                            "description": "The PURL could not be resolved to a component.",
+                            "properties": {
+                              "status": {
+                                "type": "string",
+                                "enum": [
+                                  "error"
+                                ]
+                              },
+                              "error": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "FossaForbiddenError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "FossaApiError"
                 }
               }
             }
@@ -70763,6 +84928,24 @@
               }
             }
           },
+          "packageLabels": {
+            "type": "array",
+            "description": "The organization's package labels, each with the count of packages it is assigned to.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "packageCount": {
+                  "type": "integer"
+                }
+              }
+            }
+          },
           "title": {
             "type": "string"
           },
@@ -70777,6 +84960,16 @@
           },
           "disableNonCustomTeamUserRoles": {
             "type": "boolean"
+          },
+          "snippetSourceCodeRetentionDays": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 30,
+            "description": "Number of days source code from snippet matches is retained. Must be between 1 and 30."
+          },
+          "licenseConcludedEnabled": {
+            "type": "boolean",
+            "description": "Whether the license-concluded workflow is enabled for the organization."
           }
         }
       },
@@ -70785,6 +84978,13 @@
         "properties": {
           "labels": {
             "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "packageLabels": {
+            "type": "array",
+            "description": "Package label names to set on the organization.",
             "items": {
               "type": "string"
             }
@@ -70803,6 +85003,16 @@
           },
           "disableNonCustomTeamUserRoles": {
             "type": "boolean"
+          },
+          "snippetSourceCodeRetentionDays": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 30,
+            "description": "Number of days to retain source code from snippet matches. Must be between 1 and 30, or a 400 is returned."
+          },
+          "licenseConcludedEnabled": {
+            "type": "boolean",
+            "description": "Whether the license-concluded workflow is enabled for the organization."
           }
         }
       },
@@ -70856,6 +85066,10 @@
           "projectDefaultSnippetLicensingIssueScanningEnabled": {
             "type": "boolean",
             "description": "Enable or disable snippet licensing issue scanning by default for projects in the organization"
+          },
+          "projectDefaultVendoredLicensingIssueScanningEnabled": {
+            "type": "boolean",
+            "description": "Enable or disable licensing issue scanning for vendored dependencies by default for projects in the organization"
           }
         }
       },
@@ -70877,6 +85091,10 @@
           "projectDefaultSnippetSecurityIssueScanningEnabled": {
             "type": "boolean",
             "description": "Enable or disable snippet security issue scanning by default for projects in the organization"
+          },
+          "projectDefaultVendoredSecurityIssueScanningEnabled": {
+            "type": "boolean",
+            "description": "Enable or disable security issue scanning for vendored dependencies by default for projects in the organization"
           }
         }
       },
@@ -70894,6 +85112,10 @@
           },
           "projectDefaultStatusCheckFilterQuality": {
             "type": "integer"
+          },
+          "projectDefaultVendoredQualityIssueScanningEnabled": {
+            "type": "boolean",
+            "description": "Enable or disable quality issue scanning for vendored dependencies by default for projects in the organization"
           }
         }
       },
@@ -70913,6 +85135,13 @@
       },
       "NotificationsSettings": {
         "type": "object",
+        "required": [
+          "notificationDefaultEnabled",
+          "notificationDefaultSlackScan",
+          "notificationDefaultApiWebhookScan",
+          "notificationDefaultEmailScanUsers",
+          "notificationDefaultEmailScanUserType"
+        ],
         "properties": {
           "notificationDefaultEnabled": {
             "type": "boolean",
@@ -70921,6 +85150,10 @@
           "notificationDefaultSlackScan": {
             "type": "boolean",
             "description": "the on/off status of slack notifications for scans"
+          },
+          "notificationDefaultApiWebhookScan": {
+            "type": "boolean",
+            "description": "the on/off status of API webhook notifications for scans"
           },
           "notificationDefaultEmailScanUsers": {
             "type": "array",
@@ -71279,6 +85512,26 @@
               "type": "string"
             }
           },
+          "components": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "description": "Available Jira components to include when exporting tickets. Components can be made required in Jira and are passed by ID when creating issues.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "description": "The corresponding component ID in the Jira site"
+                },
+                "displayName": {
+                  "type": "string",
+                  "description": "Display name of the component as shown in FOSSA"
+                }
+              }
+            }
+          },
           "jiraProjectIds": {
             "type": [
               "array",
@@ -71307,7 +85560,7 @@
                   "description": "Display name to use in FOSSA"
                 },
                 "isRequired": {
-                  "type": "string",
+                  "type": "boolean",
                   "description": "On/off switch to tell FOSSA if the field is required when exporting tickets"
                 },
                 "defaultValue": {
@@ -72685,7 +86938,7 @@
           "credentials": {
             "basic": {
               "username": "jira_user",
-              "password": "········"
+              "password": "\u00b7\u00b7\u00b7\u00b7\u00b7\u00b7\u00b7\u00b7"
             }
           },
           "headers": {},
@@ -72723,7 +86976,7 @@
             "credentials": {
               "basic": {
                 "username": "jira_user",
-                "password": "········"
+                "password": "\u00b7\u00b7\u00b7\u00b7\u00b7\u00b7\u00b7\u00b7"
               }
             },
             "headers": {},
@@ -72758,7 +87011,7 @@
             "credentials": {
               "basic": {
                 "username": "jira_user2",
-                "password": "········"
+                "password": "\u00b7\u00b7\u00b7\u00b7\u00b7\u00b7\u00b7\u00b7"
               }
             },
             "headers": {},
@@ -72881,7 +87134,19 @@
               "name": "Proprietary License",
               "matchCriteria": "[Pp]roprietary [Ll]icense"
             }
-          ]
+          ],
+          "requirePolicyOnUpload": false,
+          "archiveUploadAndCLILicenseScanEnabled": true,
+          "supportsPreflightChecks": true,
+          "supportsGitBackedCargoLocators": true,
+          "supportsFasterRGAddProject": true,
+          "subscription": "Premium",
+          "packageLabelScopes": [
+            "org",
+            "project",
+            "revision"
+          ],
+          "snippetScanSourceCodeRetentionDays": 30
         }
       },
       "GeneralOrganizationSettings": {
@@ -72893,11 +87158,20 @@
               "projectCount": 10
             }
           ],
+          "packageLabels": [
+            {
+              "name": "internal",
+              "id": 5,
+              "packageCount": 42
+            }
+          ],
           "title": "title",
           "email": "test@fossa.com",
           "defaultRoleId": 1,
           "dependencySignatures": "1,2,3",
-          "disableNonCustomTeamUserRoles": false
+          "disableNonCustomTeamUserRoles": false,
+          "snippetSourceCodeRetentionDays": 30,
+          "licenseConcludedEnabled": true
         }
       },
       "EditingGeneralOrganizationSettings": {
@@ -72906,11 +87180,17 @@
             "critical",
             "low"
           ],
+          "packageLabels": [
+            "internal",
+            "external"
+          ],
           "title": "title",
           "email": "test@fossa.com",
           "defaultRoleId": 1,
           "dependencySignatures": "1,2,3",
-          "disableNonCustomTeamUserRoles": false
+          "disableNonCustomTeamUserRoles": false,
+          "snippetSourceCodeRetentionDays": 30,
+          "licenseConcludedEnabled": true
         }
       },
       "SecurityIssueSettings": {
@@ -72919,7 +87199,8 @@
           "projectDefaultSecurityIssueScanningEnabled": true,
           "projectDefaultSecurityStatusCheckEnabled": true,
           "projectDefaultStatusCheckFilterVulnerability": 4,
-          "projectDefaultSnippetSecurityIssueScanningEnabled": false
+          "projectDefaultSnippetSecurityIssueScanningEnabled": false,
+          "projectDefaultVendoredSecurityIssueScanningEnabled": false
         }
       },
       "QualityIssueSettings": {
@@ -72927,7 +87208,8 @@
           "defaultQualityPolicyId": 1,
           "projectDefaultQualityIssueScanningEnabled": true,
           "projectDefaultQualityStatusCheckEnabled": true,
-          "projectDefaultStatusCheckFilterQuality": 1
+          "projectDefaultStatusCheckFilterQuality": 1,
+          "projectDefaultVendoredQualityIssueScanningEnabled": false
         }
       },
       "ContainerIssueSettings": {
@@ -72941,6 +87223,7 @@
         "value": {
           "notificationDefaultEnabled": true,
           "notificationDefaultSlackScan": true,
+          "notificationDefaultApiWebhookScan": false,
           "notificationDefaultEmailScanUsers": [
             1,
             2


### PR DESCRIPTION
## Summary
- Refreshes `plugins/fossa/swagger.json` from the live FOSSA OpenAPI spec (4.32.3 → 4.34.66), clearing the drift reported in #139
- No Go changes needed: the reported nullable-field change (`email`/`username` on `GET /teams/{id}/members`) unmarshals safely into existing string fields; `plugins/fossa/fossa-api-watchlist.json` documented flags were re-validated against the new spec and require no changes

## Test plan
- [x] `python3 scripts/fossa-api-watch.py --baseline plugins/fossa/swagger.json --watchlist plugins/fossa/fossa-api-watchlist.json --report-file ...` reports no drift
- [x] `make test-package PKG=plugins/fossa` passes (including live E2E tests)

Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)