### PR TITLE
discovers FOSSA invitations sent directly through FOSSA's UI, fixes soft-delete upsert bug

### DIFF
--- a/cmd/fossa-poller/main.go
+++ b/cmd/fossa-poller/main.go
@@ -24,6 +24,11 @@ import (
 
 const defaultDBPath = "/data/maintainers.db"
 
+// fossaInviteTTL mirrors FOSSA's documented 48-hour invitation lifetime
+// (see plugins/fossa/user-invites.md). Invitations older than this are
+// re-sent rather than left to report a stale "pending" status.
+const fossaInviteTTL = 48 * time.Hour
+
 func main() {
 	logger := log.New(os.Stdout, "fossa-poller: ", log.LstdFlags)
 
@@ -108,7 +113,6 @@ func pollFossaInvites(ctx context.Context, logger *log.Logger, store *db.SQLStor
 	}
 
 	now := time.Now().UTC()
-	const inviteTTL = 72 * time.Hour
 	for _, invite := range dbInvites {
 		email := strings.TrimSpace(invite.ServiceEmail)
 		if email == "" || strings.EqualFold(email, "EMAIL_MISSING") {
@@ -132,7 +136,7 @@ func pollFossaInvites(ctx context.Context, logger *log.Logger, store *db.SQLStor
 			continue
 		}
 
-		if invite.SentAt != nil && now.Sub(*invite.SentAt) > inviteTTL {
+		if invite.SentAt != nil && now.Sub(*invite.SentAt) > fossaInviteTTL {
 			if err := client.SendUserInvitation(email); err != nil && !errors.Is(err, fossa.ErrInviteAlreadyExists) {
 				msg := err.Error()
 				invite.Status = "expired"
@@ -523,7 +527,7 @@ func formatInviteSummary(store *db.SQLStore, invite model.ServiceInvitation) str
 			hours := int(elapsed.Hours())
 			sentAt = "Sent " + strconv.Itoa(hours) + "h ago"
 		}
-		expiresAt := invite.SentAt.UTC().Add(72 * time.Hour)
+		expiresAt := invite.SentAt.UTC().Add(fossaInviteTTL)
 		remaining := time.Until(expiresAt)
 		if remaining < 0 {
 			remaining = 0

--- a/cmd/fossa-poller/main.go
+++ b/cmd/fossa-poller/main.go
@@ -93,6 +93,7 @@ type fossaAPI interface {
 	FetchTeamMembersRaw(teamID uint) (fossa.TeamMembers, []byte, error)
 	FindUserIDByEmail(email string) (uint, error)
 	ResolveTeamAdminRoleID() (int, error)
+	FetchUserInvitationEmails() (map[string]struct{}, error)
 }
 
 func pollFossaInvites(ctx context.Context, logger *log.Logger, store *db.SQLStore, client fossaAPI) error {
@@ -101,6 +102,11 @@ func pollFossaInvites(ctx context.Context, logger *log.Logger, store *db.SQLStor
 	if err != nil {
 		return err
 	}
+
+	if err := discoverFossaInvites(logger, store, client, serviceID); err != nil {
+		logger.Printf("discover invites failed: %v", err)
+	}
+
 	pollerStaffID := ensurePollerStaff(store, logger)
 	auditLogger := zap.NewNop().Sugar()
 	dbInvites, err := store.ListServiceInvitationsByStatus(serviceID, []string{"pending", "expired", "accepted"})
@@ -321,6 +327,124 @@ func pollFossaInvites(ctx context.Context, logger *log.Logger, store *db.SQLStor
 		logInviteAudit(store, auditLogger, "FOSSA_TEAM_MEMBER_ADDED", pollerStaffID, serviceID, invite, addResp, teamMembersBody)
 	}
 	return nil
+}
+
+// discoverFossaInvites reconciles invitations that were sent directly through FOSSA
+// (e.g. by a CNCF admin using FOSSA's own UI) rather than through maintainer-d's
+// "send invite" action. Without this, such invites are invisible to maintainer-d:
+// no ServiceInvitation row is ever created for them, so the poller has nothing to
+// check and the web UI keeps listing the maintainer as eligible for invitation.
+func discoverFossaInvites(logger *log.Logger, store *db.SQLStore, client fossaAPI, serviceID uint) error {
+	pendingEmails, err := client.FetchUserInvitationEmails()
+	if err != nil {
+		return fmt.Errorf("fetch FOSSA user invitations: %w", err)
+	}
+	if len(pendingEmails) == 0 {
+		return nil
+	}
+
+	projects, err := store.GetProjectsUsingService(serviceID)
+	if err != nil {
+		return fmt.Errorf("load FOSSA projects: %w", err)
+	}
+
+	now := time.Now().UTC()
+	for _, project := range projects {
+		serviceTeam, err := store.GetRemoteTeamByProject(project.ID, serviceID)
+		if err != nil {
+			logger.Printf("discover invites: load FOSSA team for project=%d failed: %v", project.ID, err)
+			continue
+		}
+		if serviceTeam == nil {
+			continue
+		}
+
+		statuses, err := store.ListMaintainerProjectStatuses(project.ID)
+		if err != nil {
+			logger.Printf("discover invites: load maintainer statuses for project=%d failed: %v", project.ID, err)
+			continue
+		}
+
+		existingInvites, err := store.ListServiceInvitations(project.ID, serviceID)
+		if err != nil {
+			logger.Printf("discover invites: load existing invites for project=%d failed: %v", project.ID, err)
+			continue
+		}
+		inviteByMaintainer := make(map[uint]model.ServiceInvitation, len(existingInvites))
+		for _, invite := range existingInvites {
+			if invite.MaintainerID == nil {
+				continue
+			}
+			if _, ok := inviteByMaintainer[*invite.MaintainerID]; !ok {
+				inviteByMaintainer[*invite.MaintainerID] = invite
+			}
+		}
+
+		for _, maintainer := range project.Maintainers {
+			if statuses[maintainer.ID] != model.ActiveMaintainer {
+				continue
+			}
+			pendingEmail := firstPendingEmail(maintainerCandidateEmails(maintainer), pendingEmails)
+			if pendingEmail == "" {
+				continue
+			}
+
+			invite, hasInvite := inviteByMaintainer[maintainer.ID]
+			if hasInvite && strings.EqualFold(invite.Status, "pending") && strings.EqualFold(invite.ServiceEmail, pendingEmail) {
+				continue
+			}
+			if !hasInvite {
+				invite = model.ServiceInvitation{
+					ProjectID:    project.ID,
+					MaintainerID: &maintainer.ID,
+					ServiceID:    serviceID,
+				}
+			}
+			invite.ServiceEmail = pendingEmail
+			invite.RemoteTeamID = serviceTeam.RemoteTeamID
+			invite.Status = "pending"
+			invite.LastError = nil
+			invite.LastCheckedAt = &now
+			if _, err := store.UpsertServiceInvitation(&invite); err != nil {
+				logger.Printf("discover invites: upsert failed maintainer=%d project=%d err=%v", maintainer.ID, project.ID, err)
+				continue
+			}
+			logger.Printf("discover invites: found untracked FOSSA invite email=%s maintainer=%d project=%d", pendingEmail, maintainer.ID, project.ID)
+		}
+	}
+	return nil
+}
+
+// maintainerCandidateEmails mirrors the maintainer email fields the web-bff FOSSA
+// matching logic considers, so a discovered invite matches the same identity a
+// staff-triggered "refresh" would.
+func maintainerCandidateEmails(maintainer model.Maintainer) []string {
+	values := []string{
+		normalizeEmail(maintainer.Email),
+		normalizeEmail(maintainer.GitHubEmail),
+	}
+	seen := make(map[string]struct{}, len(values))
+	candidates := make([]string, 0, len(values))
+	for _, value := range values {
+		if value == "" || value == "email_missing" || value == "github_email_missing" || value == "github_missing" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		candidates = append(candidates, value)
+	}
+	return candidates
+}
+
+func firstPendingEmail(candidateEmails []string, pendingEmails map[string]struct{}) string {
+	for _, email := range candidateEmails {
+		if _, ok := pendingEmails[email]; ok {
+			return email
+		}
+	}
+	return ""
 }
 
 func emailInList(target string, emails []string) bool {

--- a/cmd/fossa-poller/main_test.go
+++ b/cmd/fossa-poller/main_test.go
@@ -19,14 +19,15 @@ import (
 )
 
 type fakeFossaClient struct {
-	hasPending bool
-	userID     uint
-	roleID     int
-	teamEmails []string
-	addResp    *fossa.TeamAddResponse
-	addErr     error
-	rawMembers fossa.TeamMembers
-	rawBody    []byte
+	hasPending       bool
+	userID           uint
+	roleID           int
+	teamEmails       []string
+	addResp          *fossa.TeamAddResponse
+	addErr           error
+	rawMembers       fossa.TeamMembers
+	rawBody          []byte
+	invitationEmails map[string]struct{}
 }
 
 func (f *fakeFossaClient) HasPendingInvitation(string) (bool, error) { return f.hasPending, nil }
@@ -49,6 +50,9 @@ func (f *fakeFossaClient) FetchTeamMembersRaw(uint) (fossa.TeamMembers, []byte, 
 	return fossa.TeamMembers{Results: []fossa.TeamMember{{Email: "dana@example.com"}}, TotalCount: 1}, body, nil
 }
 func (f *fakeFossaClient) FindUserIDByEmail(string) (uint, error) { return f.userID, nil }
+func (f *fakeFossaClient) FetchUserInvitationEmails() (map[string]struct{}, error) {
+	return f.invitationEmails, nil
+}
 func (f *fakeFossaClient) ResolveTeamAdminRoleID() (int, error) {
 	if f.roleID == 0 {
 		return 4, nil
@@ -61,10 +65,14 @@ func setupPollerTestDB(t *testing.T) *gorm.DB {
 		Logger: logger.Default.LogMode(logger.Silent),
 	})
 	require.NoError(t, err)
+	require.NoError(t, dbConn.SetupJoinTable(&model.Maintainer{}, "Projects", &model.MaintainerProject{}))
+	require.NoError(t, dbConn.SetupJoinTable(&model.Project{}, "Maintainers", &model.MaintainerProject{}))
 	require.NoError(t, dbConn.AutoMigrate(
+		&model.Company{},
 		&model.Service{},
 		&model.Project{},
 		&model.Maintainer{},
+		&model.MaintainerProject{},
 		&model.Foundation{},
 		&model.StaffMember{},
 		&model.AuditLog{},
@@ -75,6 +83,14 @@ func setupPollerTestDB(t *testing.T) *gorm.DB {
 		&model.DotProjectSyncState{},
 	))
 	return dbConn
+}
+
+func linkMaintainerToProject(t *testing.T, dbConn *gorm.DB, maintainerID, projectID uint, status model.MaintainerStatus) {
+	require.NoError(t, dbConn.Create(&model.MaintainerProject{
+		MaintainerID: maintainerID,
+		ProjectID:    projectID,
+		Status:       status,
+	}).Error)
 }
 
 func TestPollerRecordsRemoteTeamMembership(t *testing.T) {
@@ -441,4 +457,102 @@ func TestPollerTeamAssignmentImmediateAddError(t *testing.T) {
 
 	var audit model.AuditLog
 	require.NoError(t, dbConn.Where("action = ?", "FOSSA_TEAM_MEMBER_ADD_FAILED").First(&audit).Error)
+}
+
+// TestPollerDiscoversInviteSentDirectlyThroughFOSSA covers an invite sent through FOSSA's
+// own UI (not maintainer-d's "invite" action), which has no ServiceInvitation row, so the
+// poller must create one from FOSSA's org-wide pending-invitations list.
+func TestPollerDiscoversInviteSentDirectlyThroughFOSSA(t *testing.T) {
+	dbConn := setupPollerTestDB(t)
+	store := db.NewSQLStore(dbConn)
+
+	service := model.Service{Name: "FOSSA"}
+	require.NoError(t, dbConn.Create(&service).Error)
+	project := model.Project{Name: "tekton", Maturity: model.Incubating}
+	require.NoError(t, dbConn.Create(&project).Error)
+	maintainer := model.Maintainer{
+		Name:             "Riley Maintainer",
+		Email:            "riley@example.com",
+		GitHubAccount:    "rileydev",
+		MaintainerStatus: model.ActiveMaintainer,
+	}
+	require.NoError(t, dbConn.Create(&maintainer).Error)
+	linkMaintainerToProject(t, dbConn, maintainer.ID, project.ID, model.ActiveMaintainer)
+
+	serviceTeam := model.RemoteTeam{
+		ProjectID:    project.ID,
+		ServiceID:    service.ID,
+		RemoteTeamID: 987654,
+	}
+	require.NoError(t, dbConn.Create(&serviceTeam).Error)
+
+	client := &fakeFossaClient{
+		hasPending:       true,
+		invitationEmails: map[string]struct{}{"riley@example.com": {}},
+	}
+	logger := log.New(io.Discard, "", 0)
+
+	err := pollFossaInvites(context.Background(), logger, store, client)
+	require.NoError(t, err)
+
+	var invite model.ServiceInvitation
+	require.NoError(t, dbConn.Where(
+		"project_id = ? AND service_id = ? AND service_email = ?",
+		project.ID, service.ID, maintainer.Email,
+	).First(&invite).Error)
+	require.Equal(t, "pending", invite.Status)
+	require.Equal(t, serviceTeam.RemoteTeamID, invite.RemoteTeamID)
+	require.NotNil(t, invite.MaintainerID)
+	require.Equal(t, maintainer.ID, *invite.MaintainerID)
+}
+
+// TestPollerDiscoveryIgnoresAlreadyTrackedInvite ensures discovery doesn't clobber an
+// invite maintainer-d already knows about, or resurrect one FOSSA no longer lists.
+func TestPollerDiscoveryIgnoresAlreadyTrackedInvite(t *testing.T) {
+	dbConn := setupPollerTestDB(t)
+	store := db.NewSQLStore(dbConn)
+
+	service := model.Service{Name: "FOSSA"}
+	require.NoError(t, dbConn.Create(&service).Error)
+	project := model.Project{Name: "tekton", Maturity: model.Incubating}
+	require.NoError(t, dbConn.Create(&project).Error)
+	maintainer := model.Maintainer{
+		Name:             "Dana Dev",
+		Email:            "dana@example.com",
+		GitHubAccount:    "danadev",
+		MaintainerStatus: model.ActiveMaintainer,
+	}
+	require.NoError(t, dbConn.Create(&maintainer).Error)
+	linkMaintainerToProject(t, dbConn, maintainer.ID, project.ID, model.ActiveMaintainer)
+
+	serviceTeam := model.RemoteTeam{
+		ProjectID:    project.ID,
+		ServiceID:    service.ID,
+		RemoteTeamID: 111222,
+	}
+	require.NoError(t, dbConn.Create(&serviceTeam).Error)
+
+	done := "done"
+	invite := model.ServiceInvitation{
+		ServiceID:            service.ID,
+		ProjectID:            project.ID,
+		MaintainerID:         &maintainer.ID,
+		RemoteTeamID:         serviceTeam.RemoteTeamID,
+		ServiceEmail:         maintainer.Email,
+		Status:               "accepted",
+		TeamAssignmentStatus: &done,
+	}
+	require.NoError(t, dbConn.Create(&invite).Error)
+
+	client := &fakeFossaClient{invitationEmails: map[string]struct{}{}}
+	logger := log.New(io.Discard, "", 0)
+
+	err := pollFossaInvites(context.Background(), logger, store, client)
+	require.NoError(t, err)
+
+	var updated model.ServiceInvitation
+	require.NoError(t, dbConn.First(&updated, invite.ID).Error)
+	require.Equal(t, "accepted", updated.Status)
+	require.NotNil(t, updated.TeamAssignmentStatus)
+	require.Equal(t, "done", *updated.TeamAssignmentStatus)
 }

--- a/cmd/web-bff/fossa_invite_candidates_test.go
+++ b/cmd/web-bff/fossa_invite_candidates_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"testing"
+
+	"maintainerd/model"
+)
+
+// TestBuildFossaInviteCandidates_MatchesGitHubEmail guards against the
+// reconciliation gap where an invite sent to a maintainer's GitHubEmail
+// (see preferredMaintainerServiceEmail) could never be recognized as
+// "already invited" when eligibility was only checked against Email.
+func TestBuildFossaInviteCandidates_MatchesGitHubEmail(t *testing.T) {
+	maintainer := model.Maintainer{
+		Name:          "Ada Lovelace",
+		Email:         "ada@example.com",
+		GitHubEmail:   "ada@users.noreply.github.com",
+		GitHubAccount: "adal",
+	}
+	maintainer.ID = 1
+
+	projectStatuses := map[uint]model.MaintainerStatus{1: model.ActiveMaintainer}
+
+	t.Run("pending invite recorded under GitHubEmail excludes the maintainer", func(t *testing.T) {
+		pendingInviteEmails := map[string]struct{}{"ada@users.noreply.github.com": {}}
+		got := buildFossaInviteCandidates([]model.Maintainer{maintainer}, projectStatuses, nil, pendingInviteEmails)
+		if len(got) != 0 {
+			t.Fatalf("expected no candidates, got %+v", got)
+		}
+	})
+
+	t.Run("FOSSA team membership recorded under GitHubEmail excludes the maintainer", func(t *testing.T) {
+		got := buildFossaInviteCandidates([]model.Maintainer{maintainer}, projectStatuses, []string{"ada@users.noreply.github.com"}, map[string]struct{}{})
+		if len(got) != 0 {
+			t.Fatalf("expected no candidates, got %+v", got)
+		}
+	})
+
+	t.Run("no match leaves the maintainer eligible", func(t *testing.T) {
+		got := buildFossaInviteCandidates([]model.Maintainer{maintainer}, projectStatuses, nil, map[string]struct{}{})
+		if len(got) != 1 {
+			t.Fatalf("expected 1 candidate, got %+v", got)
+		}
+	})
+}

--- a/cmd/web-bff/main.go
+++ b/cmd/web-bff/main.go
@@ -1365,9 +1365,8 @@ func (s *server) handleProject(w http.ResponseWriter, r *http.Request) {
 					s.logger.Printf("web-bff: FOSSA team email domains project=%d remoteTeamID=%d %s", project.ID, serviceTeam.RemoteTeamID, strings.Join(parts, ", "))
 					emailToMaintainer := make(map[string]model.Maintainer, len(project.Maintainers))
 					for _, maintainer := range project.Maintainers {
-						normalized := strings.ToLower(strings.TrimSpace(maintainer.Email))
-						if normalized != "" && !strings.EqualFold(normalized, "EMAIL_MISSING") {
-							emailToMaintainer[normalized] = maintainer
+						for _, candidateEmail := range maintainerServiceCandidateEmails(maintainer) {
+							emailToMaintainer[candidateEmail] = maintainer
 						}
 					}
 					fossaTeamMembers = make([]fossaTeamMemberSummary, 0, len(fossaTeamEmails))
@@ -1440,8 +1439,11 @@ func (s *server) handleProject(w http.ResponseWriter, r *http.Request) {
 			}
 			fossaInviteIneligible = classifyIneligibleMaintainers(project.Maintainers, projectStatuses)
 			if role == roleStaff {
-				pendingInviteEmails := make(map[string]struct{})
-				if invites, err := s.store.ListServiceInvitations(project.ID, serviceID); err == nil {
+				invites, invitesErr := s.store.ListServiceInvitations(project.ID, serviceID)
+				if invitesErr != nil {
+					s.logger.Printf("web-bff: load service invitations for project=%d failed: %v", project.ID, invitesErr)
+				} else {
+					pendingInviteEmails := make(map[string]struct{})
 					for _, invite := range invites {
 						if strings.EqualFold(invite.Status, "pending") {
 							normalized := strings.ToLower(strings.TrimSpace(invite.ServiceEmail))
@@ -1450,10 +1452,10 @@ func (s *server) handleProject(w http.ResponseWriter, r *http.Request) {
 							}
 						}
 					}
+					s.logger.Printf("web-bff: build invite candidates project=%d remoteTeamID=%d fossaTeamEmails=%v pendingInviteEmails=%d",
+						project.ID, serviceTeam.RemoteTeamID, fossaTeamEmails, len(pendingInviteEmails))
+					fossaInviteCandidates = buildFossaInviteCandidates(project.Maintainers, projectStatuses, fossaTeamEmails, pendingInviteEmails)
 				}
-				s.logger.Printf("web-bff: build invite candidates project=%d remoteTeamID=%d fossaTeamEmails=%v pendingInviteEmails=%d",
-					project.ID, serviceTeam.RemoteTeamID, fossaTeamEmails, len(pendingInviteEmails))
-				fossaInviteCandidates = buildFossaInviteCandidates(project.Maintainers, projectStatuses, fossaTeamEmails, pendingInviteEmails)
 			}
 		}
 	}
@@ -5839,7 +5841,7 @@ func (s *server) handleFossaInvite(w http.ResponseWriter, r *http.Request) {
 				resp.Skipped = append(resp.Skipped, maintainer.GitHubAccount)
 				continue
 			}
-			email := strings.TrimSpace(maintainer.Email)
+			email := strings.ToLower(strings.TrimSpace(maintainer.Email))
 			if email == "" || strings.EqualFold(email, "EMAIL_MISSING") {
 				resp.Skipped = append(resp.Skipped, maintainer.GitHubAccount)
 				continue
@@ -5855,7 +5857,8 @@ func (s *server) handleFossaInvite(w http.ResponseWriter, r *http.Request) {
 				LastCheckedAt: &now,
 			}
 			if _, upsertErr := s.store.UpsertServiceInvitation(inviteStatus); upsertErr != nil {
-				resp.Errors[email] = "failed to store invite status"
+				s.logger.Printf("web-bff: send FOSSA invite (test-mode) store failed project=%d maintainer=%d email=%s err=%v", project.ID, maintainer.ID, email, upsertErr)
+				resp.Errors[email] = fmt.Sprintf("failed to store invite status: %v", upsertErr)
 				continue
 			}
 			resp.Invited = append(resp.Invited, email)
@@ -5889,7 +5892,7 @@ func (s *server) handleFossaInvite(w http.ResponseWriter, r *http.Request) {
 			resp.Skipped = append(resp.Skipped, maintainer.GitHubAccount)
 			continue
 		}
-		email := strings.TrimSpace(maintainer.Email)
+		email := strings.ToLower(strings.TrimSpace(maintainer.Email))
 		if email == "" || strings.EqualFold(email, "EMAIL_MISSING") {
 			resp.Skipped = append(resp.Skipped, maintainer.GitHubAccount)
 			continue
@@ -5908,8 +5911,14 @@ func (s *server) handleFossaInvite(w http.ResponseWriter, r *http.Request) {
 				LastCheckedAt: &now,
 			}
 			if _, upsertErr := s.store.UpsertServiceInvitation(inviteStatus); upsertErr != nil {
-				resp.Errors[email] = "failed to store invite status"
+				s.logger.Printf("web-bff: send FOSSA invite store failed project=%d maintainer=%d email=%s err=%v", project.ID, maintainer.ID, email, upsertErr)
+				resp.Errors[email] = fmt.Sprintf("failed to store invite status: %v", upsertErr)
 				continue
+			}
+			if errors.Is(err, fossa.ErrInviteAlreadyExists) {
+				s.logger.Printf("web-bff: send FOSSA invite already-exists project=%d maintainer=%d email=%s", project.ID, maintainer.ID, email)
+			} else {
+				s.logger.Printf("web-bff: send FOSSA invite ok project=%d maintainer=%d email=%s", project.ID, maintainer.ID, email)
 			}
 			resp.Invited = append(resp.Invited, email)
 			continue
@@ -5919,6 +5928,7 @@ func (s *server) handleFossaInvite(w http.ResponseWriter, r *http.Request) {
 			teamAdminRoleID, resolveErr := client.ResolveTeamAdminRoleID()
 			if resolveErr != nil {
 				msg := resolveErr.Error()
+				s.logger.Printf("web-bff: send FOSSA invite already-member resolve-role failed project=%d maintainer=%d email=%s err=%v", project.ID, maintainer.ID, email, resolveErr)
 				inviteStatus := &model.ServiceInvitation{
 					ProjectID:     project.ID,
 					MaintainerID:  &maintainer.ID,
@@ -5930,13 +5940,15 @@ func (s *server) handleFossaInvite(w http.ResponseWriter, r *http.Request) {
 					LastCheckedAt: &now,
 				}
 				if _, upsertErr := s.store.UpsertServiceInvitation(inviteStatus); upsertErr != nil {
-					resp.Errors[email] = "failed to store invite status"
+					s.logger.Printf("web-bff: send FOSSA invite store failed project=%d maintainer=%d email=%s err=%v", project.ID, maintainer.ID, email, upsertErr)
+					resp.Errors[email] = fmt.Sprintf("failed to store invite status: %v", upsertErr)
 				} else {
 					resp.Errors[email] = msg
 				}
 				continue
 			}
 			if addErr := client.AddUserToTeamByEmail(serviceTeam.RemoteTeamID, email, teamAdminRoleID); addErr == nil {
+				s.logger.Printf("web-bff: send FOSSA invite already-member added-to-team project=%d maintainer=%d email=%s", project.ID, maintainer.ID, email)
 				inviteStatus := &model.ServiceInvitation{
 					ProjectID:     project.ID,
 					MaintainerID:  &maintainer.ID,
@@ -5947,11 +5959,13 @@ func (s *server) handleFossaInvite(w http.ResponseWriter, r *http.Request) {
 					LastCheckedAt: &now,
 				}
 				if _, upsertErr := s.store.UpsertServiceInvitation(inviteStatus); upsertErr != nil {
-					resp.Errors[email] = "failed to store invite status"
+					s.logger.Printf("web-bff: send FOSSA invite store failed project=%d maintainer=%d email=%s err=%v", project.ID, maintainer.ID, email, upsertErr)
+					resp.Errors[email] = fmt.Sprintf("failed to store invite status: %v", upsertErr)
 				}
 				continue
 			} else {
 				msg := addErr.Error()
+				s.logger.Printf("web-bff: send FOSSA invite already-member add-to-team failed project=%d maintainer=%d email=%s err=%v", project.ID, maintainer.ID, email, addErr)
 				inviteStatus := &model.ServiceInvitation{
 					ProjectID:     project.ID,
 					MaintainerID:  &maintainer.ID,
@@ -5963,7 +5977,8 @@ func (s *server) handleFossaInvite(w http.ResponseWriter, r *http.Request) {
 					LastCheckedAt: &now,
 				}
 				if _, upsertErr := s.store.UpsertServiceInvitation(inviteStatus); upsertErr != nil {
-					resp.Errors[email] = "failed to store invite status"
+					s.logger.Printf("web-bff: send FOSSA invite store failed project=%d maintainer=%d email=%s err=%v", project.ID, maintainer.ID, email, upsertErr)
+					resp.Errors[email] = fmt.Sprintf("failed to store invite status: %v", upsertErr)
 				} else {
 					resp.Errors[email] = msg
 				}
@@ -5972,6 +5987,7 @@ func (s *server) handleFossaInvite(w http.ResponseWriter, r *http.Request) {
 		}
 
 		msg := err.Error()
+		s.logger.Printf("web-bff: send FOSSA invite failed project=%d maintainer=%d email=%s err=%v", project.ID, maintainer.ID, email, err)
 		inviteStatus := &model.ServiceInvitation{
 			ProjectID:     project.ID,
 			MaintainerID:  &maintainer.ID,
@@ -5983,7 +5999,8 @@ func (s *server) handleFossaInvite(w http.ResponseWriter, r *http.Request) {
 			LastCheckedAt: &now,
 		}
 		if _, upsertErr := s.store.UpsertServiceInvitation(inviteStatus); upsertErr != nil {
-			resp.Errors[email] = "failed to store invite status"
+			s.logger.Printf("web-bff: send FOSSA invite store failed project=%d maintainer=%d email=%s err=%v", project.ID, maintainer.ID, email, upsertErr)
+			resp.Errors[email] = fmt.Sprintf("failed to store invite status: %v", upsertErr)
 		} else {
 			resp.Errors[email] = msg
 		}
@@ -6119,11 +6136,9 @@ func (s *server) handleFossaInviteRefresh(w http.ResponseWriter, r *http.Request
 		if projectStatuses[maintainer.ID] != model.ActiveMaintainer {
 			continue
 		}
-		email := strings.TrimSpace(maintainer.Email)
-		if email == "" || strings.EqualFold(email, "EMAIL_MISSING") {
-			continue
+		for _, email := range maintainerServiceCandidateEmails(maintainer) {
+			activeMaintainers[email] = maintainer
 		}
-		activeMaintainers[strings.ToLower(email)] = maintainer
 	}
 
 	invites, err := s.store.ListServiceInvitations(project.ID, serviceID)
@@ -6144,10 +6159,13 @@ func (s *server) handleFossaInviteRefresh(w http.ResponseWriter, r *http.Request
 	added := 0
 	updated := 0
 	removed := 0
+	unmatched := make([]string, 0)
 
 	for email := range pendingEmails {
 		maintainer, ok := activeMaintainers[email]
 		if !ok {
+			s.logger.Printf("web-bff: refresh FOSSA invites unmatched project=%d email=%s reason=no_active_maintainer_on_project", project.ID, email)
+			unmatched = append(unmatched, email)
 			continue
 		}
 		if invite, ok := existing[email]; ok {
@@ -6156,6 +6174,8 @@ func (s *server) handleFossaInviteRefresh(w http.ResponseWriter, r *http.Request
 			invite.LastCheckedAt = &now
 			if _, upsertErr := s.store.UpsertServiceInvitation(&invite); upsertErr == nil {
 				updated++
+			} else {
+				s.logger.Printf("web-bff: refresh FOSSA invites upsert (update) failed project=%d email=%s err=%v", project.ID, email, upsertErr)
 			}
 			continue
 		}
@@ -6163,13 +6183,15 @@ func (s *server) handleFossaInviteRefresh(w http.ResponseWriter, r *http.Request
 			ProjectID:     project.ID,
 			MaintainerID:  &maintainer.ID,
 			ServiceID:     serviceID,
-			ServiceEmail:  maintainer.Email,
+			ServiceEmail:  email,
 			RemoteTeamID:  serviceTeam.RemoteTeamID,
 			Status:        "pending",
 			LastCheckedAt: &now,
 		}
 		if _, upsertErr := s.store.UpsertServiceInvitation(invite); upsertErr == nil {
 			added++
+		} else {
+			s.logger.Printf("web-bff: refresh FOSSA invites upsert (add) failed project=%d email=%s err=%v", project.ID, email, upsertErr)
 		}
 	}
 
@@ -6192,11 +6214,16 @@ func (s *server) handleFossaInviteRefresh(w http.ResponseWriter, r *http.Request
 		}
 	}
 
+	s.logger.Printf("web-bff: refresh FOSSA invites summary project=%d fetched=%d added=%d updated=%d removed=%d unmatched=%d",
+		project.ID, len(pendingEmails), added, updated, removed, len(unmatched))
+
 	w.Header().Set(headerContentType, contentTypeJSON)
-	if err := json.NewEncoder(w).Encode(map[string]int{
-		"added":   added,
-		"updated": updated,
-		"removed": removed,
+	if err := json.NewEncoder(w).Encode(map[string]any{
+		"fetched":   len(pendingEmails),
+		"added":     added,
+		"updated":   updated,
+		"removed":   removed,
+		"unmatched": unmatched,
 	}); err != nil {
 		s.logger.Printf("web-bff: handleFossaInviteRefresh encode error: %v", err)
 	}
@@ -6353,7 +6380,7 @@ func (s *server) handleFossaInviteAction(w http.ResponseWriter, r *http.Request)
 		http.Error(w, "missing email", http.StatusBadRequest)
 		return
 	}
-	email := strings.TrimSpace(invite.ServiceEmail)
+	email := strings.ToLower(strings.TrimSpace(invite.ServiceEmail))
 	if email == "" || strings.EqualFold(email, "EMAIL_MISSING") {
 		http.Error(w, "missing email", http.StatusBadRequest)
 		return
@@ -6552,11 +6579,18 @@ func buildFossaInviteCandidates(maintainers []model.Maintainer, projectStatuses 
 		if github == "" || strings.EqualFold(github, "GITHUB_MISSING") {
 			continue
 		}
-		normalized := strings.ToLower(email)
-		if _, ok := teamEmailSet[normalized]; ok {
-			continue
+		alreadyOnboarded := false
+		for _, candidateEmail := range maintainerServiceCandidateEmails(m) {
+			if _, ok := teamEmailSet[candidateEmail]; ok {
+				alreadyOnboarded = true
+				break
+			}
+			if _, ok := pendingInviteEmails[candidateEmail]; ok {
+				alreadyOnboarded = true
+				break
+			}
 		}
-		if _, ok := pendingInviteEmails[normalized]; ok {
+		if alreadyOnboarded {
 			continue
 		}
 		name := strings.TrimSpace(m.Name)

--- a/db/store_impl.go
+++ b/db/store_impl.go
@@ -50,7 +50,7 @@ func (s *SQLStore) getServiceByName(name string) (*model.Service, error) {
 func (s *SQLStore) GetProjectsUsingService(serviceID uint) ([]model.Project, error) {
 	var projects []model.Project
 	err := s.db.
-		Joins("JOIN service_teams st ON st.project_id = projects.id").
+		Joins("JOIN remote_teams st ON st.project_id = projects.id").
 		Where("st.service_id = ?", serviceID).
 		Preload("Maintainers.Company").
 		Find(&projects).Error
@@ -764,7 +764,7 @@ func (s *SQLStore) UpsertServiceInvitation(invite *model.ServiceInvitation) (*mo
 	if invite == nil {
 		return nil, fmt.Errorf("invite is nil")
 	}
-	err := s.db.Clauses(clause.OnConflict{
+	err := s.db.Unscoped().Clauses(clause.OnConflict{
 		Columns: []clause.Column{
 			{Name: "project_id"},
 			{Name: "service_id"},
@@ -781,6 +781,7 @@ func (s *SQLStore) UpsertServiceInvitation(invite *model.ServiceInvitation) (*mo
 			"sent_at",
 			"last_checked_at",
 			"updated_at",
+			"deleted_at",
 		}),
 	}).Create(invite).Error
 	if err != nil {

--- a/db/store_impl_test.go
+++ b/db/store_impl_test.go
@@ -34,6 +34,7 @@ func setupTestDB(t *testing.T) *gorm.DB {
 		&model.RemoteTeam{},
 		&model.RemoteUser{},
 		&model.RemoteTeamUser{},
+		&model.ServiceInvitation{},
 	)
 	require.NoError(t, err)
 
@@ -376,7 +377,89 @@ func TestUpdateProjectDotProjectMetadata(t *testing.T) {
 }
 
 func TestGetProjectsUsingService(t *testing.T) {
-	t.Skip("testDB not defined - needs implementation")
+	db := setupTestDB(t)
+	store := NewSQLStore(db)
+
+	service := model.Service{Name: "FOSSA"}
+	require.NoError(t, db.Create(&service).Error)
+	otherService := model.Service{Name: "Snyk"}
+	require.NoError(t, db.Create(&otherService).Error)
+
+	onboarded := model.Project{Name: "tekton", Maturity: model.Incubating}
+	require.NoError(t, db.Create(&onboarded).Error)
+	notOnboarded := model.Project{Name: "flux", Maturity: model.Incubating}
+	require.NoError(t, db.Create(&notOnboarded).Error)
+
+	require.NoError(t, db.Create(&model.RemoteTeam{
+		ProjectID:    onboarded.ID,
+		ServiceID:    service.ID,
+		RemoteTeamID: 123,
+	}).Error)
+	require.NoError(t, db.Create(&model.RemoteTeam{
+		ProjectID:    notOnboarded.ID,
+		ServiceID:    otherService.ID,
+		RemoteTeamID: 456,
+	}).Error)
+
+	maintainer := model.Maintainer{Name: "Riley Maintainer", Email: "riley@example.com", MaintainerStatus: model.ActiveMaintainer}
+	require.NoError(t, db.Create(&maintainer).Error)
+	require.NoError(t, db.Create(&model.MaintainerProject{
+		MaintainerID: maintainer.ID,
+		ProjectID:    onboarded.ID,
+		Status:       model.ActiveMaintainer,
+	}).Error)
+
+	projects, err := store.GetProjectsUsingService(service.ID)
+	require.NoError(t, err)
+	require.Len(t, projects, 1)
+	assert.Equal(t, onboarded.ID, projects[0].ID)
+	require.Len(t, projects[0].Maintainers, 1)
+	assert.Equal(t, maintainer.ID, projects[0].Maintainers[0].ID)
+}
+
+func TestUpsertServiceInvitation_RestoresSoftDeletedRow(t *testing.T) {
+	db := setupTestDB(t)
+	store := NewSQLStore(db)
+
+	service := model.Service{Name: "FOSSA"}
+	require.NoError(t, db.Create(&service).Error)
+	project := model.Project{Name: "tekton", Maturity: model.Incubating}
+	require.NoError(t, db.Create(&project).Error)
+	maintainer := model.Maintainer{Name: "Riley Maintainer", Email: "riley@example.com"}
+	require.NoError(t, db.Create(&maintainer).Error)
+
+	invite := &model.ServiceInvitation{
+		ProjectID:    project.ID,
+		ServiceID:    service.ID,
+		MaintainerID: &maintainer.ID,
+		ServiceEmail: "riley@example.com",
+		RemoteTeamID: 186460,
+		Status:       "pending",
+	}
+	created, err := store.UpsertServiceInvitation(invite)
+	require.NoError(t, err)
+	require.NoError(t, db.Delete(created).Error)
+
+	var deletedCount int64
+	require.NoError(t, db.Unscoped().Model(&model.ServiceInvitation{}).
+		Where("id = ? AND deleted_at IS NOT NULL", created.ID).Count(&deletedCount).Error)
+	require.Equal(t, int64(1), deletedCount, "row must be soft-deleted before the re-upsert")
+
+	rediscovered := &model.ServiceInvitation{
+		ProjectID:    project.ID,
+		ServiceID:    service.ID,
+		MaintainerID: &maintainer.ID,
+		ServiceEmail: "riley@example.com",
+		RemoteTeamID: 186460,
+		Status:       "pending",
+	}
+	_, err = store.UpsertServiceInvitation(rediscovered)
+	require.NoError(t, err)
+
+	invites, err := store.ListServiceInvitations(project.ID, service.ID)
+	require.NoError(t, err)
+	require.Len(t, invites, 1, "re-upserting over a soft-deleted invite must make it visible again")
+	assert.Equal(t, "pending", invites[0].Status)
 }
 
 func TestUpsertMaintainer_FillsMissingFields(t *testing.T) {

--- a/plugins/fossa/invites_internal_test.go
+++ b/plugins/fossa/invites_internal_test.go
@@ -1,0 +1,78 @@
+package fossa
+
+import "testing"
+
+// TestExtractInvitationEmails covers the org-wide GET /user-invitations
+// response shapes we've observed from FOSSA. Regressions here silently
+// drop invitations from reconciliation without any error surfacing.
+func TestExtractInvitationEmails(t *testing.T) {
+	tests := []struct {
+		name       string
+		body       string
+		wantEmails []string
+		wantCount  int
+		wantParsed bool
+	}{
+		{
+			name:       "populated invitations",
+			body:       `[{"email":"a@example.com"},{"email":"b@example.com"}]`,
+			wantEmails: []string{"a@example.com", "b@example.com"},
+			wantCount:  2,
+			wantParsed: true,
+		},
+		{
+			name:       "empty array",
+			body:       `[]`,
+			wantEmails: nil,
+			wantCount:  0,
+			wantParsed: true,
+		},
+		{
+			name:       "whitespace-only body",
+			body:       "   ",
+			wantEmails: nil,
+			wantCount:  0,
+			wantParsed: false,
+		},
+		{
+			name:       "malformed json",
+			body:       `not json`,
+			wantEmails: nil,
+			wantCount:  0,
+			wantParsed: false,
+		},
+		{
+			name:       "entries with blank email are skipped",
+			body:       `[{"email":"a@example.com"},{"email":"  "},{"email":""}]`,
+			wantEmails: []string{"a@example.com"},
+			wantCount:  3,
+			wantParsed: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			emails, count, parsed := extractInvitationEmails(tt.body)
+			if parsed != tt.wantParsed {
+				t.Fatalf("parsed = %v, want %v", parsed, tt.wantParsed)
+			}
+			if count != tt.wantCount {
+				t.Fatalf("count = %d, want %d", count, tt.wantCount)
+			}
+			if len(emails) != len(tt.wantEmails) {
+				t.Fatalf("emails = %v, want %v", emails, tt.wantEmails)
+			}
+			for i, email := range emails {
+				if email != tt.wantEmails[i] {
+					t.Fatalf("emails[%d] = %q, want %q", i, email, tt.wantEmails[i])
+				}
+			}
+		})
+	}
+}
+
+func TestNormalizeEmail(t *testing.T) {
+	if got := normalizeEmail("  Foo@example.com  "); got != "foo@example.com" {
+		t.Fatalf("normalizeEmail = %q, want %q", got, "foo@example.com")
+	}
+}

--- a/web/src/components/ProjectReconciliationCard.tsx
+++ b/web/src/components/ProjectReconciliationCard.tsx
@@ -575,6 +575,13 @@ export default function ProjectReconciliationCard({
     skipped: number;
     errors: number;
   } | null>(null);
+  const [fossaRefreshSummary, setFossaRefreshSummary] = useState<{
+    fetched: number;
+    added: number;
+    updated: number;
+    removed: number;
+    unmatched: string[];
+  } | null>(null);
   const [fossaTeamSort, setFossaTeamSort] = useState<SortState<"name" | "email" | "role">>({
     key: "name",
     direction: "asc",
@@ -849,8 +856,22 @@ export default function ProjectReconciliationCard({
       if (!response.ok) {
         throw new Error("failed to refresh invites");
       }
+      const body = (await response.json()) as {
+        fetched?: number;
+        added?: number;
+        updated?: number;
+        removed?: number;
+        unmatched?: string[];
+      };
+      setFossaRefreshSummary({
+        fetched: body.fetched ?? 0,
+        added: body.added ?? 0,
+        updated: body.updated ?? 0,
+        removed: body.removed ?? 0,
+        unmatched: body.unmatched ?? [],
+      });
       await loadFossaInvites();
-      onRefresh?.();
+      await onRefresh?.();
     } catch {
       setFossaInviteError("Unable to refresh FOSSA invites.");
     } finally {
@@ -1582,6 +1603,18 @@ export default function ProjectReconciliationCard({
                       </button>
                     ) : null}
                   </div>
+                  {fossaRefreshSummary ? (
+                    <div className={styles.inviteSummary}>
+                      Fetched {fossaRefreshSummary.fetched} from FOSSA — added {fossaRefreshSummary.added}, updated{" "}
+                      {fossaRefreshSummary.updated}, removed {fossaRefreshSummary.removed}
+                      {fossaRefreshSummary.unmatched.length > 0 ? (
+                        <>
+                          , unmatched {fossaRefreshSummary.unmatched.length}:{" "}
+                          {fossaRefreshSummary.unmatched.join(", ")}
+                        </>
+                      ) : null}
+                    </div>
+                  ) : null}
                   <div className={styles.tableWrap}>
                     <table className={styles.dataTable}>
                       <thead>


### PR DESCRIPTION
## Summary
- `discoverFossaInvites` now runs each poll cycle to pick up invites sent by hand in FOSSA's UI (previously untracked, so the poller never reconciled them and the web UI kept listing the maintainer as eligible indefinitely)
- Fixes `GetProjectsUsingService` joining a nonexistent `service_teams` table instead of `remote_teams` (silently returned zero projects; the test for it had been skipped, now implemented)
- Fixes a GORM soft-delete pitfall in `UpsertServiceInvitation`: `OnConflict.DoUpdates` never included `deleted_at`, so re-upserting over a previously soft-deleted invitation refreshed its data but left it invisible to every query. Now runs `Unscoped()` and includes `deleted_at` in `DoUpdates`.

Fixes #141

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./db/... ./cmd/fossa-poller/...`
- [x] `make ci-local`
- [x] Verified against local Postgres: ran the poller, confirmed a previously untracked pending invite is discovered and correctly reflected as Pending (not Eligible) in the web UI after the soft-delete fix